### PR TITLE
fix(ui): preserve extra flags and require values for value flag

### DIFF
--- a/src/ui/form_builder.ml
+++ b/src/ui/form_builder.ml
@@ -182,6 +182,7 @@ let extra_args ?baker_mode ~label ~get_args ~set_args ~get_bin_dir ~binary
   let set args m = set_args args m in
   let edit model_ref =
     let app_bin_dir = get_bin_dir !model_ref in
+    let initial_args = get_args !model_ref in
     let on_apply tokens =
       let arg_str = String.concat " " tokens in
       model_ref := set_args arg_str !model_ref
@@ -189,12 +190,19 @@ let extra_args ?baker_mode ~label ~get_args ~set_args ~get_bin_dir ~binary
     (* Call appropriate help function based on binary and subcommand *)
     match (binary, subcommand) with
     | "octez-node", _ ->
-        Binary_help_explorer.open_node_run_help ~app_bin_dir ~on_apply
+        Binary_help_explorer.open_node_run_help
+          ~app_bin_dir
+          ~initial_args
+          ~on_apply
     | "octez-baker", _ ->
         let mode =
           match baker_mode with None -> `Local | Some f -> f !model_ref
         in
-        Binary_help_explorer.open_baker_run_help ~app_bin_dir ~mode ~on_apply
+        Binary_help_explorer.open_baker_run_help
+          ~app_bin_dir
+          ~mode
+          ~initial_args
+          ~on_apply
     | _ ->
         (* Generic fallback - show error for now *)
         Modal_helpers.show_error

--- a/src/ui/form_builder_common.mli
+++ b/src/ui/form_builder_common.mli
@@ -94,3 +94,12 @@ val prepare_extra_args : string -> string list
     @param binary_name The name of the binary to find (e.g., "octez-node")
     @return The directory containing the binary, or /usr/bin as fallback *)
 val default_app_bin_dir : binary_name:string -> string
+
+(** Parse shellwords-style arguments with quote support.
+
+    Supports:
+    - Single quotes: preserve everything literally
+    - Double quotes: preserve spaces, allow escaping with backslash
+    - Unquoted: split on spaces
+    - Backslash escaping in double quotes and unquoted context *)
+val parse_shellwords : string -> string list


### PR DESCRIPTION
## Summary

  - Preserve previously selected flags when reopening the extra args modal
  - Prevent selecting value flags without providing a value

##  Changes

###  Preserve flags on modal reopen

  When the extra args modal is opened, it now parses the current extra_args
  string and pre-selects matching flags with their values. Previously, reopening
  the modal would reset all selections even if flags were already configured.

###  Require value for value flags

  When pressing Space on a flag that requires a value, the value modal opens
  instead of blindly toggling selection. This prevents selecting flags like
  --rpc-addr without providing the required value.

  - Toggle flags (e.g., --cors-all) still toggle on/off with Space
  - Value flags (e.g., --rpc-addr) open the value input modal on Space

##  Test plan

  - Select some flags in the modal, press Esc, verify they show in the field
  - Press Enter on the field again, verify previously selected flags are still
  checked
  - Press Space on a toggle flag (no <arg>), verify it toggles on/off
  - Press Space on a value flag (has <arg>), verify value modal opens
