### PR TITLE
fix(ui): allow 'h' key to toggle hidden files in file browser

### DIFF
--- a/src/ui/modal_helpers.ml
+++ b/src/ui/modal_helpers.ml
@@ -701,7 +701,6 @@ let open_file_browser_modal ?initial_path ~dirs_only ~require_writable
             match Miaou.Core.Keys.of_string key with
             | Some Miaou.Core.Keys.Right -> "Right"
             | Some Miaou.Core.Keys.Left -> "Left"
-            | Some (Miaou.Core.Keys.Char "h") -> "Left"
             | _ -> key
           in
 


### PR DESCRIPTION
## Summary

- Remove erroneous key remapping that mapped `h` to `Left` in the file browser modal
- The `h` key now correctly toggles hidden file visibility as intended by the Miaou widget

## Problem

In the file browser widget, pressing `h` to toggle hidden files visibility did not work. Instead, it navigated to the parent directory because `h` was being remapped to `"Left"` before reaching the file browser widget.

## Fix

Removed line 704 in `src/ui/modal_helpers.ml`:
```ocaml
| Some (Miaou.Core.Keys.Char "h") -> "Left"
```

Fixes #270