### PR TITLE
fix(ui): don't highlight columns when menu is selected

### DIFF
--- a/src/ui/pages/instances.ml
+++ b/src/ui/pages/instances.ml
@@ -972,12 +972,16 @@ let table_lines_matrix ~cols ~visible_height ~column_scroll state =
     let marker = if state.selected = 0 then Widgets.bold "➤" else " " in
     Printf.sprintf "%s %s" marker (Widgets.bold "[ Install new instance ]")
   in
+  (* When selection is in menu area, use -1 to dim all columns equally *)
+  let effective_active_column =
+    if state.selected < services_start_idx then -1 else state.active_column
+  in
   let instance_rows =
     merge_columns
       ~col_width
       ~visible_height
       ~column_scroll
-      ~active_column:state.active_column
+      ~active_column:effective_active_column
       ~columns_content
   in
   install_row :: "" :: instance_rows


### PR DESCRIPTION
When the cursor is in the menu area (Install new instance), all columns should be dimmed equally since the menu spans all columns. Previously, whichever column was last active would remain highlighted even when navigating back to the menu.

## Problem

From PR #203: If you select the bakers column and move up to "Install new instance", the bakers column remains highlighted even though the cursor is now in the menu area.

## Solution

The fix checks if selection is in the menu area (`selected < services_start_idx`) and passes `-1` as the `active_column` to `merge_columns`, causing all columns to be dimmed equally.

## Changes

- Added `effective_active_column` logic in `table_lines_matrix`
- When in menu area: `effective_active_column = -1` (dims all columns)
- When in service list: `effective_active_column = state.active_column` (highlights current column)

This ensures only the cursor position determines what's highlighted, not the last active column.