### PR TITLE
fix: wrap octez-node --version in shell to avoid SIGPIPE   crash

### DIFF
--- a/src/ui/rpc_client.ml
+++ b/src/ui/rpc_client.ml
@@ -346,8 +346,12 @@ let node_version (s : Service.t) : string option =
     res)
   else
     let bin = Filename.concat s.app_bin_dir "octez-node" in
+    (* Use shell to avoid SIGPIPE issues - octez-node doesn't handle broken pipes gracefully *)
+    let cmd =
+      Printf.sprintf "timeout 2s %s --version 2>/dev/null" (Common.sh_quote bin)
+    in
     let v =
-      match Common.run_out ["timeout"; "2s"; bin; "--version"] with
+      match Common.run_out ["sh"; "-c"; cmd] with
       | Ok out ->
           clear_error s ;
           Some (String.trim out)


### PR DESCRIPTION
  ## Summary

  - Wrap `octez-node --version` call in shell command with stderr
  redirect
  - Prevents crash when octez-node encounters broken pipe on stdout

  ## Context

  `octez-node` doesn't handle SIGPIPE gracefully and crashes with:
  Fatal error: exception Sys_error("Broken pipe")

  Using `sh -c "timeout 2s <bin> --version 2>/dev/null"` instead of
  direct execution prevents this error from propagating to
  octez-manager.

  ## Test plan

  - [ ] Run octez-manager with nodes installed
  - [ ] Verify version is displayed correctly in instance cards
  - [ ] No more "Broken pipe" crashes in logs

