### PR TITLE
refactor(installer): prepare directory structure for modularization

### DIFF
--- a/src/cli/dune
+++ b/src/cli/dune
@@ -1,3 +1,5 @@
+(include_subdirs no)
+
 (library
  (name octez_manager_cli)
  (wrapped false)

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,5 @@
+(include_subdirs unqualified)
+
 (library
  (name octez_manager_lib)
  (public_name octez-manager.lib)


### PR DESCRIPTION
## Summary

Prepare the build system for splitting installer.ml into focused modules within an installer/ subdirectory.

**Changes:**
- Add `(include_subdirs unqualified)` to src/dune to enable subdirectory support
- Add `(include_subdirs no)` to src/cli/dune to prevent inheritance
- Create empty src/installer/ directory

**Related Issue:** #273

**No functional changes** - this is pure build system preparation. All modules remain in the octez_manager_lib library.

**Next Steps:**
This PR is the first of 11 phases to modularize installer.ml (1,692 lines):
1. ✅ Directory structure (this PR)
2. Extract helpers module (~100 lines)
3. Extract snapshot module (~280 lines)
4. Extract config & validation (~220 lines)
5. Extract install_node (~200 lines)
6. Extract install_dal_node (~150 lines)
7. Extract install_baker (~150 lines)
8. Extract install_accuser (~100 lines)
9. Extract lifecycle (~117 lines)
10. Extract removal (~366 lines)
11. Convert installer.ml to facade

Each phase = 1 commit = 1 PR targeting main.