### PR TITLE
fix(ui): invalidate caches after editing instances

### DIFF
--- a/src/ui/dal_health.ml
+++ b/src/ui/dal_health.ml
@@ -80,5 +80,9 @@ let get ~instance = with_lock (fun () -> Hashtbl.find_opt cache instance)
 let set ~instance data =
   with_lock (fun () -> Hashtbl.replace cache instance data)
 
-(** Clear cache *)
+(** Clear cache for a specific instance *)
+let clear_instance ~instance =
+  with_lock (fun () -> Hashtbl.remove cache instance)
+
+(** Clear all cache *)
 let clear () = with_lock (fun () -> Hashtbl.clear cache)

--- a/src/ui/dal_health.mli
+++ b/src/ui/dal_health.mli
@@ -21,4 +21,6 @@ val get : instance:string -> t option
 
 val set : instance:string -> t -> unit
 
+val clear_instance : instance:string -> unit
+
 val clear : unit -> unit

--- a/src/ui/delegate_scheduler.ml
+++ b/src/ui/delegate_scheduler.ml
@@ -192,6 +192,10 @@ let get_baker_delegate_data ~instance =
   let delegates = get_baker_delegates ~instance in
   List.filter_map (fun pkh -> Delegate_data.get ~pkh) delegates
 
+(** Invalidate and refresh cached config for an instance (call after editing baker).
+    This immediately reloads the config from disk so the UI shows fresh data. *)
+let invalidate_config ~instance = refresh_config ~instance
+
 (** Clear all state *)
 let clear () =
   Delegate_data.clear () ;

--- a/src/ui/delegate_scheduler.mli
+++ b/src/ui/delegate_scheduler.mli
@@ -26,5 +26,9 @@ val get_baker_delegates : instance:string -> string list
 (** Check if baker has DAL enabled (from cache, never blocks). *)
 val baker_has_dal : instance:string -> bool
 
+(** Refresh cached config for an instance (call after editing baker).
+    Immediately reloads from disk so UI shows fresh data. *)
+val invalidate_config : instance:string -> unit
+
 (** Clear all state and cache. *)
 val clear : unit -> unit

--- a/src/ui/pages/install_accuser_form_v3.ml
+++ b/src/ui/pages/install_accuser_form_v3.ml
@@ -485,6 +485,8 @@ let spec =
                 ()
           | _ -> Ok ()
         in
+        (* Invalidate caches and mark instances dirty to refresh UI *)
+        Context.mark_instances_dirty () ;
         (* Queue restart dependents for modal on instances page *)
         if model.edit_mode && model.stopped_dependents <> [] then
           Context.set_pending_restart_dependents model.stopped_dependents ;

--- a/src/ui/pages/install_baker_form_v3.ml
+++ b/src/ui/pages/install_baker_form_v3.ml
@@ -702,6 +702,10 @@ let spec =
                 ()
           | _ -> Ok ()
         in
+        (* Refresh caches so UI shows updated data *)
+        Delegate_scheduler.invalidate_config ~instance:model.core.instance_name ;
+        Baker_highwatermarks.refresh ~instance:model.core.instance_name ;
+        Context.mark_instances_dirty () ;
         (* Queue restart dependents for modal on instances page *)
         if model.edit_mode && model.stopped_dependents <> [] then
           Context.set_pending_restart_dependents model.stopped_dependents ;

--- a/src/ui/pages/install_dal_node_form_v3.ml
+++ b/src/ui/pages/install_dal_node_form_v3.ml
@@ -440,6 +440,9 @@ let spec =
                 ()
           | _ -> Ok ()
         in
+        (* Invalidate caches so UI shows updated data *)
+        Dal_health.clear_instance ~instance:model.core.instance_name ;
+        Context.mark_instances_dirty () ;
         (* Queue restart dependents for modal on instances page *)
         if model.edit_mode && model.stopped_dependents <> [] then
           Context.set_pending_restart_dependents model.stopped_dependents ;

--- a/src/ui/pages/install_node_form_v3.ml
+++ b/src/ui/pages/install_node_form_v3.ml
@@ -1165,6 +1165,7 @@ let spec =
                   (Printf.sprintf
                      "Node %s installed successfully"
                      model.core.instance_name) ;
+                (* Invalidate caches and mark instances dirty to refresh UI *)
                 Context.mark_instances_dirty ()
             | Job_manager.Failed msg ->
                 (* Log to debug file for troubleshooting *)


### PR DESCRIPTION
## Summary
- Fix stale UI data after editing instances by invalidating relevant caches
- Add `invalidate_config` to `Delegate_scheduler` for clearing baker config cache
- Add `clear_instance` to `Dal_health` for clearing DAL health cache per instance
- Call cache invalidation in each form's on_submit handler

## Problem
After editing a baker's delegates, the old delegates would still show in the UI until restarting the application. This was because the `Delegate_scheduler.config_cache` wasn't being invalidated when the baker config changed.

## Solution
Each form now invalidates the relevant caches after successful submission:
- **Baker form**: clears delegate config cache and highwatermarks cache
- **DAL node form**: clears DAL health cache
- **All forms**: mark instances dirty to trigger UI refresh

## Test plan
- [ ] Edit a baker and change delegates - verify new delegates appear immediately
- [ ] Edit a DAL node and verify health status refreshes
- [ ] Edit a node and verify UI updates without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)