### PR TITLE
chore: use miaou's default driver instead of forcing term

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -3001,10 +3001,6 @@ let ui_term =
            Capabilities.register () ;
            (* Ignore SIGPIPE to prevent crashes when subprocesses write to closed pipes *)
            Sys.set_signal Sys.sigpipe Sys.Signal_ignore ;
-           (* Default to stable term driver if not explicitly set *)
-           (match Sys.getenv_opt "MIAOU_DRIVER" with
-           | None -> Unix.putenv "MIAOU_DRIVER" "term"
-           | Some _ -> ()) ;
            let result =
              (* Use POSIX backend to avoid io_uring resource exhaustion *)
              Eio_posix.run @@ fun env ->


### PR DESCRIPTION
## Summary
- Remove the code that forced `MIAOU_DRIVER=term`
- Allow miaou to use its default matrix driver

## Test plan
- [ ] Run the TUI and verify it works with the matrix driver

🤖 Generated with [Claude Code](https://claude.com/claude-code)