### PR TITLE
fix(ui): Use cache for load_service_states when detail=false

### DIFF
--- a/src/ui/data.ml
+++ b/src/ui/data.ml
@@ -141,9 +141,12 @@ let schedule_refresh ?detail () =
 
 let load_service_states ?detail () =
   match detail with
-  | Some true -> refresh_cache ~detail:true ()
-  | Some false -> refresh_cache ~detail:false ()
-  | None ->
+  | Some true ->
+      (* Force fresh fetch with detailed status text (for diagnostics) *)
+      refresh_cache ~detail:true ()
+  | Some false | None ->
+      (* Use cache, refresh in background if stale.
+         When detail=false, we skip fetching status_text but still use cache. *)
       let cached = Atomic.get cache in
       let now = Unix.gettimeofday () in
       let age = now -. Atomic.get last_refresh in


### PR DESCRIPTION
## Summary
- Fixed performance issue where `load_service_states ~detail:false` bypassed the cache entirely
- The instances page calls `force_refresh` every second, which was causing expensive systemctl calls on every tick
- Now `~detail:false` uses the same caching logic as the default case (returns cached values, schedules background refresh when stale)
- Only `~detail:true` (used for diagnostics) forces a synchronous refresh

## Test plan
- [ ] Verify instances page is responsive and not laggy
- [ ] Verify service states still update after cache TTL (5 seconds)
- [ ] Verify diagnostics page still shows fresh detailed status

🤖 Generated with [Claude Code](https://claude.com/claude-code)