### PR TITLE
fix: Use stable backends for Eio and Miaou drivers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           opam pin add miaou-driver-term "$MIAOU_GIT_URL" --no-action
           opam pin add miaou-driver-matrix "$MIAOU_GIT_URL" --no-action
           opam pin add miaou-runner "$MIAOU_GIT_URL" --no-action
-          opam install miaou-core miaou-driver-term miaou-driver-matrix miaou-runner
+          opam install miaou-core miaou-driver-term miaou-driver-matrix miaou-runner eio_posix
 
       - name: Build
         run: |
@@ -103,7 +103,7 @@ jobs:
           opam pin add miaou-driver-term "$MIAOU_GIT_URL" --no-action
           opam pin add miaou-driver-matrix "$MIAOU_GIT_URL" --no-action
           opam pin add miaou-runner "$MIAOU_GIT_URL" --no-action
-          opam install miaou-core miaou-driver-term miaou-driver-matrix miaou-runner
+          opam install miaou-core miaou-driver-term miaou-driver-matrix miaou-runner eio_posix
 
       - name: Build static binary
         run: |

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -35,6 +35,7 @@ RUN opam update && opam install -y \
     bos \
     eio \
     eio_main \
+    eio_posix \
     cohttp-eio \
     tls-eio \
     tls \

--- a/dune-project
+++ b/dune-project
@@ -19,6 +19,7 @@
   miaou-runner
   eio
   eio_main
+  eio_posix
   cohttp-eio
   tls-eio
   tls

--- a/octez-manager.opam
+++ b/octez-manager.opam
@@ -21,6 +21,7 @@ depends: [
   "miaou-runner"
   "eio"
   "eio_main"
+  "eio_posix"
   "cohttp-eio"
   "tls-eio"
   "tls"

--- a/src/dune
+++ b/src/dune
@@ -36,6 +36,7 @@
   mirage-crypto-rng.unix
   uri
   eio_main
+  eio_posix
   eio
   miaou-core.lib)
  (instrumentation

--- a/src/main.ml
+++ b/src/main.ml
@@ -2795,8 +2795,13 @@ let ui_cmd =
              Capabilities.register () ;
              (* Ignore SIGPIPE to prevent crashes when subprocesses write to closed pipes *)
              Sys.set_signal Sys.sigpipe Sys.Signal_ignore ;
+             (* Default to stable term driver if not explicitly set *)
+             (match Sys.getenv_opt "MIAOU_DRIVER" with
+             | None -> Unix.putenv "MIAOU_DRIVER" "term"
+             | Some _ -> ()) ;
              let result =
-               Eio_main.run @@ fun env ->
+               (* Use POSIX backend to avoid io_uring resource exhaustion *)
+               Eio_posix.run @@ fun env ->
                Eio.Switch.run @@ fun sw ->
                Miaou_helpers.Fiber_runtime.init ~env ~sw ;
                Octez_manager_ui.Manager_app.run ?page ~log ?logfile ()

--- a/src/ui/background_runner.ml
+++ b/src/ui/background_runner.ml
@@ -31,7 +31,8 @@ let start () =
   if Atomic.compare_and_set started false true then
     ignore
       (Domain.spawn (fun () ->
-           Eio_main.run (fun env ->
+           (* Use POSIX backend to avoid io_uring resource exhaustion *)
+           Eio_posix.run (fun env ->
                let stream = Lazy.force stream in
                Eio.Switch.run (fun sw ->
                    for _ = 1 to num_workers do

--- a/src/ui/dune
+++ b/src/ui/dune
@@ -11,6 +11,7 @@
   miaou-runner.tui
   lambda-term
   eio
-  eio_main)
+  eio_main
+  eio_posix)
  (preprocess
   (pps ppx_deriving.show)))


### PR DESCRIPTION
## Summary

- Use `Eio_posix` instead of `Eio_main` to avoid io_uring resource exhaustion errors (`ENOMEM` on `io_uring_queue_init`)
- Default `MIAOU_DRIVER` to `term` if not explicitly set, preferring the stable lambda-term backend over matrix/sdl

## Context

The io_uring backend can fail with `ENOMEM` when system memlock limits are reached. Using the POSIX backend avoids this issue entirely while maintaining full functionality.

The term driver is set as default but can still be overridden via the `MIAOU_DRIVER` environment variable.

## Test plan

- [x] Build passes
- [x] Tests pass
- [ ] Manual test: UI starts without io_uring errors
- [ ] Manual test: `MIAOU_DRIVER=matrix ./octez-manager ui` still uses matrix driver

🤖 Generated with [Claude Code](https://claude.com/claude-code)