### PR TITLE
feat(installer): add --prefix option and XDG-based install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,22 @@
 
 ### Installation
 
+**Quick install (default location):**
+
 ```sh
 curl -fsSL https://raw.githubusercontent.com/trilitech/octez-manager/main/install.sh | sh
 ```
 
-Or build from source:
+- Root user: installs to `/usr/local/bin` (system-wide)
+- Regular user: installs to `~/.local/bin` (user-local)
+
+**Custom installation directory:**
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/trilitech/octez-manager/main/install.sh | sh -s -- --prefix=/custom/path
+```
+
+**Build from source:**
 
 ```sh
 git clone https://github.com/trilitech/octez-manager.git

--- a/install.sh
+++ b/install.sh
@@ -2,24 +2,71 @@
 set -e
 
 # Octez Manager installer
-# Usage: curl -fsSL https://raw.githubusercontent.com/trilitech/octez-manager/main/install.sh | sh
+#
+# Usage:
+#   Default installation:
+#     curl -fsSL https://raw.githubusercontent.com/trilitech/octez-manager/main/install.sh | sh
+#
+#   Custom installation directory:
+#     curl -fsSL https://raw.githubusercontent.com/trilitech/octez-manager/main/install.sh | sh -s -- --prefix=/custom/path
+#
+# Default installation directories:
+#   - Root user: /usr/local/bin (system-wide)
+#   - Regular user: ~/.local/bin (user-local, XDG Base Directory)
 
 REPO="trilitech/octez-manager"
-INSTALL_DIR="/usr/local/bin"
 BINARY_NAME="octez-manager"
+
+# Parse arguments
+PREFIX=""
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--prefix=*)
+		PREFIX="${1#*=}"
+		shift
+		;;
+	--prefix)
+		PREFIX="$2"
+		shift 2
+		;;
+	*)
+		echo "Unknown option: $1"
+		echo "Usage: $0 [--prefix=PATH]"
+		exit 1
+		;;
+	esac
+done
+
+# Determine installation directory (XDG-based defaults)
+if [ -n "$PREFIX" ]; then
+	INSTALL_DIR="$PREFIX"
+elif [ "$(id -u)" -eq 0 ]; then
+	# Root user: install system-wide
+	INSTALL_DIR="/usr/local/bin"
+else
+	# Non-root user: install to user directory (XDG Base Directory)
+	# Use ~/.local/bin which is commonly in PATH
+	INSTALL_DIR="${HOME}/.local/bin"
+fi
 
 # Detect OS and architecture
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 
 case "$OS" in
-    linux) OS="linux" ;;
-    *) echo "Unsupported OS: $OS (only Linux is currently supported)"; exit 1 ;;
+linux) OS="linux" ;;
+*)
+	echo "Unsupported OS: $OS (only Linux is currently supported)"
+	exit 1
+	;;
 esac
 
 case "$ARCH" in
-    x86_64|amd64) ARCH="x86_64" ;;
-    *) echo "Unsupported architecture: $ARCH (only x86_64 is currently supported)"; exit 1 ;;
+x86_64 | amd64) ARCH="x86_64" ;;
+*)
+	echo "Unsupported architecture: $ARCH (only x86_64 is currently supported)"
+	exit 1
+	;;
 esac
 
 # Get latest version
@@ -27,8 +74,8 @@ echo "Fetching latest version..."
 VERSION=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
 
 if [ -z "$VERSION" ]; then
-    echo "Failed to fetch latest version"
-    exit 1
+	echo "Failed to fetch latest version"
+	exit 1
 fi
 
 # Download binary
@@ -41,13 +88,51 @@ trap 'rm -rf "$TMPDIR"' EXIT
 curl -fsSL "$DOWNLOAD_URL" -o "$TMPDIR/$BINARY_NAME"
 chmod +x "$TMPDIR/$BINARY_NAME"
 
+# Create install directory if it doesn't exist
+if [ ! -d "$INSTALL_DIR" ]; then
+	echo "Creating directory $INSTALL_DIR..."
+	if [ -w "$(dirname "$INSTALL_DIR")" ]; then
+		mkdir -p "$INSTALL_DIR"
+	else
+		sudo mkdir -p "$INSTALL_DIR"
+	fi
+fi
+
 # Install
 echo "Installing to $INSTALL_DIR/$BINARY_NAME..."
 if [ -w "$INSTALL_DIR" ]; then
-    mv "$TMPDIR/$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
+	mv "$TMPDIR/$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
 else
-    sudo mv "$TMPDIR/$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
+	sudo mv "$TMPDIR/$BINARY_NAME" "$INSTALL_DIR/$BINARY_NAME"
 fi
 
-echo "Successfully installed $BINARY_NAME $VERSION"
-echo "Run 'octez-manager --help' to get started"
+echo ""
+echo "Successfully installed $BINARY_NAME $VERSION to $INSTALL_DIR"
+
+# Check if install directory is in PATH
+case ":$PATH:" in
+*":$INSTALL_DIR:"*)
+	# Already in PATH
+	echo "Run 'octez-manager --help' to get started"
+	;;
+*)
+	# Not in PATH - provide instructions
+	echo ""
+	echo "⚠️  Note: $INSTALL_DIR is not in your PATH"
+	echo ""
+	echo "Add it to your PATH by running:"
+	echo ""
+	if [ -n "$BASH_VERSION" ] || [ -f "$HOME/.bashrc" ]; then
+		echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.bashrc"
+		echo "  source ~/.bashrc"
+	elif [ -n "$ZSH_VERSION" ] || [ -f "$HOME/.zshrc" ]; then
+		echo "  echo 'export PATH=\"$INSTALL_DIR:\$PATH\"' >> ~/.zshrc"
+		echo "  source ~/.zshrc"
+	else
+		echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+		echo "  # Add the above line to your shell's rc file"
+	fi
+	echo ""
+	echo "Or run directly: $INSTALL_DIR/octez-manager --help"
+	;;
+esac


### PR DESCRIPTION
## Summary

Improves the installation script to support custom installation directories and follow XDG Base Directory specification.

Addresses feedback from [Tezos Agora forum](https://forum.tezosagora.org/t/octez-manager-an-experimental-tool-for-operating-octez/6967/8).

---

## Problem

Current installer:
- Hardcodes installation to `/usr/local/bin`
- Requires sudo for all installations
- No way to customize install location
- Not following XDG standards for user installs

Users requested:
- `--prefix` option to choose install directory
- XDG-based defaults for non-root users
- Better support for user-local installations

---

## Solution

### 1. XDG-Based Default Paths

Installer now uses sensible defaults based on user privileges:

| User Type | Install Directory | Description |
|-----------|------------------|-------------|
| Root | `/usr/local/bin` | System-wide installation |
| Regular user | `~/.local/bin` | User-local (XDG Base Directory) |

### 2. Custom Installation with `--prefix`

Users can now specify a custom installation directory:

```bash
# Install to /opt/bin
curl -fsSL https://raw.githubusercontent.com/trilitech/octez-manager/main/install.sh | sh -s -- --prefix=/opt/bin

# Install to ~/bin
curl -fsSL https://raw.githubusercontent.com/trilitech/octez-manager/main/install.sh | sh -s -- --prefix=$HOME/bin
```

### 3. Auto-create Directories

The installer automatically creates the target directory if it doesn't exist:
- Uses `mkdir -p` for writable parent directories
- Falls back to `sudo mkdir -p` if needed

### 4. PATH Detection and Instructions

After installation, the script checks if the install directory is in `$PATH`:

**If in PATH:**
```
Successfully installed octez-manager v0.1.1 to /home/user/.local/bin
Run 'octez-manager --help' to get started
```

**If NOT in PATH:**
```
Successfully installed octez-manager v0.1.1 to /home/user/.local/bin

⚠️  Note: /home/user/.local/bin is not in your PATH

Add it to your PATH by running:

  echo 'export PATH="/home/user/.local/bin:$PATH"' >> ~/.bashrc
  source ~/.bashrc

Or run directly: /home/user/.local/bin/octez-manager --help
```

The script detects whether you're using bash or zsh and provides appropriate instructions.

---

## Implementation Details

### Changes to `install.sh`

**Argument parsing:**
```sh
# Parse --prefix option
PREFIX=""
while [ $# -gt 0 ]; do
    case "$1" in
        --prefix=*)
            PREFIX="${1#*=}"
            ;;
        --prefix)
            PREFIX="$2"
            shift
            ;;
    esac
done
```

**XDG-based default selection:**
```sh
if [ -n "$PREFIX" ]; then
    INSTALL_DIR="$PREFIX"
elif [ "$(id -u)" -eq 0 ]; then
    INSTALL_DIR="/usr/local/bin"  # Root
else
    INSTALL_DIR="${HOME}/.local/bin"  # User (XDG)
fi
```

**Directory creation:**
```sh
if [ ! -d "$INSTALL_DIR" ]; then
    if [ -w "$(dirname "$INSTALL_DIR")" ]; then
        mkdir -p "$INSTALL_DIR"
    else
        sudo mkdir -p "$INSTALL_DIR"
    fi
fi
```

**PATH detection:**
```sh
case ":$PATH:" in
    *":$INSTALL_DIR:"*)
        # Already in PATH
        ;;
    *)
        # Show instructions to add to PATH
        ;;
esac
```

### Changes to `README.md`

Updated installation section with clear examples:

```markdown
**Quick install (default location):**
curl -fsSL .../install.sh | sh

- Root user: installs to /usr/local/bin (system-wide)
- Regular user: installs to ~/.local/bin (user-local)

**Custom installation directory:**
curl -fsSL .../install.sh | sh -s -- --prefix=/custom/path
```

---

## Benefits

✅ **No sudo required** for regular user installations  
✅ **Follows XDG standards** - `~/.local/bin` for user binaries  
✅ **Flexible installation** - `--prefix` for custom setups  
✅ **Clear PATH instructions** - helps users configure their shell  
✅ **Auto-creates directories** - handles missing directories gracefully  
✅ **Backward compatible** - root installations still work as before  

---

## Testing

### Test Scenarios

**1. Root installation (system-wide):**
```bash
sudo sh -c "curl -fsSL .../install.sh | sh"
# Should install to /usr/local/bin
# Should NOT show PATH instructions (already in PATH)
```

**2. Regular user installation (XDG):**
```bash
curl -fsSL .../install.sh | sh
# Should install to ~/.local/bin
# Should show PATH instructions if not in PATH
```

**3. Custom prefix:**
```bash
curl -fsSL .../install.sh | sh -s -- --prefix=$HOME/bin
# Should install to ~/bin
# Should create directory if missing
# Should show PATH instructions if needed
```

**4. Custom prefix with missing directory:**
```bash
curl -fsSL .../install.sh | sh -s -- --prefix=/tmp/test/bin
# Should create /tmp/test/bin
# Should install successfully
```

### Syntax Check

```bash
bash -n install.sh  # ✓ No syntax errors
sh -n install.sh    # ✓ POSIX-compliant
```

---

## Migration Notes

**Existing installations (v0.1.1 and earlier):**
- Located in `/usr/local/bin` - unchanged
- Will continue to work
- No action required

**New installations:**
- Root users: same as before (`/usr/local/bin`)
- Regular users: now use `~/.local/bin` by default
- Users wanting `/usr/local/bin`: use `sudo` or `--prefix`

**For CI/Docker:**
```dockerfile
# System-wide install
RUN curl -fsSL .../install.sh | sh

# Custom location
RUN curl -fsSL .../install.sh | sh -s -- --prefix=/app/bin
```

---

## Related

- Forum discussion: https://forum.tezosagora.org/t/octez-manager-an-experimental-tool-for-operating-octez/6967/8
- XDG Base Directory spec: https://specifications.freedesktop.org/basedir-spec/latest/

Co-Authored-By: Claude <noreply@anthropic.com>