### PR TITLE
ci: make CloudFront invalidation non-blocking

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -92,6 +92,7 @@ jobs:
         run: aws s3 sync dist/ ${{ secrets.AWS_S3_BUCKET_STAGING }} --delete
 
       - name: Invalidate CloudFront cache
+        continue-on-error: true
         run: |
           aws cloudfront create-invalidation \
             --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID_STAGING }} \
@@ -137,6 +138,7 @@ jobs:
         run: aws s3 sync dist/ ${{ secrets.AWS_S3_BUCKET }} --delete
 
       - name: Invalidate CloudFront cache
+        continue-on-error: true
         run: |
           aws cloudfront create-invalidation \
             --distribution-id ${{ secrets.AWS_CLOUDFRONT_DISTRIBUTION_ID }} \


### PR DESCRIPTION
## Problem

The deployment workflow is failing at the CloudFront cache invalidation step because the AWS IAM user doesn't have the required permission:

```
User: arn:aws:iam::665253215099:user/octez-manager.tezos.com is not authorized to perform: cloudfront:CreateInvalidation
```

This blocks deployments even though the S3 upload (the critical part) succeeds.

## Solution

Add `continue-on-error: true` to the CloudFront invalidation steps for both staging and production environments. This allows deployments to complete successfully even if cache invalidation fails.

**Impact:**
- Deployments will now succeed and files will be uploaded to S3
- Cache will eventually refresh based on CloudFront's TTL settings
- No immediate user impact since content is still updated

## Proper Long-term Fix

Someone with AWS access should add this permission to the IAM policy for both users:
- Production user: `octez-manager.tezos.com`
- Staging user: (similar naming)

```json
{
  "Effect": "Allow",
  "Action": "cloudfront:CreateInvalidation",
  "Resource": "arn:aws:cloudfront::665253215099:distribution/*"
}
```

Once the IAM permissions are fixed, the `continue-on-error` can be removed.