### PR TITLE
refactor(cli): extract output formatting to cli_output module

### DIFF
--- a/src/cli/cli_output.ml
+++ b/src/cli/cli_output.ml
@@ -1,0 +1,247 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+open Octez_manager_lib
+module S = Service
+
+let pp_service fmt svc =
+  (* Don't query systemd during list - causes issues with multiple services *)
+  (* Status is shown in the UI instead *)
+  Format.fprintf
+    fmt
+    "%-16s %-8s %s (%s)"
+    svc.S.instance
+    svc.role
+    svc.network
+    svc.data_dir
+
+let print_services services =
+  if services = [] then print_endline "No services registered."
+  else (
+    List.iter (fun svc -> Format.printf "%a@." pp_service svc) services ;
+    Format.print_flush ())
+
+let pp_logging fmt = function
+  | Logging_mode.Journald -> Format.fprintf fmt "journald"
+
+let print_service_details svc =
+  (* Read env file for this instance *)
+  let env =
+    match Node_env.read ~inst:svc.S.instance with
+    | Ok pairs -> pairs
+    | Error _ -> []
+  in
+  let lookup key =
+    match List.assoc_opt key env with Some v -> String.trim v | None -> ""
+  in
+  (* Try to map endpoints to managed instances *)
+  let resolve_instance_for_endpoint (ep : string) ~(roles : string list) :
+      string option =
+    if String.trim ep = "" then None
+    else
+      match Service_registry.list () with
+      | Error _ -> None
+      | Ok (services : Service.t list) ->
+          let rec find_match (lst : Service.t list) =
+            match lst with
+            | [] -> None
+            | s :: rest ->
+                if
+                  List.exists (fun r -> String.equal s.role r) roles
+                  && String.equal (Installer.endpoint_of_rpc s.rpc_addr) ep
+                then Some s.instance
+                else find_match rest
+          in
+          find_match services
+  in
+  let print_node_endpoint () =
+    let node_inst = lookup "OCTEZ_NODE_INSTANCE" in
+    if String.trim node_inst <> "" then
+      Format.printf "Node instance : %s@." node_inst
+    else
+      let node_ep = lookup "OCTEZ_NODE_ENDPOINT" in
+      Format.printf
+        "Node endpoint : %s@."
+        (if node_ep = "" then svc.rpc_addr else node_ep)
+  in
+  (* Common fields *)
+  Format.printf "Instance      : %s@." svc.S.instance ;
+  Format.printf "Service name  : %s@." (Systemd.unit_name svc.role svc.instance) ;
+  Format.printf "Role          : %s@." svc.role ;
+  Format.printf "Network       : %s@." svc.network ;
+  (* Role-specific fields *)
+  (match svc.role with
+  | "node" ->
+      Format.printf
+        "History mode  : %s@."
+        (History_mode.to_string svc.history_mode) ;
+      Format.printf "Data dir      : %s@." svc.data_dir ;
+      Format.printf "RPC addr      : %s@." svc.rpc_addr ;
+      Format.printf "P2P addr      : %s@." svc.net_addr
+  | "baker" ->
+      let base_dir = lookup "OCTEZ_BAKER_BASE_DIR" in
+      let dal_cfg = lookup "OCTEZ_DAL_CONFIG" in
+      let delegates = lookup "OCTEZ_BAKER_DELEGATES_ARGS" in
+      let lb_vote = lookup "OCTEZ_BAKER_LB_VOTE" in
+      Format.printf "Base dir      : %s@." base_dir ;
+      print_node_endpoint () ;
+      (match String.lowercase_ascii (String.trim dal_cfg) with
+      | "disabled" -> Format.printf "DAL Config    : opt-out@."
+      | "" -> Format.printf "DAL Config    : auto@."
+      | raw -> (
+          match
+            resolve_instance_for_endpoint raw ~roles:["dal-node"; "dal"]
+          with
+          | Some inst -> Format.printf "DAL instance  : %s@." inst
+          | None -> Format.printf "DAL endpoint  : %s@." raw)) ;
+      if delegates <> "" then Format.printf "Delegates     : %s@." delegates ;
+      if lb_vote <> "" then Format.printf "LB Vote       : %s@." lb_vote
+  | "accuser" ->
+      let base_dir = lookup "OCTEZ_CLIENT_BASE_DIR" in
+      Format.printf "Base dir      : %s@." base_dir ;
+      print_node_endpoint ()
+  | "dal-node" | "dal" ->
+      let dal_data_dir = lookup "OCTEZ_DAL_DATA_DIR" in
+      Format.printf "DAL data dir  : %s@." dal_data_dir ;
+      print_node_endpoint () ;
+      if svc.rpc_addr <> "" then
+        Format.printf "DAL RPC addr  : %s@." svc.rpc_addr ;
+      if svc.net_addr <> "" then
+        Format.printf "DAL P2P addr  : %s@." svc.net_addr
+  | _ ->
+      (* Fallback for unknown roles *)
+      Format.printf "Data dir      : %s@." svc.data_dir ;
+      Format.printf "RPC addr      : %s@." svc.rpc_addr ;
+      Format.printf "P2P addr      : %s@." svc.net_addr) ;
+  (* Common footer *)
+  Format.printf "Service user  : %s@." svc.service_user ;
+  Format.printf "Octez bin dir : %s@." svc.app_bin_dir ;
+  Format.printf "Created at    : %s@." svc.created_at ;
+  Format.printf "Logging       : %a@." pp_logging svc.logging_mode ;
+
+  (* Files & Paths Section *)
+  Format.printf "@.Files & Paths:@." ;
+
+  let service_paths =
+    Systemd.get_service_paths ~role:svc.role ~instance:svc.instance
+  in
+  List.iter
+    (fun (label, path) -> Format.printf "  %-16s: %s@." label path)
+    service_paths ;
+
+  Format.printf
+    "  %-16s: %s@."
+    "Service Metadata"
+    (Filename.concat
+       (Service_registry.services_dir ())
+       (svc.instance ^ ".json")) ;
+
+  (match
+     Log_viewer.get_daily_log_file ~role:svc.role ~instance:svc.instance
+   with
+  | Ok path -> Format.printf "  %-16s: %s@." "Log File" path
+  | Error _ -> ()) ;
+
+  match svc.role with
+  | "node" ->
+      Format.printf
+        "  %-16s: %s@."
+        "Config File"
+        (Filename.concat svc.data_dir "config.json") ;
+      Format.printf
+        "  %-16s: %s@."
+        "Identity File"
+        (Filename.concat svc.data_dir "identity.json")
+  | "baker" ->
+      let base_dir = lookup "OCTEZ_BAKER_BASE_DIR" in
+      if base_dir <> "" then (
+        Format.printf "  %-16s: %s@." "Base Directory" base_dir ;
+        Format.printf
+          "  %-16s: %s@."
+          "Client Config"
+          (Filename.concat base_dir "config"))
+  | "accuser" ->
+      let base_dir = lookup "OCTEZ_CLIENT_BASE_DIR" in
+      if base_dir <> "" then (
+        Format.printf "  %-16s: %s@." "Base Directory" base_dir ;
+        Format.printf
+          "  %-16s: %s@."
+          "Client Config"
+          (Filename.concat base_dir "config"))
+  | "dal-node" | "dal" ->
+      let dal_dir = lookup "OCTEZ_DAL_DATA_DIR" in
+      if dal_dir <> "" then (
+        Format.printf "  %-16s: %s@." "DAL Data Dir" dal_dir ;
+        Format.printf
+          "  %-16s: %s@."
+          "Config File"
+          (Filename.concat dal_dir "config.json") ;
+        Format.printf
+          "  %-16s: %s@."
+          "Identity File"
+          (Filename.concat dal_dir "identity.json"))
+  | _ -> ()
+
+let print_snapshot_entry (entry : Snapshots.entry) =
+  Format.printf "%s (%s)@." entry.Snapshots.label entry.slug ;
+  (match entry.Snapshots.history_mode with
+  | Some hm -> Format.printf "  History mode : %s@." hm
+  | None -> ()) ;
+  (match entry.Snapshots.download_url with
+  | Some url -> Format.printf "  HTTPS        : %s@." url
+  | None -> ()) ;
+  entry.Snapshots.metadata
+  |> List.filter (fun (k, _) -> k <> "History mode" && k <> "HTTPS")
+  |> List.iter (fun (k, v) -> Format.printf "  %-12s %s@." (k ^ ":") v) ;
+  print_newline ()
+
+let snapshot_entry_to_json (entry : Snapshots.entry) =
+  let metadata =
+    `List
+      (List.map
+         (fun (k, v) -> `Assoc [("key", `String k); ("value", `String v)])
+         entry.Snapshots.metadata)
+  in
+  `Assoc
+    [
+      ("slug", `String entry.slug);
+      ("label", `String entry.Snapshots.label);
+      ( "history_mode",
+        match entry.Snapshots.history_mode with
+        | Some hm -> `String hm
+        | None -> `Null );
+      ( "download_url",
+        match entry.Snapshots.download_url with
+        | Some url -> `String url
+        | None -> `Null );
+      ("metadata", metadata);
+    ]
+
+let dropin_path_for ~role ~instance =
+  let dir =
+    if Common.is_root () then
+      Printf.sprintf "/etc/systemd/system/octez-%s@%s.service.d" role instance
+    else
+      let base = Filename.concat (Common.xdg_config_home ()) "systemd/user" in
+      Filename.concat
+        base
+        (Printf.sprintf "octez-%s@%s.service.d" role instance)
+  in
+  Filename.concat dir "override.conf"
+
+let slurp_file path =
+  let ic = open_in_bin path in
+  Fun.protect
+    ~finally:(fun () -> close_in_noerr ic)
+    (fun () -> really_input_string ic (in_channel_length ic))
+
+let format_bytes bytes =
+  let gb = Int64.to_float bytes /. (1024. *. 1024. *. 1024.) in
+  if gb >= 1.0 then Printf.sprintf "%.1f GB" gb
+  else
+    let mb = Int64.to_float bytes /. (1024. *. 1024.) in
+    Printf.sprintf "%.0f MB" mb

--- a/src/cli/cli_output.mli
+++ b/src/cli/cli_output.mli
@@ -1,0 +1,37 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** CLI output formatting utilities *)
+
+open Octez_manager_lib
+
+(** Format a service for list display *)
+val pp_service : Format.formatter -> Service.t -> unit
+
+(** Print a list of services *)
+val print_services : Service.t list -> unit
+
+(** Format logging mode *)
+val pp_logging : Format.formatter -> Logging_mode.t -> unit
+
+(** Print detailed information about a service *)
+val print_service_details : Service.t -> unit
+
+(** Print a snapshot entry *)
+val print_snapshot_entry : Snapshots.entry -> unit
+
+(** Convert snapshot entry to JSON *)
+val snapshot_entry_to_json : Snapshots.entry -> Yojson.Safe.t
+
+(** Get the dropin path for a service *)
+val dropin_path_for : role:string -> instance:string -> string
+
+(** Read entire file contents *)
+val slurp_file : string -> string
+
+(** Format bytes as human-readable string (GB or MB) *)
+val format_bytes : int64 -> string

--- a/src/cli/dune
+++ b/src/cli/dune
@@ -1,0 +1,7 @@
+(library
+ (name octez_manager_cli)
+ (wrapped false)
+ (modules cli_output)
+ (libraries octez_manager_lib cmdliner rresult yojson linenoise)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/src/dune
+++ b/src/dune
@@ -50,6 +50,7 @@
  (modules main)
  (libraries
   octez_manager_lib
+  octez_manager_cli
   octez-manager.ui
   cmdliner
   rresult

--- a/src/main.ml
+++ b/src/main.ml
@@ -12,237 +12,6 @@ module S = Service
 
 let cmdliner_error msg = `Error (false, msg)
 
-let pp_service fmt svc =
-  (* Don't query systemd during list - causes issues with multiple services *)
-  (* Status is shown in the UI instead *)
-  Format.fprintf
-    fmt
-    "%-16s %-8s %s (%s)"
-    svc.S.instance
-    svc.role
-    svc.network
-    svc.data_dir
-
-let print_services services =
-  if services = [] then print_endline "No services registered."
-  else (
-    List.iter (fun svc -> Format.printf "%a@." pp_service svc) services ;
-    Format.print_flush ())
-
-let pp_logging fmt = function
-  | Logging_mode.Journald -> Format.fprintf fmt "journald"
-
-let print_service_details svc =
-  (* Read env file for this instance *)
-  let env =
-    match Node_env.read ~inst:svc.S.instance with
-    | Ok pairs -> pairs
-    | Error _ -> []
-  in
-  let lookup key =
-    match List.assoc_opt key env with Some v -> String.trim v | None -> ""
-  in
-  (* Try to map endpoints to managed instances *)
-  let resolve_instance_for_endpoint (ep : string) ~(roles : string list) :
-      string option =
-    if String.trim ep = "" then None
-    else
-      match Service_registry.list () with
-      | Error _ -> None
-      | Ok (services : Service.t list) ->
-          let rec find_match (lst : Service.t list) =
-            match lst with
-            | [] -> None
-            | s :: rest ->
-                if
-                  List.exists (fun r -> String.equal s.role r) roles
-                  && String.equal (Installer.endpoint_of_rpc s.rpc_addr) ep
-                then Some s.instance
-                else find_match rest
-          in
-          find_match services
-  in
-  let print_node_endpoint () =
-    let node_inst = lookup "OCTEZ_NODE_INSTANCE" in
-    if String.trim node_inst <> "" then
-      Format.printf "Node instance : %s@." node_inst
-    else
-      let node_ep = lookup "OCTEZ_NODE_ENDPOINT" in
-      Format.printf
-        "Node endpoint : %s@."
-        (if node_ep = "" then svc.rpc_addr else node_ep)
-  in
-  (* Common fields *)
-  Format.printf "Instance      : %s@." svc.S.instance ;
-  Format.printf "Service name  : %s@." (Systemd.unit_name svc.role svc.instance) ;
-  Format.printf "Role          : %s@." svc.role ;
-  Format.printf "Network       : %s@." svc.network ;
-  (* Role-specific fields *)
-  (match svc.role with
-  | "node" ->
-      Format.printf
-        "History mode  : %s@."
-        (History_mode.to_string svc.history_mode) ;
-      Format.printf "Data dir      : %s@." svc.data_dir ;
-      Format.printf "RPC addr      : %s@." svc.rpc_addr ;
-      Format.printf "P2P addr      : %s@." svc.net_addr
-  | "baker" ->
-      let base_dir = lookup "OCTEZ_BAKER_BASE_DIR" in
-      let dal_cfg = lookup "OCTEZ_DAL_CONFIG" in
-      let delegates = lookup "OCTEZ_BAKER_DELEGATES_ARGS" in
-      let lb_vote = lookup "OCTEZ_BAKER_LB_VOTE" in
-      Format.printf "Base dir      : %s@." base_dir ;
-      print_node_endpoint () ;
-      (match String.lowercase_ascii (String.trim dal_cfg) with
-      | "disabled" -> Format.printf "DAL Config    : opt-out@."
-      | "" -> Format.printf "DAL Config    : auto@."
-      | raw -> (
-          match
-            resolve_instance_for_endpoint raw ~roles:["dal-node"; "dal"]
-          with
-          | Some inst -> Format.printf "DAL instance  : %s@." inst
-          | None -> Format.printf "DAL endpoint  : %s@." raw)) ;
-      if delegates <> "" then Format.printf "Delegates     : %s@." delegates ;
-      if lb_vote <> "" then Format.printf "LB Vote       : %s@." lb_vote
-  | "accuser" ->
-      let base_dir = lookup "OCTEZ_CLIENT_BASE_DIR" in
-      Format.printf "Base dir      : %s@." base_dir ;
-      print_node_endpoint ()
-  | "dal-node" | "dal" ->
-      let dal_data_dir = lookup "OCTEZ_DAL_DATA_DIR" in
-      Format.printf "DAL data dir  : %s@." dal_data_dir ;
-      print_node_endpoint () ;
-      if svc.rpc_addr <> "" then
-        Format.printf "DAL RPC addr  : %s@." svc.rpc_addr ;
-      if svc.net_addr <> "" then
-        Format.printf "DAL P2P addr  : %s@." svc.net_addr
-  | _ ->
-      (* Fallback for unknown roles *)
-      Format.printf "Data dir      : %s@." svc.data_dir ;
-      Format.printf "RPC addr      : %s@." svc.rpc_addr ;
-      Format.printf "P2P addr      : %s@." svc.net_addr) ;
-  (* Common footer *)
-  Format.printf "Service user  : %s@." svc.service_user ;
-  Format.printf "Octez bin dir : %s@." svc.app_bin_dir ;
-  Format.printf "Created at    : %s@." svc.created_at ;
-  Format.printf "Logging       : %a@." pp_logging svc.logging_mode ;
-
-  (* Files & Paths Section *)
-  Format.printf "@.Files & Paths:@." ;
-
-  let service_paths =
-    Systemd.get_service_paths ~role:svc.role ~instance:svc.instance
-  in
-  List.iter
-    (fun (label, path) -> Format.printf "  %-16s: %s@." label path)
-    service_paths ;
-
-  Format.printf
-    "  %-16s: %s@."
-    "Service Metadata"
-    (Filename.concat
-       (Service_registry.services_dir ())
-       (svc.instance ^ ".json")) ;
-
-  (match
-     Log_viewer.get_daily_log_file ~role:svc.role ~instance:svc.instance
-   with
-  | Ok path -> Format.printf "  %-16s: %s@." "Log File" path
-  | Error _ -> ()) ;
-
-  match svc.role with
-  | "node" ->
-      Format.printf
-        "  %-16s: %s@."
-        "Config File"
-        (Filename.concat svc.data_dir "config.json") ;
-      Format.printf
-        "  %-16s: %s@."
-        "Identity File"
-        (Filename.concat svc.data_dir "identity.json")
-  | "baker" ->
-      let base_dir = lookup "OCTEZ_BAKER_BASE_DIR" in
-      if base_dir <> "" then (
-        Format.printf "  %-16s: %s@." "Base Directory" base_dir ;
-        Format.printf
-          "  %-16s: %s@."
-          "Client Config"
-          (Filename.concat base_dir "config"))
-  | "accuser" ->
-      let base_dir = lookup "OCTEZ_CLIENT_BASE_DIR" in
-      if base_dir <> "" then (
-        Format.printf "  %-16s: %s@." "Base Directory" base_dir ;
-        Format.printf
-          "  %-16s: %s@."
-          "Client Config"
-          (Filename.concat base_dir "config"))
-  | "dal-node" | "dal" ->
-      let dal_dir = lookup "OCTEZ_DAL_DATA_DIR" in
-      if dal_dir <> "" then (
-        Format.printf "  %-16s: %s@." "DAL Data Dir" dal_dir ;
-        Format.printf
-          "  %-16s: %s@."
-          "Config File"
-          (Filename.concat dal_dir "config.json") ;
-        Format.printf
-          "  %-16s: %s@."
-          "Identity File"
-          (Filename.concat dal_dir "identity.json"))
-  | _ -> ()
-
-let print_snapshot_entry (entry : Snapshots.entry) =
-  Format.printf "%s (%s)@." entry.Snapshots.label entry.slug ;
-  (match entry.Snapshots.history_mode with
-  | Some hm -> Format.printf "  History mode : %s@." hm
-  | None -> ()) ;
-  (match entry.Snapshots.download_url with
-  | Some url -> Format.printf "  HTTPS        : %s@." url
-  | None -> ()) ;
-  entry.Snapshots.metadata
-  |> List.filter (fun (k, _) -> k <> "History mode" && k <> "HTTPS")
-  |> List.iter (fun (k, v) -> Format.printf "  %-12s %s@." (k ^ ":") v) ;
-  print_newline ()
-
-let snapshot_entry_to_json (entry : Snapshots.entry) =
-  let metadata =
-    `List
-      (List.map
-         (fun (k, v) -> `Assoc [("key", `String k); ("value", `String v)])
-         entry.Snapshots.metadata)
-  in
-  `Assoc
-    [
-      ("slug", `String entry.slug);
-      ("label", `String entry.Snapshots.label);
-      ( "history_mode",
-        match entry.Snapshots.history_mode with
-        | Some hm -> `String hm
-        | None -> `Null );
-      ( "download_url",
-        match entry.Snapshots.download_url with
-        | Some url -> `String url
-        | None -> `Null );
-      ("metadata", metadata);
-    ]
-
-let dropin_path_for ~role ~instance =
-  let dir =
-    if Common.is_root () then
-      Printf.sprintf "/etc/systemd/system/octez-%s@%s.service.d" role instance
-    else
-      let base = Filename.concat (Common.xdg_config_home ()) "systemd/user" in
-      Filename.concat
-        base
-        (Printf.sprintf "octez-%s@%s.service.d" role instance)
-  in
-  Filename.concat dir "override.conf"
-
-let slurp_file path =
-  let ic = open_in_bin path in
-  Fun.protect
-    ~finally:(fun () -> close_in_noerr ic)
-    (fun () -> really_input_string ic (in_channel_length ic))
-
 let resolve_app_bin_dir = function
   | Some dir when String.trim dir <> "" -> (
       match Common.make_absolute_path dir with
@@ -433,13 +202,6 @@ let prompt_yes_no question ~default =
     in
     loop ()
 
-let format_bytes bytes =
-  let gb = Int64.to_float bytes /. (1024. *. 1024. *. 1024.) in
-  if gb >= 1.0 then Printf.sprintf "%.1f GB" gb
-  else
-    let mb = Int64.to_float bytes /. (1024. *. 1024.) in
-    Printf.sprintf "%.0f MB" mb
-
 let resolve_tmp_dir_for_snapshot ~snapshot_url ~tmp_dir =
   (* If tmp_dir is already specified, use it *)
   match tmp_dir with
@@ -463,9 +225,9 @@ let resolve_tmp_dir_for_snapshot ~snapshot_url ~tmp_dir =
               else if is_interactive () then (
                 Printf.printf
                   "Snapshot size is %s but %s only has %s available.\n"
-                  (format_bytes size)
+                  (Cli_output.format_bytes size)
                   tmp_path
-                  (format_bytes available) ;
+                  (Cli_output.format_bytes available) ;
                 let rec prompt_dir () =
                   let dir =
                     prompt_required_directory
@@ -478,8 +240,8 @@ let resolve_tmp_dir_for_snapshot ~snapshot_url ~tmp_dir =
                         Printf.printf
                           "%s only has %s available, need %s.\n"
                           dir
-                          (format_bytes space)
-                          (format_bytes required) ;
+                          (Cli_output.format_bytes space)
+                          (Cli_output.format_bytes required) ;
                         prompt_dir ()
                     | None ->
                         Printf.printf "Cannot determine space in %s.\n" dir ;
@@ -494,9 +256,9 @@ let resolve_tmp_dir_for_snapshot ~snapshot_url ~tmp_dir =
                   (Printf.sprintf
                      "Snapshot size is %s but %s only has %s available. Use \
                       --tmp-dir to specify an alternative download location."
-                     (format_bytes size)
+                     (Cli_output.format_bytes size)
                      tmp_path
-                     (format_bytes available))))
+                     (Cli_output.format_bytes available))))
 
 let check_data_dir_space ~snapshot_url ~data_dir =
   (* Check if data directory has enough space for imported snapshot data *)
@@ -519,8 +281,8 @@ let check_data_dir_space ~snapshot_url ~data_dir =
                  "Data directory %s needs %s for node storage but only has %s \
                   available."
                  data_dir
-                 (format_bytes required)
-                 (format_bytes available)))
+                 (Cli_output.format_bytes required)
+                 (Cli_output.format_bytes available)))
 
 (* Prompt with linenoise for autocompletion support *)
 let prompt_with_completion question completions =
@@ -2012,7 +1774,7 @@ let instance_term =
         | Show -> (
             match Service_registry.find ~instance:inst with
             | Ok (Some svc) ->
-                print_service_details svc ;
+                Cli_output.print_service_details svc ;
                 `Ok ()
             | Ok None ->
                 cmdliner_error (Printf.sprintf "Unknown instance '%s'" inst)
@@ -2026,10 +1788,10 @@ let instance_term =
                 let role = svc.S.role in
                 let unit = Systemd.unit_name role inst in
                 let print_dropin () =
-                  let path = dropin_path_for ~role ~instance:inst in
+                  let path = Cli_output.dropin_path_for ~role ~instance:inst in
                   if Sys.file_exists path then
                     try
-                      let contents = slurp_file path in
+                      let contents = Cli_output.slurp_file path in
                       Format.printf "# %s@.%s@." path contents
                     with Sys_error msg -> prerr_endline msg
                 in
@@ -2739,7 +2501,7 @@ let list_cmd =
           let module SM = (val cap : Manager_interfaces.Service_manager) in
           match SM.list () with
           | Ok services ->
-              print_services services ;
+              Cli_output.print_services services ;
               `Ok ()
           | Error (`Msg msg) -> cmdliner_error msg)
       | None -> cmdliner_error "Service manager capability not available"
@@ -2963,9 +2725,11 @@ let list_snapshots_cmd =
           match Snapshots.list ~network_slug:slug with
           | Ok entries ->
               if output_json then
-                let json = `List (List.map snapshot_entry_to_json entries) in
+                let json =
+                  `List (List.map Cli_output.snapshot_entry_to_json entries)
+                in
                 Yojson.Safe.pretty_to_string json |> print_endline
-              else List.iter print_snapshot_entry entries ;
+              else List.iter Cli_output.print_snapshot_entry entries ;
               `Ok ()
           | Error (`Msg msg) -> cmdliner_error msg)
     in


### PR DESCRIPTION
## Summary

First step in refactoring the 3,053-line main.ml file (#271). This PR extracts all output formatting functions to a new `cli_output` module.

## Changes

- Create `src/cli/cli_output.{ml,mli}` with output formatting functions:
  - `print_services`, `print_service_details`
  - `print_snapshot_entry`, `snapshot_entry_to_json`
  - `format_bytes`, `slurp_file`
  - `dropin_path_for`
- Update `main.ml` to use `Cli_output` module functions
- Add `octez_manager_cli` library to `src/cli/dune` (unwrapped)
- Update `src/dune` to link new cli library

## Testing

- ✅ All existing tests pass
- ✅ Code is properly formatted
- ✅ No behavior changes

## Related

Part of #271