### PR TITLE
fix: Atomic binary downloads to prevent incomplete installations

### DIFF
--- a/src/binary_downloader.mli
+++ b/src/binary_downloader.mli
@@ -76,6 +76,10 @@ val clear_cache : unit -> unit
 (** List of binaries to download for a version *)
 val binaries_for_version : string -> (string list, Rresult.R.msg) result
 
+(** Cleanup stale temporary download directories
+    @param max_age_seconds Maximum age in seconds (default: 3600 = 1 hour) *)
+val cleanup_stale_temp_dirs : ?max_age_seconds:int -> unit -> unit
+
 (** Download a version to the managed binaries directory
     @param version Version to download (e.g., "24.0")
     @param verify_checksums Whether to verify checksums (can be cancelled by user)

--- a/src/binary_registry.mli
+++ b/src/binary_registry.mli
@@ -74,3 +74,7 @@ val list_managed_versions : unit -> (string list, Rresult.R.msg) result
 
 (** Check if a managed version is installed *)
 val managed_version_exists : string -> bool
+
+(** Check if a version installation is complete (has all binaries and metadata)
+    @param version Version to check (e.g., "24.0") *)
+val is_complete_installation : string -> bool

--- a/src/cli/cmd_binaries.ml
+++ b/src/cli/cmd_binaries.ml
@@ -174,6 +174,9 @@ let list_cmd =
 let download_cmd =
   let term =
     let run version verify_checksums =
+      (* Cleanup stale temporary download directories *)
+      Binary_downloader.cleanup_stale_temp_dirs () ;
+
       Printf.printf "Downloading Octez v%s...\n\n" version ;
 
       (* Initialize multi-line progress display *)

--- a/src/ui/pages/manager_app.ml
+++ b/src/ui/pages/manager_app.ml
@@ -49,6 +49,8 @@ let run ?page ?(log = false) ?logfile () =
   Capabilities.register () ;
   register_pages () ;
   Runtime.initialize ~log ?logfile () ;
+  (* Cleanup stale temporary download directories from interrupted sessions *)
+  Binary_downloader.cleanup_stale_temp_dirs () ;
   let start_name = Option.value ~default:Instances.name page in
   let rec loop history current_name =
     if !quit_requested then raise Exit


### PR DESCRIPTION
## Summary

Implements atomic binary downloads using temporary directories and atomic rename operations. Fixes incomplete installation bugs that block retry attempts after interrupted downloads.

Fixes #405

## Problem

Interrupted downloads (Ctrl+C, network failure, crash) leave partial installations that:
- Appear as "installed" in binaries list
- Block retry attempts with "Version already installed" error
- Require manual directory deletion
- Cannot be distinguished from complete installations

**Root causes:**
- No atomic installation guarantee
- Validation only checks if directory exists (not contents)
- `.metadata.json` written at END (incomplete = no metadata)
- No cleanup of failed download attempts

## Solution

Implemented atomic download pattern with comprehensive validation:

### 1. Atomic Installation

```ocaml
(* Download to temp directory *)
let temp_dir = .tmp.v{version}.{pid}

(* Download all binaries to temp *)
download_all_to temp_dir

(* Atomic rename on success *)
Unix.rename temp_dir final_dir  (* Same filesystem = atomic *)
```

**Benefits:**
- Either complete installation or nothing
- No partial states visible to users
- OS-level atomic guarantee via `rename(2)`
- PID-based naming prevents conflicts

### 2. Complete Installation Validation

```ocaml
let is_complete_installation version =
  (* Check directory exists *)
  directory_exists 
  (* Check metadata file exists *)
  && metadata_exists
  (* Check all 4 binaries present *)
  && all_binaries_exist
```

Applied in:
- `list_managed_versions`: Filters incomplete installations
- `download_version`: Removes incomplete before retry
- Unit tests: 5 new tests for validation logic

### 3. Cleanup Strategies

**Immediate (on error):**
```ocaml
match download with
| Error _ -> 
    rm -rf temp_dir;  (* Cleanup failed attempt *)
    e
```

**Lazy (next download):**
```ocaml
let download_version ~version =
  cleanup_stale_temp_dirs ();  (* Clean before starting *)
  ...
```

**Startup (application start):**
```ocaml
(* TUI - manager_app.ml *)
Runtime.initialize () ;
cleanup_stale_temp_dirs () ;

(* CLI - cmd_binaries.ml *)
let download_cmd =
  cleanup_stale_temp_dirs () ;
  ...
```

**Threshold:** 1 hour (stale temps older than 3600s removed)

### 4. User Communication

Silent cleanup with logging only:
- No error messages for stale temp removal
- No prompts or confirmations needed
- Invisible to end users in normal operation
- Logs cleanup actions for debugging

## Implementation Details

**Files modified:**
- `src/binary_downloader.ml` (+71 lines): Temp dir helpers, atomic download logic
- `src/binary_downloader.mli` (+4 lines): Export cleanup function
- `src/binary_registry.ml` (+20 lines): Validation function, filter incomplete
- `src/binary_registry.mli` (+4 lines): Export validation function
- `src/cli/cmd_binaries.ml` (+3 lines): Startup cleanup
- `src/ui/pages/manager_app.ml` (+2 lines): Startup cleanup
- `test/unit_tests.ml` (+134 lines): 5 new validation tests

**Total:** ~238 lines added/modified

### Key Design Decisions

1. **Temp location:** Same parent as final (ensures atomic rename)
2. **Validation scope:** Metadata + all 4 binaries (comprehensive check)
3. **Cleanup threshold:** 1 hour (balances safety with cleanup)
4. **Error handling:** Silent cleanup (no user interaction needed)
5. **Module placement:** `is_complete_installation` in `Binary_registry` (avoids cycle)

## Testing

### Unit Tests (5 new tests)

```ocaml
(* Validation tests *)
- is_complete_installation_no_dir: Non-existent directory → false
- is_complete_installation_no_metadata: Missing metadata → false  
- is_complete_installation_missing_binary: Missing binary → false
- is_complete_installation_complete: All files present → true

(* Cleanup test *)
- cleanup_stale_temp_dirs: Removes old temps, preserves fresh
```

### Manual Testing Scenarios

**Interrupted download (Ctrl+C):**
```bash
om binaries download 24.0
# Press Ctrl+C mid-download
om binaries download 24.0  # Should succeed (retry works)
```

**Network failure:**
```bash
# Simulate: disconnect network during download
om binaries download 24.0  # Should cleanup and allow retry
```

**Crash during download:**
```bash
# Simulate: kill -9 $PID during download
om binaries list-local  # Should not show incomplete version
om binaries download 24.0  # Should succeed
```

**Startup cleanup:**
```bash
# Create stale temp manually
mkdir ~/.local/share/octez-manager/binaries/.tmp.v99.99.12345
touch -d "2 hours ago" .../.tmp.v99.99.12345
om ui  # Should cleanup stale temp on startup
```

## Compatibility

- **Backward compatible:** Existing complete installations unaffected
- **No migration needed:** Incomplete dirs filtered automatically
- **No API changes:** All changes internal to download flow

## Notes

- Moved `is_complete_installation` to `Binary_registry` to avoid circular dependency
- Updated existing `binary_registry_managed_versions` test to create complete installations
- Cleanup is best-effort (failures logged but don't block operations)
- Atomic rename requires temp and final dirs on same filesystem (always true for our case)

Co-Authored-By: Claude <noreply@anthropic.com>