### PR TITLE
chore: add _opam/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 _build/
+_opam/
 .install/
 *.install
 *.merlin


### PR DESCRIPTION
The `_opam` directory contains local opam switch files and should not be tracked in version control. This prevents accidentally committing large dependency trees and local development artifacts.