### PR TITLE
fix(ci): fetch LFS files in docs deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
Add `lfs: true` to checkout step in docs deployment workflow.

## Problem
GIFs in `docs/public/gifs/` are stored with Git LFS. Without `lfs: true`, the checkout only fetches pointer files, not the actual GIF content.

## Solution
```yaml
- name: Checkout
  uses: actions/checkout@v4
  with:
    lfs: true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)