### PR TITLE
feat(ui): add system metrics and version tracking for nodes

### DIFF
--- a/src/ui/dune
+++ b/src/ui/dune
@@ -7,6 +7,7 @@
   octez_manager_lib
   miaou-core.lib
   miaou-core.internals
+  miaou-core.widgets.display
   miaou-driver-term.driver
   lambda-term
   eio

--- a/src/ui/runtime.ml
+++ b/src/ui/runtime.ml
@@ -240,6 +240,7 @@ let initialize ?(log = false) ?logfile () =
     register_system () ;
     register_palette () ;
     Rpc_scheduler.start () ;
+    System_metrics_scheduler.start () ;
     Metrics.maybe_start_from_env () ;
     initialized := true) ;
   register_logger ~log ~logfile_path:logfile

--- a/src/ui/system_metrics.ml
+++ b/src/ui/system_metrics.ml
@@ -1,0 +1,236 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2025 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** System metrics collection for service instances.
+
+    Collects CPU, memory, disk usage, and version information for
+    services managed by systemd. Designed to be reusable across
+    different service types (node, baker, accuser, dal, signer). *)
+
+open Octez_manager_lib
+
+(** Per-process resource statistics *)
+type process_stats = {
+  pid : int;
+  cpu_percent : float;  (** 0-100 per core *)
+  memory_rss : int64;  (** bytes *)
+  memory_percent : float;  (** 0-100 *)
+}
+
+(** Previous CPU sample for delta calculation *)
+type cpu_sample = {
+  utime : int64;  (** user time in clock ticks *)
+  stime : int64;  (** system time in clock ticks *)
+  timestamp : float;  (** Unix timestamp *)
+}
+
+(** Aggregate metrics for a service instance *)
+type t = {
+  version : string option;  (** e.g. "21.0" *)
+  cpu_percent : float;  (** sum across all processes *)
+  memory_rss : int64;  (** total RSS bytes *)
+  memory_percent : float;  (** sum across all processes *)
+  data_dir_size : int64 option;  (** bytes *)
+  pids : int list;  (** tracked PIDs *)
+}
+
+let empty =
+  {
+    version = None;
+    cpu_percent = 0.0;
+    memory_rss = 0L;
+    memory_percent = 0.0;
+    data_dir_size = None;
+    pids = [];
+  }
+
+(** Page size in bytes (standard on Linux) *)
+let page_size = 4096
+
+(** Clock ticks per second (standard on Linux) *)
+let clock_ticks_per_sec = 100
+
+(** Get the main PID for a systemd service *)
+let get_service_main_pid ~role ~instance =
+  let unit_name = Printf.sprintf "octez-%s@%s" role instance in
+  let cmd =
+    if Common.is_root () then
+      ["systemctl"; "show"; "--property=MainPID"; unit_name]
+    else ["systemctl"; "--user"; "show"; "--property=MainPID"; unit_name]
+  in
+  match Common.run_out cmd with
+  | Ok output -> (
+      (* Output is "MainPID=12345" *)
+      match String.split_on_char '=' output with
+      | [_; pid_str] -> (
+          let pid_str = String.trim pid_str in
+          match int_of_string_opt pid_str with
+          | Some pid when pid > 0 -> Some pid
+          | _ -> None)
+      | _ -> None)
+  | Error _ -> None
+
+(** Get child PIDs of a process *)
+let get_child_pids ~parent_pid =
+  let path =
+    Printf.sprintf "/proc/%d/task/%d/children" parent_pid parent_pid
+  in
+  try
+    let ic = open_in path in
+    let line = try input_line ic with End_of_file -> "" in
+    close_in ic ;
+    String.split_on_char ' ' line
+    |> List.filter_map (fun s ->
+           let s = String.trim s in
+           if s = "" then None else int_of_string_opt s)
+  with _ -> []
+
+(** Get all PIDs for a service (main + children, recursively) *)
+let get_service_pids ~role ~instance =
+  match get_service_main_pid ~role ~instance with
+  | None -> []
+  | Some main_pid ->
+      let rec collect_all pid =
+        let children = get_child_pids ~parent_pid:pid in
+        pid :: List.concat_map collect_all children
+      in
+      collect_all main_pid
+
+(** Read /proc/<pid>/stat and parse CPU times *)
+let read_proc_stat ~pid =
+  let path = Printf.sprintf "/proc/%d/stat" pid in
+  try
+    let ic = open_in path in
+    let line = input_line ic in
+    close_in ic ;
+    (* Format: pid (comm) state ppid pgrp session tty_nr tpgid flags minflt
+       cminflt majflt cmajflt utime stime cutime cstime ...
+       Fields are space-separated, but comm can contain spaces and is in parens *)
+    let close_paren = String.rindex line ')' in
+    let rest = String.sub line (close_paren + 2) (String.length line - close_paren - 2) in
+    let fields = String.split_on_char ' ' rest in
+    (* After (comm), fields are: state(0) ppid(1) ... utime(11) stime(12) ... rss(21) *)
+    let utime = List.nth_opt fields 11 |> Option.map Int64.of_string in
+    let stime = List.nth_opt fields 12 |> Option.map Int64.of_string in
+    let rss_pages = List.nth_opt fields 21 |> Option.map Int64.of_string in
+    match (utime, stime, rss_pages) with
+    | Some u, Some s, Some rss ->
+        Some (u, s, Int64.mul rss (Int64.of_int page_size))
+    | _ -> None
+  with _ -> None
+
+(** Read total system memory from /proc/meminfo *)
+let total_memory =
+  lazy
+    (try
+       let ic = open_in "/proc/meminfo" in
+       let result = ref 0L in
+       (try
+          while true do
+            let line = input_line ic in
+            if String.length line > 9 && String.sub line 0 9 = "MemTotal:" then (
+              let parts =
+                String.split_on_char ' ' line |> List.filter (fun s -> s <> "")
+              in
+              match parts with
+              | _ :: kb_str :: _ -> (
+                  match Int64.of_string_opt kb_str with
+                  | Some kb ->
+                      result := Int64.mul kb 1024L ;
+                      raise Exit
+                  | None -> ())
+              | _ -> ())
+          done
+        with Exit | End_of_file -> ()) ;
+       close_in ic ;
+       !result
+     with _ -> 0L)
+
+(** Calculate CPU percentage from two samples *)
+let calc_cpu_percent ~prev ~curr =
+  let delta_time = curr.timestamp -. prev.timestamp in
+  if delta_time <= 0.0 then 0.0
+  else
+    let delta_utime = Int64.sub curr.utime prev.utime in
+    let delta_stime = Int64.sub curr.stime prev.stime in
+    let delta_ticks = Int64.add delta_utime delta_stime in
+    let ticks_per_interval =
+      delta_time *. Float.of_int clock_ticks_per_sec
+    in
+    if ticks_per_interval <= 0.0 then 0.0
+    else
+      (* CPU percentage (can exceed 100% on multi-core systems) *)
+      Int64.to_float delta_ticks /. ticks_per_interval *. 100.0
+
+(** Get process stats with CPU calculated from previous sample *)
+let get_process_stats ~pid ~prev_sample =
+  match read_proc_stat ~pid with
+  | None -> None
+  | Some (utime, stime, rss) ->
+      let now = Unix.gettimeofday () in
+      let curr_sample = {utime; stime; timestamp = now} in
+      let cpu_percent =
+        match prev_sample with
+        | None -> 0.0
+        | Some prev -> calc_cpu_percent ~prev ~curr:curr_sample
+      in
+      let mem_total = Lazy.force total_memory in
+      let memory_percent =
+        if mem_total > 0L then
+          Int64.to_float rss /. Int64.to_float mem_total *. 100.0
+        else 0.0
+      in
+      Some
+        ( {pid; cpu_percent; memory_rss = rss; memory_percent},
+          curr_sample )
+
+(** Extract version string from binary --version output *)
+let parse_version_output output =
+  (* Look for "Octez XX.Y" pattern *)
+  let lines = String.split_on_char '\n' output in
+  let rec find_version = function
+    | [] -> None
+    | line :: rest -> (
+        match Str.search_forward (Str.regexp "Octez \\([0-9]+\\.[0-9]+\\)") line 0 with
+        | _ -> Some (Str.matched_group 1 line)
+        | exception Not_found -> find_version rest)
+  in
+  find_version lines
+
+(** Get version string from a binary *)
+let get_version ~binary =
+  let full_path =
+    if Filename.is_relative binary then
+      match Common.which binary with Some p -> p | None -> binary
+    else binary
+  in
+  if not (Sys.file_exists full_path) then None
+  else
+    match Common.run_out [full_path; "--version"] with
+    | Ok output -> parse_version_output output
+    | Error _ -> None
+
+(** Get directory size using du *)
+let get_dir_size ~path =
+  if not (Sys.file_exists path) then None
+  else
+    match Common.run_out ["du"; "-sb"; path] with
+    | Ok output -> (
+        (* Output is "12345\t/path" *)
+        match String.split_on_char '\t' output with
+        | size_str :: _ -> Int64.of_string_opt (String.trim size_str)
+        | _ -> None)
+    | Error _ -> None
+
+(** Format bytes as human-readable string *)
+let format_bytes bytes =
+  let b = Int64.to_float bytes in
+  if b >= 1099511627776.0 then Printf.sprintf "%.1fT" (b /. 1099511627776.0)
+  else if b >= 1073741824.0 then Printf.sprintf "%.1fG" (b /. 1073741824.0)
+  else if b >= 1048576.0 then Printf.sprintf "%.0fM" (b /. 1048576.0)
+  else if b >= 1024.0 then Printf.sprintf "%.0fK" (b /. 1024.0)
+  else Printf.sprintf "%LdB" bytes

--- a/src/ui/system_metrics.mli
+++ b/src/ui/system_metrics.mli
@@ -1,0 +1,91 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2025 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** System metrics collection for service instances.
+
+    Collects CPU, memory, disk usage, and version information for
+    services managed by systemd. Designed to be reusable across
+    different service types (node, baker, accuser, dal, signer). *)
+
+(** Per-process resource statistics *)
+type process_stats = {
+  pid : int;
+  cpu_percent : float;  (** 0-100 per core *)
+  memory_rss : int64;  (** bytes *)
+  memory_percent : float;  (** 0-100 *)
+}
+
+(** Previous CPU sample for delta calculation *)
+type cpu_sample = {
+  utime : int64;  (** user time in clock ticks *)
+  stime : int64;  (** system time in clock ticks *)
+  timestamp : float;  (** Unix timestamp *)
+}
+
+(** Aggregate metrics for a service instance *)
+type t = {
+  version : string option;  (** e.g. "21.0" *)
+  cpu_percent : float;  (** sum across all processes *)
+  memory_rss : int64;  (** total RSS bytes *)
+  memory_percent : float;  (** sum across all processes *)
+  data_dir_size : int64 option;  (** bytes *)
+  pids : int list;  (** tracked PIDs *)
+}
+
+(** Empty metrics record *)
+val empty : t
+
+(** {2 PID Discovery} *)
+
+(** Get the main PID for a systemd service.
+    Returns [None] if the service is not running or PID cannot be determined. *)
+val get_service_main_pid : role:string -> instance:string -> int option
+
+(** Get child PIDs of a process (direct children only). *)
+val get_child_pids : parent_pid:int -> int list
+
+(** Get all PIDs for a service (main + all descendants).
+    Returns empty list if service is not running. *)
+val get_service_pids : role:string -> instance:string -> int list
+
+(** {2 Process Metrics} *)
+
+(** Read raw CPU times and RSS from /proc/<pid>/stat.
+    Returns [(utime, stime, rss_bytes)] or [None] if process not found. *)
+val read_proc_stat : pid:int -> (int64 * int64 * int64) option
+
+(** Calculate CPU percentage from two samples. *)
+val calc_cpu_percent : prev:cpu_sample -> curr:cpu_sample -> float
+
+(** Get process stats with CPU calculated from previous sample.
+    Returns the stats and the new sample for the next calculation.
+    Pass [None] for [prev_sample] on first call (CPU will be 0.0). *)
+val get_process_stats :
+  pid:int ->
+  prev_sample:cpu_sample option ->
+  (process_stats * cpu_sample) option
+
+(** {2 Version Detection} *)
+
+(** Parse version string from binary --version output.
+    Looks for "Octez XX.Y" pattern and returns just the version number. *)
+val parse_version_output : string -> string option
+
+(** Get version string from a binary.
+    Runs [binary --version] and extracts version number. *)
+val get_version : binary:string -> string option
+
+(** {2 Disk Usage} *)
+
+(** Get directory size in bytes using du.
+    Returns [None] if path doesn't exist or du fails. *)
+val get_dir_size : path:string -> int64 option
+
+(** {2 Formatting} *)
+
+(** Format bytes as human-readable string (e.g., "1.2G", "450M"). *)
+val format_bytes : int64 -> string

--- a/src/ui/system_metrics_scheduler.ml
+++ b/src/ui/system_metrics_scheduler.ml
@@ -1,0 +1,471 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2025 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Background scheduler for collecting system metrics.
+
+    Polls CPU, memory, disk usage, and version information at
+    configurable intervals. Uses sparklines to display history. *)
+
+open Octez_manager_lib
+module Bg = Background_runner
+
+(** Metrics storage per instance *)
+type instance_state = {
+  mutable version : string option;
+  mutable pids : int list;
+  mutable last_pid_check : float;
+  cpu_samples : (int, System_metrics.cpu_sample) Hashtbl.t;
+  mutable cpu_history : float list;  (** Recent CPU values for line chart *)
+  mem_sparkline : Miaou_widgets_display.Sparkline_widget.t;
+  mutable memory_rss : int64;
+  mutable data_dir_size : int64 option;
+  mutable last_cpu_poll : float;
+  mutable last_mem_poll : float;
+  mutable last_disk_poll : float;
+}
+
+(** Chart configuration *)
+let cpu_chart_width = 20
+
+let cpu_chart_height = 3
+
+let cpu_max_points = 40
+
+let mem_sparkline_width = 10
+
+let mem_max_points = 20
+
+(** Create a new instance state *)
+let make_instance_state () =
+  {
+    version = None;
+    pids = [];
+    last_pid_check = 0.0;
+    cpu_samples = Hashtbl.create 17;
+    cpu_history = [];
+    mem_sparkline =
+      Miaou_widgets_display.Sparkline_widget.create
+        ~width:mem_sparkline_width
+        ~max_points:mem_max_points
+        ~min_value:0.0
+        ();
+    memory_rss = 0L;
+    data_dir_size = None;
+    last_cpu_poll = 0.0;
+    last_mem_poll = 0.0;
+    last_disk_poll = 0.0;
+  }
+
+(** Storage and lock *)
+let table : (string, instance_state) Hashtbl.t = Hashtbl.create 17
+
+let lock = Mutex.create ()
+
+(** Track which instances we've already warned about version *)
+let version_warned : (string, unit) Hashtbl.t = Hashtbl.create 17
+
+(** Forward ref for version toast check (defined later after version parsing) *)
+let check_version_toast_ref :
+    (key:string -> instance:string -> version:string -> unit) ref =
+  ref (fun ~key:_ ~instance:_ ~version:_ -> ())
+
+let with_lock f =
+  Mutex.lock lock ;
+  Fun.protect ~finally:(fun () -> Mutex.unlock lock) f
+
+(** Poll intervals *)
+let cpu_interval = 0.5 (* 500ms *)
+
+let mem_interval = 1.0 (* 1s *)
+
+let disk_interval = 5.0 (* 5s *)
+
+let pid_check_interval = 5.0 (* Check PIDs every 5s *)
+
+(** Get or create instance state *)
+let get_state key =
+  with_lock (fun () ->
+      match Hashtbl.find_opt table key with
+      | Some s -> s
+      | None ->
+          let s = make_instance_state () in
+          Hashtbl.replace table key s ;
+          s)
+
+
+(** Update PIDs and version if changed *)
+let update_pids_and_version ~role ~instance ~binary ~data_dir state now =
+  if now -. state.last_pid_check < pid_check_interval then ()
+  else (
+    state.last_pid_check <- now ;
+    let new_pids = System_metrics.get_service_pids ~role ~instance in
+    let pids_changed =
+      List.length new_pids <> List.length state.pids
+      || List.exists2 ( <> ) (List.sort compare new_pids) (List.sort compare state.pids)
+    in
+    state.pids <- new_pids ;
+    (* Refresh version when PIDs change (service restarted) *)
+    let old_version = state.version in
+    if pids_changed || Option.is_none state.version then
+      state.version <- System_metrics.get_version ~binary ;
+    (* Check version and show toast if outdated (on first detection or change) *)
+    let key = Printf.sprintf "%s/%s" role instance in
+    (match (old_version, state.version) with
+    | _, None -> ()
+    | old, Some v when old <> Some v ->
+        (* Version changed or first detection - check and toast *)
+        Hashtbl.remove version_warned key ;
+        !check_version_toast_ref ~key ~instance ~version:v
+    | _ -> ()) ;
+    (* Update disk size on PID check *)
+    state.data_dir_size <- System_metrics.get_dir_size ~path:data_dir)
+
+(** Poll CPU for all tracked PIDs *)
+let poll_cpu state now =
+  if now -. state.last_cpu_poll < cpu_interval then ()
+  else (
+    state.last_cpu_poll <- now ;
+    let total_cpu = ref 0.0 in
+    List.iter
+      (fun pid ->
+        let prev = Hashtbl.find_opt state.cpu_samples pid in
+        match System_metrics.get_process_stats ~pid ~prev_sample:prev with
+        | None -> Hashtbl.remove state.cpu_samples pid
+        | Some (stats, new_sample) ->
+            Hashtbl.replace state.cpu_samples pid new_sample ;
+            total_cpu := !total_cpu +. stats.cpu_percent)
+      state.pids ;
+    let cpu = !total_cpu in
+    (* Add to history, keep last N points *)
+    let history = state.cpu_history @ [cpu] in
+    let len = List.length history in
+    state.cpu_history <-
+      if len > cpu_max_points then
+        List.filteri (fun i _ -> i >= len - cpu_max_points) history
+      else history)
+
+(** Poll memory for all tracked PIDs *)
+let poll_mem state now =
+  if now -. state.last_mem_poll < mem_interval then ()
+  else (
+    state.last_mem_poll <- now ;
+    let total_rss = ref 0L in
+    List.iter
+      (fun pid ->
+        match System_metrics.read_proc_stat ~pid with
+        | None -> ()
+        | Some (_, _, rss) -> total_rss := Int64.add !total_rss rss)
+      state.pids ;
+    state.memory_rss <- !total_rss ;
+    let mem_mb = Int64.to_float !total_rss /. 1048576.0 in
+    Miaou_widgets_display.Sparkline_widget.push state.mem_sparkline mem_mb)
+
+(** Poll disk size *)
+let poll_disk ~data_dir state now =
+  if now -. state.last_disk_poll < disk_interval then ()
+  else (
+    state.last_disk_poll <- now ;
+    state.data_dir_size <- System_metrics.get_dir_size ~path:data_dir)
+
+(** Poll all metrics for an instance *)
+let poll ~role ~instance ~binary ~data_dir =
+  let key = Printf.sprintf "%s/%s" role instance in
+  let state = get_state key in
+  let now = Unix.gettimeofday () in
+  update_pids_and_version ~role ~instance ~binary ~data_dir state now ;
+  poll_cpu state now ;
+  poll_mem state now ;
+  poll_disk ~data_dir state now
+
+(** Render CPU line chart (multi-row braille) *)
+let render_cpu_chart ~role ~instance ~focus:_ =
+  let key = Printf.sprintf "%s/%s" role instance in
+  with_lock (fun () ->
+      match Hashtbl.find_opt table key with
+      | None -> None
+      | Some state ->
+          if state.cpu_history = [] then None
+          else
+            (* Convert history to points *)
+            let points =
+              List.mapi
+                (fun i y ->
+                  Miaou_widgets_display.Line_chart_widget.
+                    {x = Float.of_int i; y; color = None})
+                state.cpu_history
+            in
+            let series =
+              Miaou_widgets_display.Line_chart_widget.
+                [{label = "cpu"; points; color = None}]
+            in
+            let chart =
+              Miaou_widgets_display.Line_chart_widget.create
+                ~width:cpu_chart_width
+                ~height:cpu_chart_height
+                ~series
+                ()
+            in
+            let thresholds =
+              Miaou_widgets_display.Line_chart_widget.
+                [
+                  {value = 90.0; color = "\027[31m"};
+                  {value = 75.0; color = "\027[33m"};
+                ]
+            in
+            let rendered =
+              Miaou_widgets_display.Line_chart_widget.render
+                chart
+                ~show_axes:false
+                ~show_grid:false
+                ~thresholds
+                ~mode:Braille
+                ()
+            in
+            (* Calculate average *)
+            let avg =
+              let sum = List.fold_left ( +. ) 0.0 state.cpu_history in
+              sum /. Float.of_int (List.length state.cpu_history)
+            in
+            Some (rendered, avg))
+
+(** Render memory sparkline *)
+let render_mem_sparkline ~role ~instance ~focus =
+  let key = Printf.sprintf "%s/%s" role instance in
+  with_lock (fun () ->
+      match Hashtbl.find_opt table key with
+      | None -> ""
+      | Some state ->
+          if Miaou_widgets_display.Sparkline_widget.is_empty state.mem_sparkline
+          then ""
+          else
+            let value_str = System_metrics.format_bytes state.memory_rss in
+            let chart =
+              Miaou_widgets_display.Sparkline_widget.render
+                state.mem_sparkline
+                ~focus
+                ~show_value:false
+                ()
+            in
+            Printf.sprintf "%s %s" chart value_str)
+
+(** Get current version *)
+let get_version ~role ~instance =
+  let key = Printf.sprintf "%s/%s" role instance in
+  with_lock (fun () ->
+      match Hashtbl.find_opt table key with
+      | None -> None
+      | Some state -> state.version)
+
+(** Get disk size *)
+let get_disk_size ~role ~instance =
+  let key = Printf.sprintf "%s/%s" role instance in
+  with_lock (fun () ->
+      match Hashtbl.find_opt table key with
+      | None -> None
+      | Some state -> state.data_dir_size)
+
+(** Background polling state *)
+let bg_inflight = ref 0
+
+let bg_inflight_cap = 2
+
+let bg_lock = Mutex.create ()
+
+let schedule (f : unit -> unit) : bool =
+  let allowed =
+    Mutex.lock bg_lock ;
+    let allowed = !bg_inflight < bg_inflight_cap in
+    if allowed then incr bg_inflight ;
+    Mutex.unlock bg_lock ;
+    allowed
+  in
+  if allowed then (
+    Bg.submit_blocking
+      ~on_complete:(fun () ->
+        Mutex.lock bg_lock ;
+        decr bg_inflight ;
+        Mutex.unlock bg_lock)
+      (fun () -> try f () with _ -> ()) ;
+    true)
+  else false
+
+(** Tick - poll all node instances *)
+let tick () =
+  let nodes =
+    Data.load_service_states ()
+    |> List.filter (fun (st : Data.Service_state.t) ->
+           st.service.Service.role = "node")
+  in
+  List.iter
+    (fun (st : Data.Service_state.t) ->
+      let svc = st.service in
+      let binary =
+        Filename.concat svc.Service.app_bin_dir "octez-node"
+      in
+      let data_dir = svc.Service.data_dir in
+      let _ =
+        schedule (fun () ->
+            poll
+              ~role:svc.Service.role
+              ~instance:svc.Service.instance
+              ~binary
+              ~data_dir)
+      in
+      ())
+    nodes
+
+let started = ref false
+
+let rec loop () =
+  tick () ;
+  (* Sleep for minimum poll interval *)
+  Unix.sleepf 0.5 ;
+  loop ()
+
+(** Latest stable Octez version from feed *)
+let latest_stable_version : (int * int) option ref = ref None
+
+(** Parse version string like "23.3" or "v23.3" into (major, minor) *)
+let parse_version s =
+  let s = String.trim s in
+  let s = if String.length s > 0 && s.[0] = 'v' then String.sub s 1 (String.length s - 1) else s in
+  match String.split_on_char '.' s with
+  | major :: minor :: _ -> (
+      match (int_of_string_opt major, int_of_string_opt minor) with
+      | Some maj, Some min -> Some (maj, min)
+      | _ -> None)
+  | [major] -> (
+      match int_of_string_opt major with
+      | Some maj -> Some (maj, 0)
+      | None -> None)
+  | _ -> None
+
+(** Check if version string contains RC or dev markers *)
+let is_rc_or_dev s =
+  let s = String.lowercase_ascii s in
+  String.contains s '-'  (* -rc, -rc1, -dev, etc. *)
+
+(** Fetch and parse latest stable version from octez releases JSON *)
+let fetch_latest_version () =
+  let url = "https://octez.tezos.com/releases/versions.json" in
+  match Common.run_out ["curl"; "-sfL"; "--max-time"; "10"; url] with
+  | Error _ -> ()
+  | Ok json -> (
+      try
+        let data = Yojson.Safe.from_string json in
+        (* Find entry with "latest": true and no "rc" field *)
+        match data with
+        | `List versions ->
+            let latest =
+              List.find_opt
+                (fun v ->
+                  let is_latest =
+                    match Yojson.Safe.Util.member "latest" v with
+                    | `Bool true -> true
+                    | _ -> false
+                  in
+                  let is_rc =
+                    match Yojson.Safe.Util.member "rc" v with
+                    | `Null -> false
+                    | _ -> true
+                  in
+                  is_latest && not is_rc)
+                versions
+            in
+            (match latest with
+            | Some v ->
+                let major =
+                  Yojson.Safe.Util.member "major" v
+                  |> Yojson.Safe.Util.to_int_option
+                in
+                let minor =
+                  Yojson.Safe.Util.member "minor" v
+                  |> Yojson.Safe.Util.to_int_option
+                in
+                (match (major, minor) with
+                | Some maj, Some min -> latest_stable_version := Some (maj, min)
+                | _ -> ())
+            | None -> ())
+        | _ -> ()
+      with _ -> ())
+
+(** Version status for coloring *)
+type version_status =
+  | Latest      (** Running latest stable *)
+  | MinorBehind (** Same major, older minor *)
+  | MajorBehind (** Older major version *)
+  | DevOrRC     (** Running dev or RC version *)
+  | Unknown     (** Can't determine *)
+
+(** Compare running version against latest stable *)
+let check_version_status ~running =
+  if is_rc_or_dev running then DevOrRC
+  else
+    match (parse_version running, !latest_stable_version) with
+    | None, _ -> Unknown
+    | _, None -> Unknown
+    | Some (rmaj, rmin), Some (lmaj, lmin) ->
+        if rmaj = lmaj && rmin = lmin then Latest
+        else if rmaj = lmaj && rmin < lmin then MinorBehind
+        else if rmaj < lmaj then MajorBehind
+        else Latest  (* Running newer than "latest" - treat as latest *)
+
+(** Get ANSI color for version status *)
+let version_color status =
+  match status with
+  | Latest -> "\027[32m"       (* green *)
+  | MinorBehind -> "\027[33m"  (* yellow *)
+  | MajorBehind -> "\027[31m"  (* red *)
+  | DevOrRC -> "\027[34m"      (* blue *)
+  | Unknown -> ""              (* no color *)
+
+(** Color reset *)
+let color_reset = "\027[0m"
+
+(** Format version with color based on status *)
+let format_version_colored version =
+  let status = check_version_status ~running:version in
+  let color = version_color status in
+  if color = "" then Printf.sprintf "v%s" version
+  else Printf.sprintf "%sv%s%s" color version color_reset
+
+(** Check version for a single instance and show toast if outdated *)
+let check_version_toast_for ~key ~instance ~version =
+  (* Only check if we have latest version info *)
+  match !latest_stable_version with
+  | None -> ()
+  | Some (lmaj, lmin) ->
+      if Hashtbl.mem version_warned key then ()
+      else
+        let status = check_version_status ~running:version in
+        (match status with
+        | MinorBehind ->
+            Hashtbl.replace version_warned key () ;
+            Context.toast_warn
+              (Printf.sprintf "%s: v%s is outdated (latest: %d.%d)"
+                 instance version lmaj lmin)
+        | MajorBehind ->
+            Hashtbl.replace version_warned key () ;
+            Context.toast_error
+              (Printf.sprintf "%s: v%s is deprecated (latest: %d.%d)"
+                 instance version lmaj lmin)
+        | _ -> ())
+
+(* Wire up the forward reference *)
+let () = check_version_toast_ref := check_version_toast_for
+
+let start () =
+  if not !started then (
+    started := true ;
+    (* Fetch latest version in background *)
+    Bg.submit_blocking (fun () ->
+        try fetch_latest_version () with _ -> ()) ;
+    Bg.submit_blocking (fun () -> loop ()))
+
+(** Clear all state *)
+let clear () =
+  with_lock (fun () -> Hashtbl.clear table)

--- a/src/ui/system_metrics_scheduler.mli
+++ b/src/ui/system_metrics_scheduler.mli
@@ -1,0 +1,58 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2025 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Background scheduler for collecting system metrics.
+
+    Polls CPU, memory, disk usage, and version information at
+    configurable intervals. Uses sparklines to display history. *)
+
+(** {2 Metrics Polling} *)
+
+(** Poll metrics for a specific service instance.
+    Call this to update CPU, memory, disk, and version data. *)
+val poll :
+  role:string -> instance:string -> binary:string -> data_dir:string -> unit
+
+(** {2 Metrics Access} *)
+
+
+(** Get version string for an instance. *)
+val get_version : role:string -> instance:string -> string option
+
+(** Format version with color based on comparison with latest stable.
+    - Green: running latest stable
+    - Yellow: same major, older minor
+    - Red: older major version
+    - Blue: dev or RC version *)
+val format_version_colored : string -> string
+
+(** Get disk size for an instance. *)
+val get_disk_size : role:string -> instance:string -> int64 option
+
+(** {2 Rendering} *)
+
+(** Render CPU line chart for an instance (multi-row braille).
+    Returns [Some (chart_lines, avg_percent)] or [None] if no data.
+    The chart_lines string contains newlines for multi-row display. *)
+val render_cpu_chart :
+  role:string -> instance:string -> focus:bool -> (string * float) option
+
+(** Render memory sparkline for an instance.
+    Returns empty string if no data. *)
+val render_mem_sparkline : role:string -> instance:string -> focus:bool -> string
+
+(** {2 Scheduler Control} *)
+
+(** Start the background polling loop.
+    Only starts once; subsequent calls are no-ops. *)
+val start : unit -> unit
+
+(** Perform one tick of polling. *)
+val tick : unit -> unit
+
+(** Clear all stored metrics. *)
+val clear : unit -> unit


### PR DESCRIPTION
  Adds real-time system metrics and version tracking for node instances on the
  instances page.

  New features:
  - System metrics display for nodes: CPU usage (braille line chart), memory
  (sparkline), disk size, and version
  - Version tracking: Fetches latest stable version from
  octez.tezos.com/releases/versions.json at startup
  - Version status coloring: green (latest), yellow (minor behind), red (major
  behind), blue (RC/dev)
  - Deprecation toasts: Warning for outdated versions, error for deprecated
  versions (shown once per instance)
  - Help hint: Press ? on a node to see markdown-rendered explanation of all
  displayed metrics
  - Simplified RPC line: Removed "proto:" and "chain:" prefixes, shows "no rpc"
  badge on errors

  New files:
  - src/ui/system_metrics.ml - Core metrics collection (PID discovery, /proc
  parsing, version extraction)
  - src/ui/system_metrics_scheduler.ml - Background polling with configurable
  intervals (CPU 500ms, memory 1s, disk 5s)

  Test plan

  - Start octez-manager with a running node
  - Verify CPU chart renders with braille characters (3 rows)
  - Verify memory sparkline shows current usage
  - Verify version is colored based on comparison with latest (23.3)
  - Press ? on a node to see help popup
  - Restart a node and verify version toast appears if outdated

  ---

● ## Summary

  - Add real-time system metrics for node instances (CPU, memory, disk, version)
  - Fetch latest stable Octez version from releases API and color-code running
  versions
  - Show deprecation toasts for outdated/deprecated node versions
  - Add contextual help (`?`) explaining node metrics display
  - Simplify RPC status line format

  ## Changes

  **New modules:**
  - `system_metrics.ml` - PID discovery via systemd, `/proc` parsing for
  CPU/memory, version extraction
  - `system_metrics_scheduler.ml` - Background polling (CPU 500ms, memory 1s,
  disk 5s) with sparklines

  **Node display:**
  ● valentin       node       rolling    mainnet       [enabled]
                   synced · L12345 · Pt1234ab · NetXyz12 · Δ 5s
                   v23.3 · MEM ▄▅▆▇█ 937M · DISK 454M
                       ⡀⠀⠀⣀⠤⠒⠉⠢⣀
                       ⠈⠢⠔⠊⠀⠀⠀⠀⠀⠑
                   CPU ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀ 5%

  **Version colors:**
  - 🟢 Green: latest stable
  - 🟡 Yellow: same major, older minor
  - 🔴 Red: older major (deprecated)
  - 🔵 Blue: RC or dev version
