### PR TITLE
docs: fix CLI reference and guides discrepancies

### DIFF
--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -31,7 +31,7 @@ eval $(opam env)
 ### 2. Clone and Build
 
 ```bash
-git clone https://github.com/mathiasbourgoin/octez-manager.git
+git clone https://github.com/trilitech/octez-manager.git
 cd octez-manager
 
 # Install dependencies

--- a/docs/src/content/docs/guides/dal-node-setup.md
+++ b/docs/src/content/docs/guides/dal-node-setup.md
@@ -20,7 +20,7 @@ The Data Availability Layer (DAL) is Tezos's scalability solution. Running a DAL
    - **Instance name**: `my-dal-node`
    - **Node**: Select your local node or enter endpoint
    - **RPC address**: `127.0.0.1:10732` (default)
-   - **Net address**: `[::]:11732` (default)
+   - **Net address**: `0.0.0.0:11732` (default)
 
 ## Installation via CLI
 
@@ -30,23 +30,22 @@ octez-manager install-dal-node \
   --instance my-dal-node \
   --node-instance my-node \
   --rpc-addr 127.0.0.1:10732 \
-  --net-addr "[::]:11732"
+  --net-addr 0.0.0.0:11732
 
 # Using remote endpoint
 octez-manager install-dal-node \
   --instance my-dal-node \
-  --node-endpoint http://localhost:8732 \
+  --node-instance http://localhost:8732 \
   --rpc-addr 127.0.0.1:10732
 ```
 
 ## Connecting Baker to DAL Node
 
-After setting up your DAL node, connect your baker:
+After setting up your DAL node, connect your baker by editing its configuration:
 
 ```bash
-# Edit existing baker
-octez-manager instance my-baker edit \
-  --dal-node my-dal-node
+# Edit existing baker configuration
+octez-manager instance my-baker edit
 ```
 
 Or specify during baker installation:
@@ -54,8 +53,9 @@ Or specify during baker installation:
 octez-manager install-baker \
   --instance my-baker \
   --node-instance my-node \
-  --delegates tz1... \
-  --dal-node my-dal-node
+  --delegate tz1... \
+  --dal-endpoint my-dal-node \
+  --liquidity-baking-vote pass
 ```
 
 ## Ports

--- a/docs/src/content/docs/guides/node-setup.md
+++ b/docs/src/content/docs/guides/node-setup.md
@@ -40,7 +40,7 @@ This guide walks you through setting up a Tezos node with Octez Manager.
    - **Network**: `mainnet` or `ghostnet`
    - **History mode**: `rolling` (recommended)
    - **RPC address**: `127.0.0.1:8732` (default)
-   - **Net address**: `[::]:9732` (default)
+   - **Net address**: `0.0.0.0:9732` (default)
    - **Bootstrap**: `Snapshot` (recommended)
 
 ## Installation via CLI
@@ -51,7 +51,7 @@ octez-manager install-node \
   --network mainnet \
   --history-mode rolling \
   --rpc-addr 127.0.0.1:8732 \
-  --net-addr "[::]:9732" \
+  --net-addr 0.0.0.0:9732 \
   --snapshot
 ```
 

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -35,11 +35,14 @@ octez-manager install-node [OPTIONS]
 | `--history-mode <MODE>` | rolling, full, archive | rolling |
 | `--data-dir <PATH>` | Data directory | auto |
 | `--rpc-addr <ADDR>` | RPC address | 127.0.0.1:8732 |
-| `--net-addr <ADDR>` | P2P address | [::]:9732 |
+| `--net-addr <ADDR>` | P2P address | 0.0.0.0:9732 |
 | `--snapshot` | Bootstrap from snapshot | false |
 | `--snapshot-uri <URL>` | Custom snapshot URL | auto |
 | `--snapshot-no-check` | Skip snapshot integrity check | false |
+| `--keep-snapshot` | Keep snapshot file after import | false |
+| `--tmp-dir <PATH>` | Temporary directory for snapshot download | /tmp |
 | `--service-user <USER>` | System user for the service | current user |
+| `--app-bin-dir <PATH>` | Directory containing Octez binaries | auto |
 | `--no-enable` | Don't auto-start the service | false |
 | `--preserve-data` | Keep existing data directory | false |
 | `--extra-arg <ARG>` | Extra argument for octez-node (repeatable) | - |
@@ -58,8 +61,9 @@ octez-manager install-dal-node [OPTIONS]
 | `--node-instance <NAME or URL>` | Local node instance name or remote endpoint URL | - |
 | `--data-dir <PATH>` | Data directory | auto |
 | `--rpc-addr <ADDR>` | RPC address | 127.0.0.1:10732 |
-| `--net-addr <ADDR>` | P2P address | [::]:11732 |
+| `--net-addr <ADDR>` | P2P address | 0.0.0.0:11732 |
 | `--service-user <USER>` | System user for the service | current user |
+| `--app-bin-dir <PATH>` | Directory containing Octez binaries | auto |
 | `--no-enable` | Don't auto-start the service | false |
 | `--extra-arg <ARG>` | Extra argument for octez-dal-node (repeatable) | - |
 
@@ -80,6 +84,7 @@ octez-manager install-baker [OPTIONS]
 | `--dal-endpoint <NAME or URL>` | DAL node instance name or endpoint URL | - |
 | `--base-dir <PATH>` | Baker base directory | auto |
 | `--service-user <USER>` | System user for the service | current user |
+| `--app-bin-dir <PATH>` | Directory containing Octez binaries | auto |
 | `--no-enable` | Don't auto-start the service | false |
 | `--extra-arg <ARG>` | Extra argument for octez-baker (repeatable) | - |
 
@@ -97,7 +102,9 @@ octez-manager install-accuser [OPTIONS]
 | `--node-instance <NAME or URL>` | Local node instance name or remote endpoint URL | - |
 | `--base-dir <PATH>` | Accuser base directory | auto |
 | `--service-user <USER>` | System user for the service | current user |
+| `--app-bin-dir <PATH>` | Directory containing Octez binaries | auto |
 | `--no-enable` | Don't auto-start the service | false |
+| `--extra-arg <ARG>` | Extra argument for octez-accuser (repeatable) | - |
 
 ### `instance`
 
@@ -117,21 +124,18 @@ Actions:
 | `show` | Show instance details |
 | `show-service` | Show systemd service status |
 | `logs` | View logs |
+| `export-logs` | Export logs to a tar.gz archive |
 | `edit` | Edit configuration |
 | `remove` | Remove instance (keeps data) |
 | `purge` | Remove instance and delete data |
 
 ### `list`
 
-List all instances.
+List all registered instances.
 
 ```bash
-octez-manager list [OPTIONS]
+octez-manager list
 ```
-
-| Option | Description |
-|--------|-------------|
-| `--json` | Output as JSON |
 
 ### `ui`
 
@@ -229,8 +233,8 @@ octez-manager instance mainnet restart
 # View logs
 octez-manager instance mainnet logs
 
-# List all instances as JSON
-octez-manager list --json
+# List all instances
+octez-manager list
 
 # Launch the TUI
 octez-manager


### PR DESCRIPTION
## Summary
Fix documentation discrepancies between CLI reference/guides and actual CLI behavior.

### CLI Reference (cli.md)
- Add missing options: `--app-bin-dir`, `--keep-snapshot`, `--tmp-dir`, `--extra-arg`
- Fix `--net-addr` defaults: `0.0.0.0` instead of `[::]`
- Add `export-logs` action to instance actions
- Remove non-existent `--json` option from `list` command

### Node Setup Guide
- Fix `--net-addr` default to `0.0.0.0:9732`

### DAL Node Setup Guide
- Fix `--net-addr` default to `0.0.0.0:11732`
- Fix option names: `--node-instance`, `--delegate`, `--dal-endpoint`
- Fix `edit` command example (doesn't take flags)

### Installation Guide
- Fix repo URL: `trilitech/octez-manager` instead of `mathiasbourgoin/octez-manager`

🤖 Generated with [Claude Code](https://claude.com/claude-code)