### PR TITLE
docs(readme): fix install-node snapshot command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ The UI provides installation wizards, service monitoring, log viewing, and snaps
 octez-manager install-node \
   --instance mainnet-node \
   --network mainnet \
-  --snapshot rolling
+  --snapshot \
+  --history-mode rolling
 
 # Install a baker
 octez-manager install-baker \


### PR DESCRIPTION
Fixes #305

The README incorrectly documented the `--snapshot` flag as taking a positional argument 'rolling'. The correct syntax requires separate `--snapshot` and `--history-mode` flags.

**Before:**
```sh
octez-manager install-node \
  --instance mainnet-node \
  --network mainnet \
  --snapshot rolling
```

**After:**
```sh
octez-manager install-node \
  --instance mainnet-node \
  --network mainnet \
  --snapshot \
  --history-mode rolling
```