### PR TITLE
fix: Pass --endpoint to both global and DAL node options

### DIFF
--- a/src/systemd.ml
+++ b/src/systemd.ml
@@ -167,12 +167,14 @@ let exec_line role =
        \"${OCTEZ_CLIENT_BASE_DIR}\" --endpoint \"${OCTEZ_NODE_ENDPOINT}\" run \
        accuser ${OCTEZ_SERVICE_ARGS:-}'"
   | "dal-node" | "dal" ->
-      (* DAL node is a subcommand of octez-baker: octez-baker [global] run dal [opts] *)
+      (* DAL node is a subcommand of octez-baker: octez-baker [global] run dal [opts]
+         Note: --endpoint must be passed both as global option (for baker client)
+         and after "run dal" (for the DAL node component to connect to the L1 node) *)
       "ExecStart=/bin/sh -lc 'exec \"${APP_BIN_DIR}/octez-baker\" --base-dir \
        \"${OCTEZ_CLIENT_BASE_DIR}\" --endpoint \"${OCTEZ_NODE_ENDPOINT}\" run \
-       dal --data-dir \"${OCTEZ_DAL_DATA_DIR}\" --rpc-addr \
-       \"${OCTEZ_DAL_RPC_ADDR}\" --net-addr \"${OCTEZ_DAL_NET_ADDR}\" \
-       ${OCTEZ_SERVICE_ARGS:-}'"
+       dal --endpoint \"${OCTEZ_NODE_ENDPOINT}\" --data-dir \
+       \"${OCTEZ_DAL_DATA_DIR}\" --rpc-addr \"${OCTEZ_DAL_RPC_ADDR}\" \
+       --net-addr \"${OCTEZ_DAL_NET_ADDR}\" ${OCTEZ_SERVICE_ARGS:-}'"
   | other ->
       Printf.sprintf
         "ExecStart=/bin/sh -lc 'exec \"${APP_BIN_DIR}/octez-%s\" \


### PR DESCRIPTION
## Summary

When running `octez-baker run dal`, the `--endpoint` flag must be passed in two places:

1. **Before `run`** - as a global option for the baker client
2. **After `run dal`** - for the DAL node component to connect to L1

### Before
```bash
octez-baker --endpoint $NODE run dal --data-dir ...
```

### After
```bash
octez-baker --endpoint $NODE run dal --endpoint $NODE --data-dir ...
```

Previously only the global option was set, causing the DAL node to fail connecting to the L1 node.

## Test plan
- [ ] Install a DAL node and verify it connects to the L1 node successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)