### PR TITLE
Add CI workflow and CI-friendly deps target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+      - '**/*.md'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+      - '**/*.md'
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -17,6 +25,7 @@ jobs:
     env:
       OPAMYES: "true"
       MIAOU_GIT_URL: ${{ secrets.MIAOU_GIT_URL }}
+      DUNE_CACHE: "enabled"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,6 +38,22 @@ jobs:
           cache: true
           opam-repositories: |
             default: https://opam.ocaml.org
+
+      - name: Cache dune
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/dune
+          key: ${{ runner.os }}-dune-${{ hashFiles('dune-project', 'Makefile', 'octez-manager.opam', '**/dune') }}
+          restore-keys: |
+            ${{ runner.os }}-dune-
+
+      - name: Cache opam download cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/opam
+          key: ${{ runner.os }}-opam-cache-${{ hashFiles('octez-manager.opam', '**/*.opam') }}
+          restore-keys: |
+            ${{ runner.os }}-opam-cache-
 
       - name: Ensure Miaou pin secret
         if: ${{ env.MIAOU_GIT_URL == '' }}

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ BISECT = $(OPAM_EXEC) bisect-ppx-report
 
 deps:
 	opam update -y
-	opam install --deps-only --with-test -y .
+	opam install --deps-only --with-test --reuse-build -y .
 
 deps-ci:
 	@if [ -n "$$MIAOU_GIT_URL" ]; then \
 		opam pin add --yes miaou "$$MIAOU_GIT_URL"; \
 	fi
 	opam update -y
-	opam install --deps-only --with-test -y .
+	opam install --deps-only --with-test --reuse-build -y .
 
 build:
 	$(DUNE) build


### PR DESCRIPTION
This pull request introduces a continuous integration (CI) workflow for the project and updates the `Makefile` to better support dependency management, especially in CI environments. The main focus is on automating builds and tests via GitHub Actions, and ensuring dependencies are handled correctly when running in CI.

**Continuous Integration Setup:**

* Added a new GitHub Actions workflow (`.github/workflows/ci.yml`) to automatically build and test the project on pushes and pull requests to the `main` branch. This includes OCaml setup, dependency installation, build, and test steps.
* Configured workflow concurrency to cancel in-progress jobs for the same branch/ref, preventing overlapping CI runs.

**Dependency Management Improvements:**

* Added `deps` and `deps-ci` targets to the `Makefile`:
  - `deps` installs all dependencies (including test dependencies).
  - `deps-ci` installs dependencies and, if the `MIAOU_GIT_URL` environment variable is set, pins the private `miaou` package before installing dependencies.
* Updated `.PHONY` targets in the `Makefile` to include the new dependency targets.