### PR TITLE
refactor(instances): extract layout module (Phase 2 of #272)

### DIFF
--- a/src/ui/pages/instances.ml
+++ b/src/ui/pages/instances.ml
@@ -26,252 +26,9 @@ let min_column_width = 50
 let column_separator = "   "
 
 (** Role ordering for display grouping *)
-let role_order = function
-  | "node" -> 0
-  | "baker" -> 1
-  | "accuser" -> 2
-  | "dal-node" -> 3
-  | "signer" -> 4
-  | _ -> 5
 
-(** Role section headers *)
-let role_header = function
-  | "node" -> "── Nodes ──"
-  | "baker" -> "── Bakers ──"
-  | "accuser" -> "── Accusers ──"
-  | "dal-node" -> "── DAL Nodes ──"
-  | "signer" -> "── Signers ──"
-  | r -> Printf.sprintf "── %s ──" (String.capitalize_ascii r)
-
-(** Sort services by role, then by instance name *)
-let sort_services services =
-  List.sort
-    (fun (a : Service_state.t) (b : Service_state.t) ->
-      let role_cmp =
-        compare
-          (role_order a.service.Service.role)
-          (role_order b.service.Service.role)
-      in
-      if role_cmp <> 0 then role_cmp
-      else String.compare a.service.Service.instance b.service.Service.instance)
-    services
-
-let load_services () = Data.load_service_states () |> sort_services
-
-let load_services_fresh () =
-  Data.load_service_states ~detail:false () |> sort_services
-
-(** Calculate number of columns based on terminal width *)
-let calc_num_columns ~cols =
-  let separator_width = String.length column_separator in
-  let available = cols - separator_width in
-  (* At least 1 column, max based on available width *)
-  max 1 (available / (min_column_width + separator_width))
-
-(** Group services by role, preserving order *)
-let group_by_role services =
-  let roles = ["node"; "baker"; "accuser"; "dal-node"; "signer"] in
-  List.filter_map
-    (fun role ->
-      let instances =
-        List.filter
-          (fun (st : Service_state.t) -> st.service.Service.role = role)
-          services
-      in
-      if instances = [] then None else Some (role, instances))
-    roles
-
-(** Distribute role groups across columns, balancing by instance count.
-    Returns: column index -> list of (role, instances) *)
-let distribute_to_columns ~num_columns role_groups =
-  if num_columns <= 1 then [|role_groups|]
-  else
-    let columns = Array.make num_columns [] in
-    let column_counts = Array.make num_columns 0 in
-    (* Assign each role group to the column with fewest instances *)
-    List.iter
-      (fun ((_role, instances) as group) ->
-        let min_col =
-          let min_idx = ref 0 in
-          for i = 1 to num_columns - 1 do
-            if column_counts.(i) < column_counts.(!min_idx) then min_idx := i
-          done ;
-          !min_idx
-        in
-        columns.(min_col) <- columns.(min_col) @ [group] ;
-        column_counts.(min_col) <-
-          column_counts.(min_col) + List.length instances + 2
-        (* +2 for header and spacing *))
-      role_groups ;
-    columns
-
-(** Get flat list of services for a column, with their global indices *)
-type column_item =
-  | Header of string
-  | Instance of int * Service_state.t (* global index, service *)
-
-let column_items ~column_groups ~global_services =
-  List.concat_map
-    (fun (role, instances) ->
-      let header = Header (role_header role) in
-      let items =
-        List.map
-          (fun (st : Service_state.t) ->
-            (* Find global index *)
-            let idx =
-              List.find_mapi
-                (fun i (s : Service_state.t) ->
-                  if
-                    String.equal
-                      s.service.Service.instance
-                      st.service.Service.instance
-                  then Some i
-                  else None)
-                global_services
-              |> Option.value ~default:0
-            in
-            Instance (idx, st))
-          instances
-      in
-      header :: items)
-    column_groups
-
-(** Get list of global service indices in a column *)
-let column_service_indices ~column_groups ~global_services =
-  column_items ~column_groups ~global_services
-  |> List.filter_map (function
-    | Header _ -> None
-    | Instance (idx, _) -> Some idx)
-
-(** Get first service index in a column *)
-let first_service_in_column ~num_columns ~services col =
-  if num_columns <= 1 then 0
-  else
-    let role_groups = group_by_role services in
-    let columns = distribute_to_columns ~num_columns role_groups in
-    if col >= Array.length columns then 0
-    else
-      let indices =
-        column_service_indices
-          ~column_groups:columns.(col)
-          ~global_services:services
-      in
-      match indices with [] -> 0 | first :: _ -> first
-
-(** Get all service indices in a column *)
-let services_in_column ~num_columns ~services col =
-  if num_columns <= 1 then List.mapi (fun i _ -> i) services
-  else
-    let role_groups = group_by_role services in
-    let columns = distribute_to_columns ~num_columns role_groups in
-    if col >= Array.length columns then []
-    else
-      column_service_indices
-        ~column_groups:columns.(col)
-        ~global_services:services
-
-(** Find which column contains a given service index *)
-let column_for_service ~num_columns ~services idx =
-  if num_columns <= 1 then 0
-  else
-    let rec find_col col =
-      if col >= num_columns then 0
-      else
-        let indices = services_in_column ~num_columns ~services col in
-        if List.mem idx indices then col else find_col (col + 1)
-    in
-    find_col 0
-
-(** Calculate line position of a service within its column.
-    Returns (start_line, line_count) where start_line is 0-indexed
-    from the top of the column content (after headers). *)
-let service_line_position ~num_columns ~services ~folded svc_idx col =
-  if num_columns <= 1 then (0, 1)
-  else
-    let role_groups = group_by_role services in
-    let columns = distribute_to_columns ~num_columns role_groups in
-    if col >= Array.length columns then (0, 1)
-    else
-      let column_groups = columns.(col) in
-      let items = column_items ~column_groups ~global_services:services in
-      let rec count_lines line_acc is_first = function
-        | [] -> (line_acc, 1)
-        | Header _ :: rest ->
-            (* Header + possible empty line before it *)
-            let header_lines = if is_first then 1 else 2 in
-            count_lines (line_acc + header_lines) false rest
-        | Instance (idx, st) :: rest ->
-            let is_folded = StringSet.mem st.service.Service.instance folded in
-            let line_count = if is_folded then 2 else 6 in
-            (* Approximate: 2 lines folded, ~6 unfolded *)
-            if idx = svc_idx then (line_acc, line_count)
-            else count_lines (line_acc + line_count) false rest
-      in
-      count_lines 0 true items
-
-(** Adjust column scroll to keep selection visible.
-    Mutates column_scroll array in place. *)
-let adjust_column_scroll ~column_scroll ~col ~line_start ~line_count
-    ~visible_height =
-  let scroll = column_scroll.(col) in
-  let new_scroll =
-    if line_start < scroll then line_start
-    else if line_start + line_count > scroll + visible_height then
-      line_start + line_count - visible_height
-    else scroll
-  in
-  column_scroll.(col) <- max 0 new_scroll
-
-(* Mutable reference to track visible height for scroll calculations *)
-let last_visible_height_ref = ref 20
-
-(** Find first non-empty column, or None if all empty *)
-let find_non_empty_column ~num_columns ~services =
-  let rec find col =
-    if col >= num_columns then None
-    else
-      let indices = services_in_column ~num_columns ~services col in
-      if indices <> [] then Some col else find (col + 1)
-  in
-  find 0
-
-(** Ensure active_column points to a non-empty column, adjusting selection if needed.
-    If all columns are empty (no services), move selection to menu. *)
-let ensure_valid_column state =
-  if state.services = [] then
-    (* No services, go to "Install new instance" *)
-    {state with selected = 0; active_column = 0}
-  else if state.num_columns <= 1 then state
-  else
-    let current_indices =
-      services_in_column
-        ~num_columns:state.num_columns
-        ~services:state.services
-        state.active_column
-    in
-    if current_indices <> [] then state
-    else
-      (* Current column is empty, find a non-empty one *)
-      match
-        find_non_empty_column
-          ~num_columns:state.num_columns
-          ~services:state.services
-      with
-      | None ->
-          (* All columns empty (shouldn't happen if services <> []) *)
-          {state with selected = 0; active_column = 0}
-      | Some new_col ->
-          let first_svc =
-            first_service_in_column
-              ~num_columns:state.num_columns
-              ~services:state.services
-              new_col
-          in
-          {
-            state with
-            active_column = new_col;
-            selected = first_svc + services_start_idx;
-          }
+(* Layout logic extracted to instances/instances_layout.ml *)
+include Instances_layout
 
 let init_state () =
   let services = load_services () in
@@ -905,7 +662,9 @@ let table_lines_single state =
 
 (** Multi-column matrix layout *)
 let table_lines_matrix ~cols ~visible_height ~column_scroll state =
-  let num_columns = calc_num_columns ~cols in
+  let num_columns =
+    calc_num_columns ~cols ~min_column_width ~column_separator
+  in
   let role_groups = group_by_role state.services in
   let columns = distribute_to_columns ~num_columns role_groups in
   let col_width =
@@ -939,7 +698,9 @@ let table_lines_matrix ~cols ~visible_height ~column_scroll state =
 let table_lines ?(cols = 80) ?(visible_height = 20) state =
   (* Clear visibility markers at start of render pass *)
   System_metrics_scheduler.clear_visibility () ;
-  let num_columns = calc_num_columns ~cols in
+  let num_columns =
+    calc_num_columns ~cols ~min_column_width ~column_separator
+  in
   if state.services = [] then
     let install_row =
       let marker = if state.selected = 0 then Widgets.bold "➤" else " " in
@@ -1841,7 +1602,9 @@ Press **Enter** to open instance menu.|}
         let avail_rows = max 5 avail_rows in
         (* Update visible height for scroll calculations - subtract menu rows *)
         last_visible_height_ref := avail_rows - services_start_idx ;
-        let num_columns = calc_num_columns ~cols in
+        let num_columns =
+          calc_num_columns ~cols ~min_column_width ~column_separator
+        in
         (* Matrix layout handles its own scrolling per-column *)
         if num_columns > 1 then
           let table = table_lines ~cols ~visible_height:avail_rows s in
@@ -2128,7 +1891,9 @@ Press **Enter** to open instance menu.|}
     let s = ps.Navigation.s in
     (* Update num_columns based on current terminal size *)
     let cols = size.LTerm_geom.cols in
-    let num_columns = calc_num_columns ~cols in
+    let num_columns =
+      calc_num_columns ~cols ~min_column_width ~column_separator
+    in
     let s = {s with num_columns} in
     let ps = Navigation.update (fun _ -> s) ps in
     if Miaou.Core.Modal_manager.has_active () then (

--- a/src/ui/pages/instances/instances_layout.ml
+++ b/src/ui/pages/instances/instances_layout.ml
@@ -1,0 +1,257 @@
+(*****************************************************************************)
+(*                                                                           *)
+(* SPDX-License-Identifier: MIT                                              *)
+(* Copyright (c) 2025 Nomadic Labs <contact@nomadic-labs.com>                *)
+(*                                                                           *)
+(*****************************************************************************)
+
+open Octez_manager_lib
+module Service_state = Data.Service_state
+open Instances_state
+
+let role_order = function
+  | "node" -> 0
+  | "baker" -> 1
+  | "accuser" -> 2
+  | "dal-node" -> 3
+  | "signer" -> 4
+  | _ -> 5
+
+(** Role section headers *)
+let role_header = function
+  | "node" -> "── Nodes ──"
+  | "baker" -> "── Bakers ──"
+  | "accuser" -> "── Accusers ──"
+  | "dal-node" -> "── DAL Nodes ──"
+  | "signer" -> "── Signers ──"
+  | r -> Printf.sprintf "── %s ──" (String.capitalize_ascii r)
+
+(** Sort services by role, then by instance name *)
+let sort_services services =
+  List.sort
+    (fun (a : Service_state.t) (b : Service_state.t) ->
+      let role_cmp =
+        compare
+          (role_order a.service.Service.role)
+          (role_order b.service.Service.role)
+      in
+      if role_cmp <> 0 then role_cmp
+      else String.compare a.service.Service.instance b.service.Service.instance)
+    services
+
+let load_services () = Data.load_service_states () |> sort_services
+
+let load_services_fresh () =
+  Data.load_service_states ~detail:false () |> sort_services
+
+(** Calculate number of columns based on terminal width *)
+let calc_num_columns ~cols ~min_column_width ~column_separator =
+  let separator_width = String.length column_separator in
+  let available = cols - separator_width in
+  (* At least 1 column, max based on available width *)
+  max 1 (available / (min_column_width + separator_width))
+
+(** Group services by role, preserving order *)
+let group_by_role services =
+  let roles = ["node"; "baker"; "accuser"; "dal-node"; "signer"] in
+  List.filter_map
+    (fun role ->
+      let instances =
+        List.filter
+          (fun (st : Service_state.t) -> st.service.Service.role = role)
+          services
+      in
+      if instances = [] then None else Some (role, instances))
+    roles
+
+(** Distribute role groups across columns, balancing by instance count.
+    Returns: column index -> list of (role, instances) *)
+let distribute_to_columns ~num_columns role_groups =
+  if num_columns <= 1 then [|role_groups|]
+  else
+    let columns = Array.make num_columns [] in
+    let column_counts = Array.make num_columns 0 in
+    (* Assign each role group to the column with fewest instances *)
+    List.iter
+      (fun ((_role, instances) as group) ->
+        let min_col =
+          let min_idx = ref 0 in
+          for i = 1 to num_columns - 1 do
+            if column_counts.(i) < column_counts.(!min_idx) then min_idx := i
+          done ;
+          !min_idx
+        in
+        columns.(min_col) <- columns.(min_col) @ [group] ;
+        column_counts.(min_col) <-
+          column_counts.(min_col) + List.length instances + 2
+        (* +2 for header and spacing *))
+      role_groups ;
+    columns
+
+(** Get flat list of services for a column, with their global indices *)
+type column_item =
+  | Header of string
+  | Instance of int * Service_state.t (* global index, service *)
+
+let column_items ~column_groups ~global_services =
+  List.concat_map
+    (fun (role, instances) ->
+      let header = Header (role_header role) in
+      let items =
+        List.map
+          (fun (st : Service_state.t) ->
+            (* Find global index *)
+            let idx =
+              List.find_mapi
+                (fun i (s : Service_state.t) ->
+                  if
+                    String.equal
+                      s.service.Service.instance
+                      st.service.Service.instance
+                  then Some i
+                  else None)
+                global_services
+              |> Option.value ~default:0
+            in
+            Instance (idx, st))
+          instances
+      in
+      header :: items)
+    column_groups
+
+(** Get list of global service indices in a column *)
+let column_service_indices ~column_groups ~global_services =
+  column_items ~column_groups ~global_services
+  |> List.filter_map (function
+    | Header _ -> None
+    | Instance (idx, _) -> Some idx)
+
+(** Get first service index in a column *)
+let first_service_in_column ~num_columns ~services col =
+  if num_columns <= 1 then 0
+  else
+    let role_groups = group_by_role services in
+    let columns = distribute_to_columns ~num_columns role_groups in
+    if col >= Array.length columns then 0
+    else
+      let indices =
+        column_service_indices
+          ~column_groups:columns.(col)
+          ~global_services:services
+      in
+      match indices with [] -> 0 | first :: _ -> first
+
+(** Get all service indices in a column *)
+let services_in_column ~num_columns ~services col =
+  if num_columns <= 1 then List.mapi (fun i _ -> i) services
+  else
+    let role_groups = group_by_role services in
+    let columns = distribute_to_columns ~num_columns role_groups in
+    if col >= Array.length columns then []
+    else
+      column_service_indices
+        ~column_groups:columns.(col)
+        ~global_services:services
+
+(** Find which column contains a given service index *)
+let column_for_service ~num_columns ~services idx =
+  if num_columns <= 1 then 0
+  else
+    let rec find_col col =
+      if col >= num_columns then 0
+      else
+        let indices = services_in_column ~num_columns ~services col in
+        if List.mem idx indices then col else find_col (col + 1)
+    in
+    find_col 0
+
+(** Calculate line position of a service within its column.
+    Returns (start_line, line_count) where start_line is 0-indexed
+    from the top of the column content (after headers). *)
+let service_line_position ~num_columns ~services ~folded svc_idx col =
+  if num_columns <= 1 then (0, 1)
+  else
+    let role_groups = group_by_role services in
+    let columns = distribute_to_columns ~num_columns role_groups in
+    if col >= Array.length columns then (0, 1)
+    else
+      let column_groups = columns.(col) in
+      let items = column_items ~column_groups ~global_services:services in
+      let rec count_lines line_acc is_first = function
+        | [] -> (line_acc, 1)
+        | Header _ :: rest ->
+            (* Header + possible empty line before it *)
+            let header_lines = if is_first then 1 else 2 in
+            count_lines (line_acc + header_lines) false rest
+        | Instance (idx, st) :: rest ->
+            let is_folded = StringSet.mem st.service.Service.instance folded in
+            let line_count = if is_folded then 2 else 6 in
+            (* Approximate: 2 lines folded, ~6 unfolded *)
+            if idx = svc_idx then (line_acc, line_count)
+            else count_lines (line_acc + line_count) false rest
+      in
+      count_lines 0 true items
+
+(** Adjust column scroll to keep selection visible.
+    Mutates column_scroll array in place. *)
+let adjust_column_scroll ~column_scroll ~col ~line_start ~line_count
+    ~visible_height =
+  let scroll = column_scroll.(col) in
+  let new_scroll =
+    if line_start < scroll then line_start
+    else if line_start + line_count > scroll + visible_height then
+      line_start + line_count - visible_height
+    else scroll
+  in
+  column_scroll.(col) <- max 0 new_scroll
+
+(* Mutable reference to track visible height for scroll calculations *)
+let last_visible_height_ref = ref 20
+
+(** Find first non-empty column, or None if all empty *)
+let find_non_empty_column ~num_columns ~services =
+  let rec find col =
+    if col >= num_columns then None
+    else
+      let indices = services_in_column ~num_columns ~services col in
+      if indices <> [] then Some col else find (col + 1)
+  in
+  find 0
+
+(** Ensure active_column points to a non-empty column, adjusting selection if needed.
+    If all columns are empty (no services), move selection to menu. *)
+let ensure_valid_column state =
+  if state.services = [] then
+    (* No services, go to "Install new instance" *)
+    {state with selected = 0; active_column = 0}
+  else if state.num_columns <= 1 then state
+  else
+    let current_indices =
+      services_in_column
+        ~num_columns:state.num_columns
+        ~services:state.services
+        state.active_column
+    in
+    if current_indices <> [] then state
+    else
+      (* Current column is empty, find a non-empty one *)
+      match
+        find_non_empty_column
+          ~num_columns:state.num_columns
+          ~services:state.services
+      with
+      | None ->
+          (* All columns empty (shouldn't happen if services <> []) *)
+          {state with selected = 0; active_column = 0}
+      | Some new_col ->
+          let first_svc =
+            first_service_in_column
+              ~num_columns:state.num_columns
+              ~services:state.services
+              new_col
+          in
+          {
+            state with
+            active_column = new_col;
+            selected = first_svc + services_start_idx;
+          }

--- a/src/ui/pages/instances/instances_layout.mli
+++ b/src/ui/pages/instances/instances_layout.mli
@@ -1,0 +1,93 @@
+(*****************************************************************************)
+(*                                                                           *)
+(* SPDX-License-Identifier: MIT                                              *)
+(* Copyright (c) 2025 Nomadic Labs <contact@nomadic-labs.com>                *)
+(*                                                                           *)
+(*****************************************************************************)
+
+(** Layout and column calculation for instances page *)
+
+module Service_state = Data.Service_state
+open Instances_state
+
+(** Role ordering for grouping *)
+val role_order : string -> int
+
+(** Role section headers *)
+val role_header : string -> string
+
+(** Sort services by role then instance name *)
+val sort_services : Service_state.t list -> Service_state.t list
+
+(** Load services from Data module *)
+val load_services : unit -> Service_state.t list
+
+val load_services_fresh : unit -> Service_state.t list
+
+(** Calculate number of columns based on terminal width *)
+val calc_num_columns :
+  cols:int -> min_column_width:int -> column_separator:string -> int
+
+(** Group services by role *)
+val group_by_role : Service_state.t list -> (string * Service_state.t list) list
+
+(** Distribute role groups across columns *)
+val distribute_to_columns :
+  num_columns:int ->
+  (string * Service_state.t list) list ->
+  (string * Service_state.t list) list array
+
+(** Column item type for rendering *)
+type column_item = Header of string | Instance of int * Service_state.t
+
+(** Get flat list of items for a column *)
+val column_items :
+  column_groups:(string * Service_state.t list) list ->
+  global_services:Service_state.t list ->
+  column_item list
+
+(** Get list of service indices in a column *)
+val column_service_indices :
+  column_groups:(string * Service_state.t list) list ->
+  global_services:Service_state.t list ->
+  int list
+
+(** Get first service index in a column *)
+val first_service_in_column :
+  num_columns:int -> services:Service_state.t list -> int -> int
+
+(** Get all service indices in a column *)
+val services_in_column :
+  num_columns:int -> services:Service_state.t list -> int -> int list
+
+(** Find which column contains a service index *)
+val column_for_service :
+  num_columns:int -> services:Service_state.t list -> int -> int
+
+(** Calculate line position of a service within its column *)
+val service_line_position :
+  num_columns:int ->
+  services:Service_state.t list ->
+  folded:StringSet.t ->
+  int ->
+  int ->
+  int * int
+
+(** Adjust column scroll to keep selection visible *)
+val adjust_column_scroll :
+  column_scroll:int array ->
+  col:int ->
+  line_start:int ->
+  line_count:int ->
+  visible_height:int ->
+  unit
+
+(** Mutable reference for visible height tracking *)
+val last_visible_height_ref : int ref
+
+(** Find first non-empty column *)
+val find_non_empty_column :
+  num_columns:int -> services:Service_state.t list -> int option
+
+(** Ensure active column points to a non-empty column *)
+val ensure_valid_column : state -> state


### PR DESCRIPTION
## Overview

Second phase of splitting the 2246-line instances.ml into focused modules.
Builds on Phase 1 (#312).

## This PR - Phase 2: Layout Module ✅

Extracts layout and column calculation logic into a dedicated module:

- ✅ Created `src/ui/pages/instances/instances_layout.ml` (257 lines)
- ✅ Created `src/ui/pages/instances/instances_layout.mli` (93 lines)
- ✅ Modified `instances.ml` to `include Instances_layout`
- ✅ Reduced main file from 2196 to 1961 lines (235 lines extracted)

### Extracted Components

**Role management:**
- `role_order`, `role_header` - Role ordering and display names
- `sort_services` - Sort by role then instance name

**Service loading:**
- `load_services`, `load_services_fresh` - Load from Data module

**Column calculations:**
- `calc_num_columns` - Calculate columns based on terminal width
- `group_by_role` - Group services by role
- `distribute_to_columns` - Balance services across columns

**Column navigation:**
- `column_item` type - Headers and instance items
- `column_items`, `column_service_indices` - Column content utilities
- `first_service_in_column`, `services_in_column` - Index lookups
- `column_for_service` - Find which column contains a service

**Scrolling:**
- `service_line_position` - Calculate position within column
- `adjust_column_scroll` - Keep selection visible
- `last_visible_height_ref` - Track visible height

**Validation:**
- `find_non_empty_column`, `ensure_valid_column` - Column state validation

## Testing

- ✅ All 163 tests pass (`dune runtest`)
- ✅ Clean build (`dune build`)
- ✅ Code formatted (`dune fmt`)
- ✅ No functional changes - pure refactoring

## Progress

| Phase | Status | Lines | Module |
|-------|--------|-------|---------|
| 1 | ✅ Merged (#312) | 59 | State management |
| 2 | ✅ This PR | 257 | Layout calculations |
| 3 | 🔄 Next | ~400 | Rendering |
| 4 | 📋 Planned | ~500 | Actions |
| 5 | 📋 Planned | ~400 | Key handling |
| 6 | 📋 Planned | ~200 | Composition |

Part of #272