### PR TITLE
fix: change default network from mainnet to shadownet

### DIFF
--- a/src/cli/cmd_install_node.ml
+++ b/src/cli/cmd_install_node.ml
@@ -16,7 +16,7 @@ let install_node_cmd =
     Arg.(value & opt (some string) None & info ["instance"] ~doc ~docv:"NAME")
   in
   let network =
-    let doc = "Chain network (default: mainnet)." in
+    let doc = "Chain network (default: shadownet)." in
     Arg.(value & opt (some string) None & info ["network"] ~doc ~docv:"NET")
   in
   let data_dir =
@@ -251,7 +251,7 @@ let install_node_cmd =
                       in
                       Ok (loop ())
                   | Error (`Msg err) -> Error err
-                else Ok "mainnet"
+                else Ok "shadownet"
           in
           let history_mode =
             match history_mode_opt with

--- a/src/cli/cmd_utils.ml
+++ b/src/cli/cmd_utils.ml
@@ -287,7 +287,7 @@ let list_networks_cmd =
 let list_snapshots_cmd =
   let network =
     let doc = "Network alias or teztnets.json URL to inspect." in
-    Arg.(value & opt string "mainnet" & info ["network"] ~doc ~docv:"NET")
+    Arg.(value & opt string "shadownet" & info ["network"] ~doc ~docv:"NET")
   in
   let output_json =
     Arg.(value & flag & info ["json"] ~doc:"Emit JSON output instead of text.")

--- a/src/ui/pages/install_accuser_form_v3.ml
+++ b/src/ui/pages/install_accuser_form_v3.ml
@@ -431,7 +431,7 @@ let spec =
           {
             role = "accuser";
             instance = model.core.instance_name;
-            network = Option.value ~default:"mainnet" network;
+            network = Option.value ~default:"shadownet" network;
             history_mode = History_mode.default;
             data_dir =
               Common.default_role_dir "accuser" model.core.instance_name;

--- a/src/ui/pages/install_dal_node_form_v3.ml
+++ b/src/ui/pages/install_dal_node_form_v3.ml
@@ -376,7 +376,7 @@ let spec =
           {
             role = "dal-node";
             instance = model.core.instance_name;
-            network = Option.value ~default:"mainnet" network;
+            network = Option.value ~default:"shadownet" network;
             history_mode = History_mode.default;
             data_dir = dal_data_dir;
             rpc_addr = model.rpc_addr;

--- a/src/ui/pages/install_node_form_v3.ml
+++ b/src/ui/pages/install_node_form_v3.ml
@@ -111,7 +111,7 @@ let create_default_snapshot ~network ~history_mode =
       | None -> `None)
 
 let base_initial_model () =
-  let network = "mainnet" in
+  let network = "shadownet" in
   let history_mode = "rolling" in
   let instance_name = generate_instance_name ~network ~history_mode in
   {

--- a/src/ui/pages/snapshots.ml
+++ b/src/ui/pages/snapshots.ml
@@ -30,7 +30,7 @@ let load_snapshots network =
   | Error (`Msg _e) -> []
 
 let init () =
-  let network = "mainnet" in
+  let network = "shadownet" in
   let entries = load_snapshots network in
   Navigation.make {network; entries; selected = 0; error = None}
 

--- a/test/tui_flow_tests.ml
+++ b/test/tui_flow_tests.ml
@@ -406,9 +406,10 @@ let test_node_form_network_field () =
       let text = strip_ansi screen in
       check
         bool
-        "shows mainnet"
+        "shows shadownet"
         true
-        (contains_substring text "mainnet" || contains_substring text "Mainnet"))
+        (contains_substring text "shadownet"
+        || contains_substring text "Shadownet"))
 
 (* ============================================================ *)
 (* Install Baker Form Tests *)
@@ -861,9 +862,13 @@ let test_node_form_change_network () =
   TH.with_test_env (fun () ->
       Headless.Stateful.init (module Install_node_form.Page) ;
 
-      (* Default network should be mainnet *)
+      (* Default network should be shadownet *)
       let screen1 = TH.get_screen_text () in
-      check bool "shows mainnet" true (TH.contains_substring screen1 "mainnet") ;
+      check
+        bool
+        "shows shadownet"
+        true
+        (TH.contains_substring screen1 "shadownet") ;
 
       (* Navigate to network field (second field) *)
       ignore (TH.send_key_and_wait "Down") ;
@@ -893,12 +898,12 @@ let test_node_form_change_network () =
 
       (* The form should now show the selected network *)
       let screen2 = TH.get_screen_text () in
-      (* Either ghostnet is shown or we stayed on mainnet - both are valid *)
+      (* Either ghostnet is shown or we stayed on shadownet - both are valid *)
       check
         bool
         "network field has value"
         true
-        (TH.contains_substring screen2 "mainnet"
+        (TH.contains_substring screen2 "shadownet"
         || TH.contains_substring screen2 "ghostnet"))
 
 (** Test: Navigate through entire node form without errors.


### PR DESCRIPTION
## Summary

Changes the default network from mainnet to shadownet across all installers and forms.

Fixes #378

## Rationale

As noted by @vch9 in #378, octez-manager is still experimental and shouldn't default to mainnet to prevent accidental mainnet operations. Shadownet is a safer default for testing and development.

## Changes

### CLI Commands
- `install-node` - default network changed to shadownet
- `list-snapshots` - default network changed to shadownet

### TUI Forms  
- Install node form - initial network shadownet
- Install accuser form - fallback network shadownet
- Install DAL node form - fallback network shadownet
- Snapshots page - initial network shadownet

### Tests
- Updated TUI flow tests to expect shadownet instead of mainnet

## Testing

- `dune build` - compiles successfully
- `dune runtest` - all tests pass
- `dune fmt` - code formatted

## Impact

Users will now see shadownet as the default when installing services. They can still select mainnet or any other network manually.