### PR TITLE
docs: fix GitHub URLs and light theme support

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -4,7 +4,7 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://mathiasbourgoin.github.io',
+	site: 'https://trilitech.github.io',
 	base: '/octez-manager',
 	integrations: [
 		starlight({
@@ -15,7 +15,7 @@ export default defineConfig({
 			favicon: '/favicon.png',
 			description: 'CLI and TUI for managing Tezos nodes, bakers, and DAL infrastructure',
 			social: [
-				{ icon: 'github', label: 'GitHub', href: 'https://github.com/mathiasbourgoin/octez-manager' },
+				{ icon: 'github', label: 'GitHub', href: 'https://github.com/trilitech/octez-manager' },
 			],
 			sidebar: [
 				{


### PR DESCRIPTION
## Summary

### Fix GitHub URLs in Astro config
- `site`: `mathiasbourgoin.github.io` → `trilitech.github.io`
- `social.href`: `mathiasbourgoin/octez-manager` → `trilitech/octez-manager`

### Fix light theme support in custom CSS
- Move dark-specific colors to `[data-theme='dark']` selector
- Add proper light theme colors for `[data-theme='light']`
- Replace hardcoded hex colors with CSS variables for theme compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)