### PR TITLE
perf: Cache port validation to avoid I/O during form render

### DIFF
--- a/src/port_validation.mli
+++ b/src/port_validation.mli
@@ -46,6 +46,9 @@ val validate_addr :
   unit ->
   (unit, validation_error) result
 
+(** Clear the port process cache. Call when form opens to get fresh data. *)
+val clear_port_process_cache : unit -> unit
+
 (** Validate an RPC address (example: 127.0.0.1:8732). *)
 val validate_rpc_addr :
   ?exclude_instance:string -> string -> (unit, validation_error) result

--- a/src/ui/modal_helpers.ml
+++ b/src/ui/modal_helpers.ml
@@ -544,10 +544,14 @@ let prompt_validated_text_modal ?title ?(width = 60) ?initial ?placeholder
         Miaou.Core.Modal_manager.close_top `Cancel ;
         ps)
       else
-        Navigation.update
-          (fun _ ->
-            Miaou_widgets_input.Validated_textbox_widget.handle_key s ~key)
-          ps
+        (* Process key and flush validation to avoid stale error messages *)
+        let s =
+          Miaou_widgets_input.Validated_textbox_widget.handle_key s ~key
+        in
+        let s =
+          Miaou_widgets_input.Validated_textbox_widget.flush_validation s
+        in
+        Navigation.update (fun _ -> s) ps
 
     let handle_key = handle_modal_key
 


### PR DESCRIPTION
## Summary
- Fix slow form rendering caused by I/O during port validation
- Add caching for service port lookups (2s TTL)
- Make expensive `ss`/`netstat` process check optional (off by default)

## Problem
Port validation was extremely slow because on every render it:
1. Called `Service_registry.list()` which reads from disk
2. Ran `ss`/`netstat` shell commands to check if ports were in use

This happened for every port field on every keystroke/render.

## Solution
- Cache service ports with 2-second TTL
- Add `~check_process` optional parameter (default `false`)
- Process check can be enabled on form submit for thorough validation

## Test plan
- [ ] Open DAL node or node install form - should be responsive now
- [ ] Edit port fields - no lag during typing
- [ ] Submit form - validation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)