### PR TITLE
docs: use shadownet in examples instead of mainnet

### DIFF
--- a/docs/src/content/docs/getting-started/introduction.mdx
+++ b/docs/src/content/docs/getting-started/introduction.mdx
@@ -28,7 +28,7 @@ Setting up Tezos infrastructure requires:
 One command:
 
 ```bash
-octez-manager install-node --instance mainnet --network mainnet
+octez-manager install-node --instance shadownet --network shadownet
 ```
 
 Or an interactive TUI:

--- a/docs/src/content/docs/guides/node-setup.md
+++ b/docs/src/content/docs/guides/node-setup.md
@@ -65,7 +65,7 @@ octez-manager install-node \
 ```bash
 octez-manager install-node \
   --instance my-node \
-  --network mainnet \
+  --network shadownet \
   --snapshot \
   --snapshot-uri https://example.com/snapshot.rolling
 ```
@@ -75,7 +75,7 @@ octez-manager install-node \
 ```bash
 octez-manager install-node \
   --instance my-node \
-  --network mainnet \
+  --network shadownet \
   --data-dir /mnt/fast-ssd/tezos-node
 ```
 


### PR DESCRIPTION
Since Octez Manager is experimental, all examples should target shadownet, not mainnet.