### PR TITLE
fix: Dynamically discover instance actions for shell completions

### DIFF
--- a/completions/_octez-manager
+++ b/completions/_octez-manager
@@ -20,13 +20,14 @@ _octez-manager() {
 
   local -a instance_actions
   instance_actions=(
-    'start:Start the service'
-    'stop:Stop the service'
-    'restart:Restart the service'
-    'remove:Unregister and remove the service'
-    'purge:Remove service and delete all data'
-    'show:Display service configuration'
-    'show-service:Display systemd unit and status'
+    'start'
+    'stop'
+    'restart'
+    'remove'
+    'purge'
+    'show'
+    'show-service'
+    'logs'
   )
 
   local -a history_modes

--- a/completions/octez-manager
+++ b/completions/octez-manager
@@ -28,7 +28,7 @@ _octez_manager() {
   prev="${COMP_WORDS[COMP_CWORD-1]}"
 
   local commands="cleanup-orphans install-accuser install-baker install-dal-node install-node instance list list-available-networks list-snapshots purge-all ui"
-  local instance_actions="start stop restart remove purge show show-service"
+  local instance_actions="start stop restart remove purge show show-service logs"
   local history_modes="archive full rolling"
   local snapshot_kinds="rolling full full:50 archive"
   local lb_votes="on off pass"


### PR DESCRIPTION
Instead of hardcoding instance actions in gen_completion.ml, discover them by parsing the error message from `octez-manager instance _ <invalid>`. This ensures new actions like `logs` are automatically included in completions.