### PR TITLE
feat(install): check disk space before snapshot download

### DIFF
--- a/src/common.ml
+++ b/src/common.ml
@@ -616,6 +616,19 @@ let get_available_space dir =
       | _ :: value_line :: _ -> Int64.of_string_opt (String.trim value_line)
       | _ -> None)
 
+let get_filesystem_id path =
+  (* Use stat to get the filesystem (device) ID for a path *)
+  try
+    let stats = Unix.stat path in
+    Some stats.Unix.st_dev
+  with Unix.Unix_error _ -> None
+
+let same_filesystem path1 path2 =
+  (* Check if two paths are on the same filesystem *)
+  match (get_filesystem_id path1, get_filesystem_id path2) with
+  | Some id1, Some id2 -> Some (id1 = id2)
+  | _ -> None
+
 (** Map Octez exit codes to human-readable descriptions.
     See https://octez.tezos.com/docs/user/exits.html *)
 let octez_exit_code_description code =

--- a/src/common.mli
+++ b/src/common.mli
@@ -108,5 +108,12 @@ val get_remote_file_size : string -> int64 option
 
 val get_available_space : string -> int64 option
 
+(** Get the filesystem device ID for a path. *)
+val get_filesystem_id : string -> int option
+
+(** Check if two paths are on the same filesystem.
+    Returns [Some true] if same, [Some false] if different, [None] if unknown. *)
+val same_filesystem : string -> string -> bool option
+
 (** Map Octez exit codes to human-readable descriptions. *)
 val octez_exit_code_description : int -> string


### PR DESCRIPTION
## Summary
- Add disk space validation when installing a node with snapshot
- Check data directory has enough space for imported data (~1.2x snapshot size)
- Check tmp directory has enough space for download (~1.1x snapshot size)
- Handle same filesystem case by checking combined space requirement
- Add `Common.same_filesystem` helper to detect shared filesystems

Both CLI and TUI forms now validate available space before proceeding with snapshot download/import.

Closes #162

## Test plan
- [ ] Test with insufficient tmp space - should show error
- [ ] Test with insufficient data_dir space - should show error  
- [ ] Test with sufficient space on both - should proceed normally
- [ ] Test when tmp_dir and data_dir are on same filesystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)