### PR TITLE
refactor(cli): extract install-accuser command to cmd_install_accuser module

### DIFF
--- a/src/cli/cmd_install_accuser.ml
+++ b/src/cli/cmd_install_accuser.ml
@@ -1,0 +1,117 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+open Cmdliner
+open Octez_manager_lib
+open Installer_types
+module S = Service
+
+let install_accuser_cmd =
+  let instance =
+    let doc = "Accuser instance name" in
+    Arg.(value & opt (some string) None & info ["instance"] ~doc ~docv:"NAME")
+  in
+  let node_instance =
+    let doc =
+      "Existing octez-manager node instance to reuse for endpoint; can also be \
+       a custom RPC endpoint"
+    in
+    Arg.(
+      value & opt (some string) None & info ["node-instance"] ~doc ~docv:"NODE")
+  in
+  let base_dir =
+    Arg.(
+      value
+      & opt (some string) None
+      & info ["base-dir"] ~doc:"Accuser base directory" ~docv:"DIR")
+  in
+  let extra_args =
+    Arg.(
+      value & opt_all string []
+      & info
+          ["extra-arg"]
+          ~doc:"Additional arguments appended to the accuser command."
+          ~docv:"ARG")
+  in
+  let default_user =
+    if Common.is_root () then "octez"
+    else fst (Common.current_user_group_names ())
+  in
+  let service_user =
+    Arg.(
+      value & opt string default_user
+      & info ["service-user"] ~doc:"System user" ~docv:"USER")
+  in
+  let app_bin_dir =
+    Arg.(
+      value
+      & opt (some string) None
+      & info
+          ["app-bin-dir"]
+          ~doc:"Directory containing Octez binaries"
+          ~docv:"DIR")
+  in
+  let auto_enable =
+    Arg.(
+      value & flag & info ["no-enable"] ~doc:"Disable automatic enable --now")
+  in
+  let make instance_opt node_instance base_dir extra_args service_user
+      app_bin_dir no_enable logging_mode =
+    let res =
+      let ( let* ) = Result.bind in
+      let* app_bin_dir = Cli_helpers.resolve_app_bin_dir app_bin_dir in
+      let* instance =
+        match Cli_helpers.normalize_opt_string instance_opt with
+        | Some inst -> Ok inst
+        | None ->
+            if Cli_helpers.is_interactive () then
+              Ok (Cli_helpers.prompt_required_string "Instance name")
+            else Error "Instance name is required in non-interactive mode"
+      in
+      let* choice =
+        Result.map_error (fun (`Msg s) -> s)
+        @@ Cli_helpers.resolve_node_instance_or_endpoint ~node_instance
+      in
+      let node_mode =
+        match choice with
+        | `Instance ins -> Local_instance ins
+        | `Endpoint endpoint -> Remote_endpoint endpoint
+      in
+      let req : accuser_request =
+        {
+          instance;
+          app_bin_dir;
+          node_mode;
+          base_dir;
+          extra_args;
+          service_user;
+          logging_mode;
+          auto_enable = not no_enable;
+          preserve_data = false;
+        }
+      in
+      match Installer.install_accuser req with
+      | Ok svc -> Ok svc
+      | Error (`Msg msg) -> Error msg
+    in
+    match res with
+    | Ok service ->
+        Format.printf "Installed  %s (%s)\n" service.S.instance service.network ;
+        `Ok ()
+    | Error msg -> Cli_helpers.cmdliner_error msg
+  in
+  let term =
+    Term.(
+      ret
+        (const make $ instance $ node_instance $ base_dir $ extra_args
+       $ service_user $ app_bin_dir $ auto_enable
+       $ Cli_helpers.logging_mode_term))
+  in
+  let info =
+    Cmd.info "install-accuser" ~doc:"Install an octez-accuser service"
+  in
+  Cmd.v info term

--- a/src/cli/cmd_install_accuser.mli
+++ b/src/cli/cmd_install_accuser.mli
@@ -1,0 +1,11 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Install accuser command *)
+
+(** The install-accuser command *)
+val install_accuser_cmd : unit Cmdliner.Cmd.t

--- a/src/cli/dune
+++ b/src/cli/dune
@@ -1,7 +1,7 @@
 (library
  (name octez_manager_cli)
  (wrapped false)
- (modules cli_output cli_helpers)
+ (modules cli_output cli_helpers cmd_install_accuser)
  (libraries octez_manager_lib cmdliner rresult yojson linenoise)
  (instrumentation
   (backend bisect_ppx)))

--- a/src/main.ml
+++ b/src/main.ml
@@ -613,112 +613,6 @@ let install_baker_cmd =
   let info = Cmd.info "install-baker" ~doc:"Install an octez-baker service" in
   Cmd.v info term
 
-let install_accuser_cmd =
-  let instance =
-    let doc = "Accuser instance name" in
-    Arg.(value & opt (some string) None & info ["instance"] ~doc ~docv:"NAME")
-  in
-  let node_instance =
-    let doc =
-      "Existing octez-manager node instance to reuse for endpoint; can also be \
-       a custom RPC endpoint"
-    in
-    Arg.(
-      value & opt (some string) None & info ["node-instance"] ~doc ~docv:"NODE")
-  in
-  let base_dir =
-    Arg.(
-      value
-      & opt (some string) None
-      & info ["base-dir"] ~doc:"Accuser base directory" ~docv:"DIR")
-  in
-  let extra_args =
-    Arg.(
-      value & opt_all string []
-      & info
-          ["extra-arg"]
-          ~doc:"Additional arguments appended to the accuser command."
-          ~docv:"ARG")
-  in
-  let default_user =
-    if Common.is_root () then "octez"
-    else fst (Common.current_user_group_names ())
-  in
-  let service_user =
-    Arg.(
-      value & opt string default_user
-      & info ["service-user"] ~doc:"System user" ~docv:"USER")
-  in
-  let app_bin_dir =
-    Arg.(
-      value
-      & opt (some string) None
-      & info
-          ["app-bin-dir"]
-          ~doc:"Directory containing Octez binaries"
-          ~docv:"DIR")
-  in
-  let auto_enable =
-    Arg.(
-      value & flag & info ["no-enable"] ~doc:"Disable automatic enable --now")
-  in
-  let make instance_opt node_instance base_dir extra_args service_user
-      app_bin_dir no_enable logging_mode =
-    let res =
-      let ( let* ) = Result.bind in
-      let* app_bin_dir = Cli_helpers.resolve_app_bin_dir app_bin_dir in
-      let* instance =
-        match Cli_helpers.normalize_opt_string instance_opt with
-        | Some inst -> Ok inst
-        | None ->
-            if Cli_helpers.is_interactive () then
-              Ok (Cli_helpers.prompt_required_string "Instance name")
-            else Error "Instance name is required in non-interactive mode"
-      in
-      let* choice =
-        Result.map_error (fun (`Msg s) -> s)
-        @@ Cli_helpers.resolve_node_instance_or_endpoint ~node_instance
-      in
-      let node_mode =
-        match choice with
-        | `Instance ins -> Local_instance ins
-        | `Endpoint endpoint -> Remote_endpoint endpoint
-      in
-      let req : accuser_request =
-        {
-          instance;
-          app_bin_dir;
-          node_mode;
-          base_dir;
-          extra_args;
-          service_user;
-          logging_mode;
-          auto_enable = not no_enable;
-          preserve_data = false;
-        }
-      in
-      match Installer.install_accuser req with
-      | Ok svc -> Ok svc
-      | Error (`Msg msg) -> Error msg
-    in
-    match res with
-    | Ok service ->
-        Format.printf "Installed  %s (%s)\n" service.S.instance service.network ;
-        `Ok ()
-    | Error msg -> Cli_helpers.cmdliner_error msg
-  in
-  let term =
-    Term.(
-      ret
-        (const make $ instance $ node_instance $ base_dir $ extra_args
-       $ service_user $ app_bin_dir $ auto_enable
-       $ Cli_helpers.logging_mode_term))
-  in
-  let info =
-    Cmd.info "install-accuser" ~doc:"Install an octez-accuser service"
-  in
-  Cmd.v info term
-
 let install_dal_node_cmd =
   let instance =
     let doc = "Instance name used for dal-node.env and systemd units." in
@@ -2345,7 +2239,7 @@ let root_cmd =
       instance_cmd;
       install_node_cmd;
       install_baker_cmd;
-      install_accuser_cmd;
+      Cmd_install_accuser.install_accuser_cmd;
       install_dal_node_cmd;
       list_cmd;
       purge_all_cmd;


### PR DESCRIPTION
## Summary

Third step in refactoring main.ml (#271). This PR extracts the `install-accuser` command to a dedicated module. This is the first of several command extractions.

## Changes

- Create `src/cli/cmd_install_accuser.{ml,mli}` (~117 lines)
- Update `main.ml` to use `Cmd_install_accuser.install_accuser_cmd`
- Update `src/cli/dune` to include `cmd_install_accuser` module

## Testing

- ✅ All existing tests pass
- ✅ Code is properly formatted
- ✅ No behavior changes

## Dependencies

Depends on #309 (which depends on #308)

## Related

Part of #271