### PR TITLE
fix(ui): strip node- prefix from auto-generated instance names

### DIFF
--- a/src/ui/flows.ml
+++ b/src/ui/flows.ml
@@ -22,6 +22,13 @@ let invalid_instance_name_error_msg =
   "Instance name contains invalid characters. "
   ^ Installer.invalid_instance_name_chars_msg
 
+(** Strip "node-" prefix from instance name to create cleaner dependent names.
+    E.g., "node-shadownet" -> "shadownet" so baker becomes "baker-shadownet" *)
+let strip_node_prefix inst =
+  if String.starts_with ~prefix:"node-" inst then
+    String.sub inst 5 (String.length inst - 5)
+  else inst
+
 let require_package_manager () =
   match
     Miaou_interfaces.Capability.get
@@ -122,7 +129,7 @@ let create_baker_flow ~services ~on_success =
       ~on_select:(fun parent_node ->
         prompt_text_modal
           ~title:"Baker Instance Name"
-          ~initial:("baker-" ^ parent_node)
+          ~initial:("baker-" ^ strip_node_prefix parent_node)
           ~on_submit:(fun instance ->
             let instance = String.trim instance in
             if instance = "" then

--- a/src/ui/pages/install_accuser_form_v3.ml
+++ b/src/ui/pages/install_accuser_form_v3.ml
@@ -199,7 +199,14 @@ let node_selection_field =
             in
             model_ref := {!model_ref with client = new_client} ;
             if should_autoname then (
-              let new_name = Printf.sprintf "accuser-%s" svc.Service.instance in
+              (* Strip "node-" prefix to avoid "accuser-node-shadownet" *)
+              let dep_name =
+                let inst = svc.Service.instance in
+                if String.starts_with ~prefix:"node-" inst then
+                  String.sub inst 5 (String.length inst - 5)
+                else inst
+              in
+              let new_name = Printf.sprintf "accuser-%s" dep_name in
               let default_dir = Common.default_role_dir "accuser" new_name in
               let new_core = {!model_ref.core with instance_name = new_name} in
               let new_client =

--- a/src/ui/pages/install_baker_form_v3.ml
+++ b/src/ui/pages/install_baker_form_v3.ml
@@ -288,7 +288,14 @@ let parent_node_field =
                 node_data_dir = svc.Service.data_dir;
               } ;
             if should_autoname then (
-              let new_name = Printf.sprintf "baker-%s" svc.Service.instance in
+              (* Strip "node-" prefix to avoid "baker-node-shadownet" *)
+              let dep_name =
+                let inst = svc.Service.instance in
+                if String.starts_with ~prefix:"node-" inst then
+                  String.sub inst 5 (String.length inst - 5)
+                else inst
+              in
+              let new_name = Printf.sprintf "baker-%s" dep_name in
               let default_dir = Common.default_role_dir "baker" new_name in
               let new_core = {!model_ref.core with instance_name = new_name} in
               let new_client =


### PR DESCRIPTION
## Summary
- Fix auto-generated instance names to strip redundant "node-" prefix
- `node-shadownet` → baker becomes `baker-shadownet` instead of `baker-node-shadownet`
- Applies to quick baker flow, baker form, and accuser form

## Problem
PR #187 fixed duplicate prefixes in **data directories**, but the **instance names** still had the issue. When selecting a node named `node-shadownet` as a dependency:
- Baker was suggested as `baker-node-shadownet`
- Accuser was suggested as `accuser-node-shadownet`

## Solution
Strip the `node-` prefix from the parent node's instance name before constructing the dependent service's name:
- `node-shadownet` → `shadownet` → `baker-shadownet`

## Files changed
- `src/ui/flows.ml` - Quick baker flow
- `src/ui/pages/install_baker_form_v3.ml` - Baker form autoname
- `src/ui/pages/install_accuser_form_v3.ml` - Accuser form autoname

## Test plan
- [ ] Create a node named `node-shadownet`
- [ ] Create a baker depending on it - should suggest `baker-shadownet`
- [ ] Create an accuser depending on it - should suggest `accuser-shadownet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)