### PR TITLE
chore: release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.1.1] - 2026-01-15
+
+### Added
+
+- One-liner install script (`curl -fsSL ... | sh`)
+- Binary accessibility validation for service users
+- Tab shortcut hint in TUI for folding sections
+- Ubuntu and Debian `.deb` packages in releases
+
+### Fixed
+
+- Hero button text color in dark mode
+- Temp directory cleanup on install script error
+- Use official Tezos logo
+
+### Changed
+
+- Documentation examples now target shadownet instead of mainnet
+- Documentation styling aligned with Tezlink/Tezos design
+
 ## [0.1.0] - 2026-01-14
 
 ### Added

--- a/src/main.ml
+++ b/src/main.ml
@@ -3025,7 +3025,7 @@ let ui_cmd =
 
 let root_cmd =
   let doc = "Terminal UI for managing Octez services" in
-  let info = Cmd.info "octez-manager" ~doc ~version:"0.1.0" in
+  let info = Cmd.info "octez-manager" ~doc ~version:"0.1.1" in
   Cmd.group
     info
     ~default:ui_term


### PR DESCRIPTION
## Release 0.1.1

### Added
- One-liner install script (`curl -fsSL ... | sh`)
- Binary accessibility validation for service users
- Tab shortcut hint in TUI for folding sections
- Ubuntu and Debian `.deb` packages in releases

### Fixed
- Hero button text color in dark mode
- Temp directory cleanup on install script error
- Use official Tezos logo

### Changed
- Documentation examples now target shadownet instead of mainnet
- Documentation styling aligned with Tezlink/Tezos design

---

After merge, tag with:
```bash
git tag v0.1.1
git push origin v0.1.1
```