### PR TITLE
chore(docs): compress GIF assets for faster page loads

### DIFF
--- a/docs/public/gifs/edit_baker.gif
+++ b/docs/public/gifs/edit_baker.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4cc44b254ae3a822dc7ccc352af69562d817baecaf9e14b4160e7d0aed08751b
-size 64731706
+oid sha256:75e9491742a87d32f2ddc8d7e1d8a77611d16821c9251dac996b7ada51eabe1a
+size 3338832

--- a/docs/public/gifs/install_accuser.gif
+++ b/docs/public/gifs/install_accuser.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:90d7c7540ca95a9b7dbfedde82d97f647a1994e81ca7da1b0ddc0526fd7b1c0a
-size 5840784
+oid sha256:5c871a9214303a978da65d49c3ccd79ecbbe8a477b24ba92c33ce7958d371075
+size 1946673

--- a/docs/public/gifs/install_baker.gif
+++ b/docs/public/gifs/install_baker.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c7ecf39e688d9fac93c96af472ba1c53bf43e2e822e5916d89f62cccb0cbb8f8
-size 7896753
+oid sha256:bfa9b2544a9660b18b2a15b9495d8bba4d4bed22b02165e6178e281a2227df26
+size 3347617

--- a/docs/public/gifs/install_dal_node.gif
+++ b/docs/public/gifs/install_dal_node.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:83a4f87d132fc46e6068d49e81f570740f0c44d12601b1ea195ea09d66b51f85
-size 12567611
+oid sha256:cb0c59618115bfd8e7f25d6e400d10f6a6c01e6e21c30d98f6cd4a1c27faaa87
+size 2467817

--- a/docs/public/gifs/install_node.gif
+++ b/docs/public/gifs/install_node.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b34aa100bb975e262b44dc6a80f4468080c63fb5a26212d40b9535eebc4a05ba
-size 21908166
+oid sha256:a62d3df7434a4ff3f0fad6d5da25ef1d038ca3a5d11db618298a6d9872e95214
+size 4009915

--- a/docs/public/gifs/octez-manager.gif
+++ b/docs/public/gifs/octez-manager.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ac590cc5c5be8ee197365f78cd798d632e7a02b7e90220a6a19fa12a7de7e213
-size 121416054
+oid sha256:196bdff41e2644d8ac36c9350e80e73baf80ad089cf281e579226b6d0823e320
+size 5413009


### PR DESCRIPTION
## Summary
- Compress GIF assets in docs to reduce page load times

## Test plan
- Verify GIFs display correctly on the docs site