### PR TITLE
fix(docs): remove hardcoded /octez-manager/ from internal links

### DIFF
--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -105,5 +105,5 @@ sudo octez-manager
 
 ## Next Steps
 
-- [Quick Start Guide](/octez-manager/getting-started/quick-start)
-- [Setting Up a Node](/octez-manager/guides/node-setup)
+- [Quick Start Guide](/getting-started/quick-start)
+- [Setting Up a Node](/guides/node-setup)

--- a/docs/src/content/docs/getting-started/introduction.mdx
+++ b/docs/src/content/docs/getting-started/introduction.mdx
@@ -33,7 +33,7 @@ octez-manager install-node --instance shadownet --network shadownet
 
 Or an interactive TUI:
 
-![Install Node](/octez-manager/gifs/install_node.gif)
+![Install Node](/gifs/install_node.gif)
 
 ## Services
 
@@ -60,5 +60,5 @@ sudo octez-manager
 
 ## Next
 
-- [Installation](/octez-manager/getting-started/installation/)
-- [Using the TUI](/octez-manager/guides/tui-guide/)
+- [Installation](/getting-started/installation/)
+- [Using the TUI](/guides/tui-guide/)

--- a/docs/src/content/docs/getting-started/quick-start.mdx
+++ b/docs/src/content/docs/getting-started/quick-start.mdx
@@ -10,5 +10,5 @@ This page has moved. See the TUI guide for getting started:
 <LinkCard
   title="Using the TUI"
   description="The recommended way to install and monitor your Tezos infrastructure"
-  href="/octez-manager/guides/tui-guide/"
+  href="/guides/tui-guide/"
 />

--- a/docs/src/content/docs/guides/baker-setup.md
+++ b/docs/src/content/docs/guides/baker-setup.md
@@ -37,7 +37,7 @@ See the [Octez documentation](https://octez.tezos.com/docs/introduction/howtorun
 
 ## Installation via TUI
 
-![Install Baker](/octez-manager/gifs/install_baker.gif)
+![Install Baker](/gifs/install_baker.gif)
 
 1. Launch `octez-manager`
 2. Select **[ Install new instance ]** → **Baker**

--- a/docs/src/content/docs/guides/dal-node-setup.md
+++ b/docs/src/content/docs/guides/dal-node-setup.md
@@ -12,7 +12,7 @@ The Data Availability Layer (DAL) is Tezos's scalability solution. Running a DAL
 
 ## Installation via TUI
 
-![Install DAL Node](/octez-manager/gifs/install_dal_node.gif)
+![Install DAL Node](/gifs/install_dal_node.gif)
 
 1. Launch `octez-manager`
 2. Select **[ Install new instance ]** → **DAL Node**

--- a/docs/src/content/docs/guides/node-setup.md
+++ b/docs/src/content/docs/guides/node-setup.md
@@ -36,7 +36,7 @@ This guide walks you through setting up a Tezos node with Octez Manager.
 
 ## Installation via TUI
 
-![Install Node](/octez-manager/gifs/install_node.gif)
+![Install Node](/gifs/install_node.gif)
 
 1. Launch `octez-manager`
 2. Select **[ Install new instance ]** → **Node**

--- a/docs/src/content/docs/guides/tui-guide.md
+++ b/docs/src/content/docs/guides/tui-guide.md
@@ -37,7 +37,7 @@ The TUI provides access to all Octez Manager features:
 
 From the main screen, select **[ Install new instance ]** and choose **Node**.
 
-![Install Node](/octez-manager/gifs/install_node.gif)
+![Install Node](/gifs/install_node.gif)
 
 The installation wizard guides you through:
 
@@ -69,7 +69,7 @@ Select any instance with arrow keys and press `Enter` to see details, or use the
 
 After your node is synced, you can add a baker. Select **[ Install new instance ]** → **Baker**.
 
-![Install Baker](/octez-manager/gifs/install_baker.gif)
+![Install Baker](/gifs/install_baker.gif)
 
 The wizard will:
 1. Ask which node to connect to (select your Shadownet node)
@@ -81,7 +81,7 @@ The wizard will:
 
 Need to change delegates or other settings? Select the instance and press `e` to edit.
 
-![Edit Baker](/octez-manager/gifs/edit_baker.gif)
+![Edit Baker](/gifs/edit_baker.gif)
 
 Changes take effect after saving. The TUI will restart the service if needed.
 
@@ -126,7 +126,7 @@ Here's a typical workflow for a complete Shadownet baking setup:
 5. **Install an accuser** (recommended)
    - Monitors for double-baking
 
-![Install Accuser](/octez-manager/gifs/install_accuser.gif)
+![Install Accuser](/gifs/install_accuser.gif)
 
 ## Tips
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -8,7 +8,7 @@ hero:
     file: ../../assets/logo.png
   actions:
     - text: Get Started
-      link: /octez-manager/getting-started/introduction/
+      link: /getting-started/introduction/
       icon: right-arrow
     - text: GitHub
       link: https://github.com/trilitech/octez-manager
@@ -37,13 +37,13 @@ cd octez-manager
 opam install . --deps-only
 dune build && dune install
 ```
-See [full instructions](/octez-manager/getting-started/installation/#from-source) for OCaml/opam setup.
+See [full instructions](/getting-started/installation/#from-source) for OCaml/opam setup.
   </TabItem>
 </Tabs>
 
 ## See it in action
 
-![Octez Manager TUI](/octez-manager/gifs/octez-manager.gif)
+![Octez Manager TUI](/gifs/octez-manager.gif)
 
 ## Deploy a node in one command
 
@@ -124,7 +124,7 @@ octez-manager instance shadownet show
 
 <div style="display: flex; align-items: center; justify-content: center; margin-top: 2rem; opacity: 0.8;">
   <a href="https://www.nomadic-labs.com/" target="_blank" rel="noopener">
-    <img src="/octez-manager/nomadic-labs-logo.png" alt="Nomadic Labs" class="logo-light" style="height: 28px;" />
-    <img src="/octez-manager/nomadic-labs-logo-white.png" alt="Nomadic Labs" class="logo-dark" style="height: 28px;" />
+    <img src="/nomadic-labs-logo.png" alt="Nomadic Labs" class="logo-light" style="height: 28px;" />
+    <img src="/nomadic-labs-logo-white.png" alt="Nomadic Labs" class="logo-dark" style="height: 28px;" />
   </a>
 </div>

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -3,7 +3,7 @@ title: CLI Reference
 description: Command reference for scripting and automation
 ---
 
-The CLI is for advanced users who prefer command-line workflows or need to automate deployments with scripts. For interactive use, see [Using the TUI](/octez-manager/guides/tui-guide).
+The CLI is for advanced users who prefer command-line workflows or need to automate deployments with scripts. For interactive use, see [Using the TUI](/guides/tui-guide).
 
 ## Global Options
 


### PR DESCRIPTION
## Problem

Internal links and asset references in markdown content files were hardcoded with `/octez-manager/` prefix from the old GitHub Pages deployment.

Example:
```markdown
![Install Node](/octez-manager/gifs/install_node.gif)
- [Installation](/octez-manager/getting-started/installation/)
```

## Solution

Remove `/octez-manager/` prefix from all internal links:
```markdown
![Install Node](/gifs/install_node.gif)
- [Installation](/getting-started/installation/)
```

## Files Updated

- `installation.md` - internal links
- `introduction.mdx` - links and images
- `quick-start.mdx` - links
- `baker-setup.md` - images
- `dal-node-setup.md` - images
- `node-setup.md` - images
- `tui-guide.md` - images
- `index.mdx` - links and images
- `cli.md` - links

GitHub URLs (e.g., `github.com/trilitech/octez-manager/releases`) are unchanged as they're correct.

## Test Plan

- [ ] Merge and deploy
- [ ] Verify all links work on the site
- [ ] Verify all GIF images load correctly