### PR TITLE
refactor(instances): extract state module (Phase 1 of #272)

### DIFF
--- a/src/ui/pages/instances.ml
+++ b/src/ui/pages/instances.ml
@@ -8,7 +8,6 @@
 module Widgets = Miaou_widgets_display.Widgets
 module Vsection = Miaou_widgets_layout.Vsection
 module Keys = Miaou.Core.Keys
-module Service_state = Data.Service_state
 module Metrics = Rpc_metrics
 module Navigation = Miaou.Core.Navigation
 open Octez_manager_lib
@@ -18,58 +17,13 @@ let ( let* ) = Result.bind
 
 let name = "instances"
 
-module StringSet = Set.Make (String)
-
-(** Track recent start/restart failures for display.
-    Maps instance name to (error_message, timestamp) *)
-let recent_failures : (string, string * float) Hashtbl.t = Hashtbl.create 16
-
-let recent_failure_ttl = 30.0 (* seconds to keep showing failure *)
-
-let record_failure ~instance ~error =
-  Hashtbl.replace recent_failures instance (error, Unix.gettimeofday ())
-
-let clear_failure ~instance = Hashtbl.remove recent_failures instance
-
-let get_recent_failure ~instance =
-  match Hashtbl.find_opt recent_failures instance with
-  | Some (error, ts) when Unix.gettimeofday () -. ts < recent_failure_ttl ->
-      Some error
-  | Some _ ->
-      (* Expired, clean up *)
-      Hashtbl.remove recent_failures instance ;
-      None
-  | None -> None
+(* State management extracted to instances/instances_state.ml *)
+include Instances_state
 
 (** Matrix layout configuration *)
 let min_column_width = 50
 
 let column_separator = "   "
-
-(** Number of menu items before services (just Install button) *)
-let menu_item_count = 1
-
-(** Index where services start (after menu items + separator line) *)
-let services_start_idx = menu_item_count + 1
-
-type state = {
-  services : Service_state.t list;
-  selected : int;
-  folded : StringSet.t; (* instance names that are folded *)
-  last_updated : float;
-  (* Matrix layout state *)
-  num_columns : int; (* number of columns based on terminal width *)
-  active_column : int; (* which column has focus, 0-indexed *)
-  column_scroll : int array; (* scroll offset per column *)
-}
-
-type msg = unit
-
-type pstate = state Navigation.t
-
-let clamp_selection services idx =
-  let len = List.length services + services_start_idx in
-  max 0 (min idx (len - 1))
 
 (** Role ordering for display grouping *)
 let role_order = function
@@ -397,10 +351,6 @@ let maybe_refresh ps =
   if Context.consume_instances_dirty () || now -. state.last_updated > 1. then
     Navigation.update (fun s -> force_refresh s) ps
   else Navigation.update ensure_valid_column ps
-
-let current_service state =
-  if state.selected < services_start_idx then None
-  else List.nth_opt state.services (state.selected - services_start_idx)
 
 let with_service state handler =
   match current_service state with

--- a/src/ui/pages/instances/instances_state.ml
+++ b/src/ui/pages/instances/instances_state.ml
@@ -1,0 +1,59 @@
+(*****************************************************************************)
+(*                                                                           *)
+(* SPDX-License-Identifier: MIT                                              *)
+(* Copyright (c) 2025 Nomadic Labs <contact@nomadic-labs.com>                *)
+(*                                                                           *)
+(*****************************************************************************)
+
+module Service_state = Data.Service_state
+module StringSet = Set.Make (String)
+
+(** Track recent start/restart failures for display.
+    Maps instance name to (error_message, timestamp) *)
+let recent_failures : (string, string * float) Hashtbl.t = Hashtbl.create 16
+
+let recent_failure_ttl = 30.0 (* seconds to keep showing failure *)
+
+let record_failure ~instance ~error =
+  Hashtbl.replace recent_failures instance (error, Unix.gettimeofday ())
+
+let clear_failure ~instance = Hashtbl.remove recent_failures instance
+
+let get_recent_failure ~instance =
+  match Hashtbl.find_opt recent_failures instance with
+  | Some (error, ts) when Unix.gettimeofday () -. ts < recent_failure_ttl ->
+      Some error
+  | Some _ ->
+      (* Expired, clean up *)
+      Hashtbl.remove recent_failures instance ;
+      None
+  | None -> None
+
+(** Number of menu items before services (just Install button) *)
+let menu_item_count = 1
+
+(** Index where services start (after menu items + separator line) *)
+let services_start_idx = menu_item_count + 1
+
+type state = {
+  services : Service_state.t list;
+  selected : int;
+  folded : StringSet.t; (* instance names that are folded *)
+  last_updated : float;
+  (* Matrix layout state *)
+  num_columns : int; (* number of columns based on terminal width *)
+  active_column : int; (* which column has focus, 0-indexed *)
+  column_scroll : int array; (* scroll offset per column *)
+}
+
+type msg = unit
+
+type pstate = state Miaou.Core.Navigation.t
+
+let clamp_selection services idx =
+  let len = List.length services + services_start_idx in
+  max 0 (min idx (len - 1))
+
+let current_service state =
+  if state.selected < services_start_idx then None
+  else List.nth_opt state.services (state.selected - services_start_idx)

--- a/src/ui/pages/instances/instances_state.mli
+++ b/src/ui/pages/instances/instances_state.mli
@@ -1,0 +1,47 @@
+(*****************************************************************************)
+(*                                                                           *)
+(* SPDX-License-Identifier: MIT                                              *)
+(* Copyright (c) 2025 Nomadic Labs <contact@nomadic-labs.com>                *)
+(*                                                                           *)
+(*****************************************************************************)
+
+(** State management for instances page *)
+
+module Service_state = Data.Service_state
+
+module StringSet : Set.S with type elt = string
+
+(** Recent failure tracking *)
+val recent_failure_ttl : float
+
+val record_failure : instance:string -> error:string -> unit
+
+val clear_failure : instance:string -> unit
+
+val get_recent_failure : instance:string -> string option
+
+(** Layout constants *)
+val menu_item_count : int
+
+val services_start_idx : int
+
+(** Instances page state *)
+type state = {
+  services : Service_state.t list;
+  selected : int;
+  folded : StringSet.t;
+  last_updated : float;
+  num_columns : int;
+  active_column : int;
+  column_scroll : int array;
+}
+
+type msg = unit
+
+type pstate = state Miaou.Core.Navigation.t
+
+(** Clamp selection index to valid range *)
+val clamp_selection : Service_state.t list -> int -> int
+
+(** Get currently selected service, if any *)
+val current_service : state -> Service_state.t option


### PR DESCRIPTION
## Overview

First phase of splitting the 2246-line instances.ml into focused modules as outlined in #272.

## This PR - Phase 1: State Module ✅

Extracts state management into a dedicated module:

- ✅ Created `src/ui/pages/instances/instances_state.ml` (59 lines)
- ✅ Created `src/ui/pages/instances/instances_state.mli` (47 lines)  
- ✅ Modified `instances.ml` to `include Instances_state`
- ✅ Reduced main file from 2246 to 2196 lines (50 lines extracted)

### Extracted Components

- State type definitions (`state`, `msg`, `pstate`)
- `StringSet` module for tracking folded instances
- Recent failure tracking (hashtable + helper functions)
- Layout constants (`menu_item_count`, `services_start_idx`)
- Helper functions: `clamp_selection`, `current_service`

## Testing

- ✅ All tests pass (`dune runtest`)
- ✅ Clean build (`dune build`)
- ✅ Code formatted (`dune fmt`)
- ✅ No functional changes - pure refactoring

## Methodology

- Followed AGENTS.md guidelines for code movement
- Used shell commands (sed) for exact code extraction
- Verified line counts and compilation after extraction
- No Read+Write copying (prevents line drops/hallucinations)

## Remaining Phases

Following phases will be done in separate PRs:
- Phase 2: Extract layout module (`instances_layout.ml`) ~250 lines
- Phase 3: Extract rendering module (`instances_render.ml`) ~400 lines
- Phase 4: Extract actions module (`instances_actions.ml`) ~500 lines
- Phase 5: Extract key handling module (`instances_keys.ml`) ~400 lines
- Phase 6: Minimize main `instances.ml` to composition only (~200 lines)

Each phase will be tested independently to ensure no regressions.

Part of #272