### PR TITLE
fix: hero button text color in dark mode

### DIFF
--- a/docs/src/styles/custom.css
+++ b/docs/src/styles/custom.css
@@ -45,6 +45,11 @@
   color: var(--sl-color-gray-1);
 }
 
+/* Hero action buttons - ensure readable text in dark mode */
+.hero a.primary {
+  color: #ffffff !important;
+}
+
 /* Code blocks - terminal style */
 pre {
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- Force white text on primary hero button for better contrast in dark mode

The dark blue button background with dark text was hard to read.