### PR TITLE
fix(file-browser): remove Space from commit_on to allow edit mode

### DIFF
--- a/src/ui/modal_helpers.ml
+++ b/src/ui/modal_helpers.ml
@@ -737,12 +737,12 @@ let open_file_browser_modal ?initial_path ~dirs_only ~require_writable
       dim_background = true;
     }
   in
-  (* Space commits via Miaou's commit_on, Enter/s handled manually in handle_key *)
+  (* Enter/s commits via Space handler in widget, Enter/s handled manually in handle_key *)
   Miaou.Core.Modal_manager.push
     (module Modal)
     ~init:(Modal.init ())
     ~ui
-    ~commit_on:["Space"; " "]
+    ~commit_on:[]
     ~cancel_on:["Esc"; "Escape"]
     ~on_close:(fun pstate -> function
       | `Commit -> (


### PR DESCRIPTION
Fixes the file browser Space key issue where pressing Space in EditingPath mode would close the modal instead of inserting a space character.

**Problem:**
The file browser modal had `commit_on:["Space"; " "]` which caused the modal manager to immediately close the modal whenever Space was pressed, regardless of whether the browser was in Browsing or EditingPath mode.

**Solution:**
Remove Space from `commit_on` list. The file browser widget already handles Space correctly:
- In Browsing mode: pressing Space sets `pending_selection`, which the modal detects and commits
- In EditingPath mode: pressing Space inserts a space character in the textbox

This allows users to type paths with spaces when editing in the file browser.

Related to https://github.com/trilitech/miaou/issues/45