### PR TITLE
fix(ui): Restore phase indicator in job status header

### DIFF
--- a/src/ui/pages/instances.ml
+++ b/src/ui/pages/instances.ml
@@ -1804,12 +1804,17 @@ Press **Enter** to open instance menu.|}
               | Job_manager.Succeeded -> Widgets.green "Done"
               | Job_manager.Failed _ -> Widgets.red "Failed"
             in
+            let phase_str =
+              if job.Job_manager.phase = "" then ""
+              else " " ^ Widgets.cyan ("[" ^ job.phase ^ "]")
+            in
             "\n"
             ^ Widgets.dim
                 (Printf.sprintf
-                   "--- Job: %s (%s) ---"
+                   "--- Job: %s (%s)%s ---"
                    job.description
-                   status_str)
+                   status_str
+                   phase_str)
             ^ "\n" ^ tail
       | None -> ""
     in


### PR DESCRIPTION
## Summary

The phase indicator code from commits 958455f and 6ed4ec0 was lost during a rebase. This restores the feature that shows the current phase in the job header.

## What was lost

- `phase` field in job record
- Phase detection from `=== Header ===` markers in log output
- Phase display in job header

## How it works

When a job logs a line like `=== Downloading snapshot ===`, the phase is extracted and displayed:

```
--- Job: Install node (Running) [Downloading snapshot] ---
```

This provides visual feedback during long operations like snapshot downloads and imports.

## Test plan

- [ ] Install a node with snapshot
- [ ] Verify phase changes from "Downloading snapshot" to "Importing snapshot"

🤖 Generated with [Claude Code](https://claude.ai/code)