### PR TITLE
fix(docs): update base URL for octez-manager.tezos.com

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -4,8 +4,8 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://trilitech.github.io',
-	base: '/octez-manager',
+	site: 'https://octez-manager.tezos.com',
+	base: '/',
 	integrations: [
 		starlight({
 			title: 'Octez Manager',


### PR DESCRIPTION
## Problem

Links in the docs site include an extra `/octez-manager/` prefix because the Astro config was set for GitHub Pages deployment.

## Solution

Update `docs/astro.config.mjs`:
```diff
- site: 'https://trilitech.github.io',
- base: '/octez-manager',
+ site: 'https://octez-manager.tezos.com',
+ base: '/',
```

## Test Plan

- [ ] Merge and wait for staging deploy
- [ ] Verify links work correctly on staging
- [ ] Create release to deploy to production (after CloudFront cache is invalidated)