### PR TITLE
feat(prune): add disk space calculation to prune command

### DIFF
--- a/src/binary_downloader.mli
+++ b/src/binary_downloader.mli
@@ -98,6 +98,14 @@ val download_version :
     @param version Version to remove (e.g., "24.0") *)
 val remove_version : string -> (unit, Rresult.R.msg) result
 
+(** Calculate directory size for a version
+    @param version Version to measure (e.g., "24.0")
+    @return Tuple of (bytes, formatted_string) *)
+val get_version_size : string -> (int64 * string, Rresult.R.msg) result
+
+(** Format byte count into human-readable string (e.g., "1.5 MB") *)
+val format_size_bytes : int64 -> string
+
 (** {2 Disk space} *)
 
 (** Estimate download size for a version in bytes *)


### PR DESCRIPTION
## Summary

This PR implements **Issue #267: Enhanced Prune Unused Versions** - the final piece of Phase 6 (Polish) of the Binary Management System milestone.

### What This PR Does

- ✅ **Disk space calculation for managed versions**
  - New `calculate_directory_size()` function using `du -sb`
  - New `format_size_bytes()` for human-readable display (B, KB, MB, GB)
  - New `get_version_size()` public API

- ✅ **Enhanced TUI prune modal**
  - Shows each version with its disk size:
    ```
    The following versions will be removed:

      • v23.0 (145.3 MB)
      • v23.1 (147.8 MB)

    Total space to free: 293.1 MB
    ```
  - Better success reporting: "Removed 2 version(s), freed 293.1 MB"
  - Better error handling with failure count

- ✅ **Enhanced CLI prune command**
  - Shows size for each version: `- v24.0 (150.2 MB)`
  - Shows total space to free before confirmation
  - Success message includes freed space
  - `--dry-run` flag already existed (preserved)

### Before / After

**Before (TUI):**
```
Remove 2 unused version(s): v23.0, v23.1?
```

**After (TUI):**
```
Prune 2 unused version(s)?

The following versions will be removed:

  • v23.0 (145.3 MB)
  • v23.1 (147.8 MB)

Total space to free: 293.1 MB
```

**Before (CLI):**
```
Found 2 unused version(s):
  - v23.0
  - v23.1

Removing...
✓ Successfully pruned 2 version(s)
```

**After (CLI):**
```
Found 2 unused version(s):
  - v23.0 (145.3 MB)
  - v23.1 (147.8 MB)

Total space to free: 293.1 MB

Removing...
✓ Successfully pruned 2 version(s), freed 293.1 MB
```

### Technical Details

**New Functions in `Binary_downloader`:**
- `calculate_directory_size(path)` - Uses `du -sb` to get byte count
- `format_size_bytes(bytes)` - Formats as B/KB/MB/GB with 1 decimal
- `get_version_size(version)` - Returns `(bytes, formatted_string)`

**Modified Files:**
- `src/binary_downloader.ml` - NEW functions (+40 lines)
- `src/binary_downloader.mli` - NEW API exports (+8 lines)
- `src/cli/cmd_binaries.ml` - Enhanced prune command (+19/-2 lines)
- `src/ui/pages/binaries/binaries_page.ml` - Enhanced prune modal (+53/-15 lines)

### Testing

```bash
dune build     # ✅ Compiles
dune runtest   # ✅ All 184 tests pass
dune fmt       # ✅ Formatted
```

**Manual Testing:**
- TUI: Press 'p' on binaries page to test modal
- CLI: `octez-manager binaries prune --dry-run` to test output

### Completion Status

This PR completes **Phase 6: Polish** of the Binary Management System:
- ✅ Issue #266: Version Notifications (PR #370)
- ✅ Issue #267: Enhanced Prune (This PR)

**The entire Binary Management System milestone is now complete!**

### Related

- Part of: Binary Management System Milestone
- Implements: Issue #267
- Depends on: PR #362 (Binaries TUI + CLI)
- Follows: PR #364 (Cascade Updates), PR #367 (Installer Integration), PR #370 (Version Notifications)
- Completes: Phase 6 (Polish)

### Checklist

- [x] Code compiles without errors
- [x] All tests pass (184 tests)
- [x] Code is formatted with `dune fmt`
- [x] TUI modal shows disk space correctly
- [x] CLI command shows disk space correctly
- [x] `--dry-run` flag preserved and functional
- [x] Follows project coding standards from AGENTS.md