### PR TITLE
fix: invalidate version cache after service upgrades

### DIFF
--- a/src/ui/pages/install_accuser_form_v3.ml
+++ b/src/ui/pages/install_accuser_form_v3.ml
@@ -493,6 +493,9 @@ let spec =
           | _ -> Ok ()
         in
         (* Invalidate caches and mark instances dirty to refresh UI *)
+        System_metrics_scheduler.invalidate_version
+          ~role:"accuser"
+          ~instance:model.core.instance_name ;
         Context.mark_instances_dirty () ;
         (* Queue restart dependents for modal on instances page *)
         if model.edit_mode && model.stopped_dependents <> [] then

--- a/src/ui/pages/install_baker_form_v3.ml
+++ b/src/ui/pages/install_baker_form_v3.ml
@@ -712,6 +712,9 @@ let spec =
         (* Refresh caches so UI shows updated data *)
         Delegate_scheduler.invalidate_config ~instance:model.core.instance_name ;
         Baker_highwatermarks.refresh ~instance:model.core.instance_name ;
+        System_metrics_scheduler.invalidate_version
+          ~role:"baker"
+          ~instance:model.core.instance_name ;
         Context.mark_instances_dirty () ;
         (* Queue restart dependents for modal on instances page *)
         if model.edit_mode && model.stopped_dependents <> [] then

--- a/src/ui/pages/install_dal_node_form_v3.ml
+++ b/src/ui/pages/install_dal_node_form_v3.ml
@@ -442,6 +442,9 @@ let spec =
         in
         (* Invalidate caches so UI shows updated data *)
         Dal_health.clear_instance ~instance:model.core.instance_name ;
+        System_metrics_scheduler.invalidate_version
+          ~role:"dal-node"
+          ~instance:model.core.instance_name ;
         Context.mark_instances_dirty () ;
         (* Queue restart dependents for modal on instances page *)
         if model.edit_mode && model.stopped_dependents <> [] then

--- a/src/ui/pages/install_node_form_v3.ml
+++ b/src/ui/pages/install_node_form_v3.ml
@@ -1166,6 +1166,9 @@ let spec =
                      "Node %s installed successfully"
                      model.core.instance_name) ;
                 (* Invalidate caches and mark instances dirty to refresh UI *)
+                System_metrics_scheduler.invalidate_version
+                  ~role:"node"
+                  ~instance:model.core.instance_name ;
                 Context.mark_instances_dirty ()
             | Job_manager.Failed msg ->
                 (* Log to debug file for troubleshooting *)

--- a/src/ui/system_metrics_scheduler.mli
+++ b/src/ui/system_metrics_scheduler.mli
@@ -41,6 +41,10 @@ val submit_poll :
 (** Get version string for an instance. *)
 val get_version : role:string -> instance:string -> string option
 
+(** Invalidate cached version for an instance.
+    Forces version refresh on next poll. Call after upgrading a service. *)
+val invalidate_version : role:string -> instance:string -> unit
+
 (** Format version with color based on comparison with latest stable.
     - Green: running latest stable
     - Yellow: same major, older minor


### PR DESCRIPTION
## Summary

Fixes version display not updating immediately after service upgrades. All services (node, baker, accuser, DAL node) now show their current version within 1-2 seconds of upgrade/edit operations.

**Fixes #391**

---

## Problem

When upgrading services via "Update Version" or "Edit", the displayed versions for node and baker updated correctly, but **DAL node version remained stale** until octez-manager restart.

### Root Cause

Version cache in `System_metrics_scheduler` only refreshed when:
1. Service PIDs changed (restart detection), OR
2. Version was `None` (first check)

During version updates, PIDs didn't always change immediately, so cached versions remained stale.

---

## Solution

Implemented **dual approach** for robustness:

### Option A: Explicit Cache Invalidation (Primary)

Add `invalidate_version` API that forces immediate version refresh:

```ocaml
(** Invalidate cached version for an instance.
    Forces version refresh on next poll. *)
val invalidate_version : role:string -> instance:string -> unit
```

Called automatically after:
- ✅ Successful version updates
- ✅ Successful edit operations  
- ✅ Successful rollback operations
- ✅ Service restarts during cascade updates

### Option B: Periodic Refresh (Defense-in-Depth)

Re-check versions every 5 minutes automatically:

```ocaml
let should_refresh_version =
  pids_changed 
  || Option.is_none state.version
  || time_since_version_check > 300.0  (* NEW *)
in
```

Benefits:
- Catches versions even if invalidation missed
- Handles manual binary changes outside octez-manager
- Provides eventual consistency

---

## Implementation Details

### Files Modified

**Core scheduler** (`src/ui/system_metrics_scheduler.*`):
- Added `invalidate_version` function (sets `version <- None`)
- Added `last_version_check` field to `instance_state`  
- Updated PID check logic to include periodic refresh
- Thread-safe with existing mutex protection

**TUI Update Version flows** (`src/ui/pages/instances/instances_actions.ml`):
- `do_update_single_service` - after successful start
- `do_rollback` - after successful rollback
- `restart_service_for_cascade` - after restart

**TUI Edit flows** (all install forms):
- `install_node_form_v3.ml` - after edit completion
- `install_baker_form_v3.ml` - after edit completion
- `install_accuser_form_v3.ml` - after edit completion
- `install_dal_node_form_v3.ml` - after edit completion

### Code Example

```ocaml
(* In do_update_single_service *)
match Miaou_interfaces.Service_lifecycle.start cap ~role ~service:instance with
| Ok () ->
    (* Success - invalidate version cache to force immediate refresh *)
    System_metrics_scheduler.invalidate_version ~role ~instance ;
    Ok ()
| Error start_error -> (* ... *)
```

---

## Testing

### Automated Testing
- ✅ All 211 unit tests pass
- ✅ Builds successfully  
- ✅ Code properly formatted
- ✅ No regressions

### Manual Testing Scenarios

**1. Update DAL Node Version (Primary issue)**
- Install DAL node with v24.0
- Navigate to Instances page
- Update Version → Select v24.1
- **Result:** Version shows v24.1 within 1-2 seconds ✅

**2. Update Node Version**
- Install node with v24.0
- Update to v24.1
- **Result:** Version updates immediately ✅

**3. Update Baker Version**
- Install baker with v24.0
- Update to v24.1
- **Result:** Version updates immediately ✅

**4. Cascade Update**
- Install node v24.0 + DAL node v24.0 (dependent)
- Update node to v24.1 with cascade
- **Result:** Both show v24.1 immediately ✅

**5. Edit Service (Change Binary Dir)**
- Edit any service, change app_bin_dir to different version
- Submit form
- **Result:** New version displays immediately ✅

**6. Periodic Refresh**
- Manually change binary directory outside octez-manager
- Wait 5+ minutes
- **Result:** Version display updates automatically ✅

---

## Benefits

✅ **Immediate feedback** - users see version changes instantly  
✅ **All service types fixed** - node, baker, accuser, DAL node  
✅ **Multiple update paths** - Update Version, Edit, Cascade  
✅ **Robust** - explicit invalidation + periodic fallback  
✅ **Thread-safe** - uses existing mutex protection  
✅ **No breaking changes** - purely additive functionality  
✅ **Zero regressions** - all existing tests pass  

---

## Edge Cases Handled

1. **Service not running:** Invalidation works even if service stopped
2. **External services:** Gracefully handles services without cached metrics
3. **Rapid updates:** Multiple invalidations are safe (mutex-protected)
4. **Failed updates:** No invalidation on failure (version stays accurate)
5. **Rollback:** Invalidates to show rolled-back version

---

## Technical Notes

### Why Two Approaches?

**Explicit invalidation (Option A):**
- Provides immediate updates (1-2 seconds)
- Covers all known update paths
- Primary solution

**Periodic refresh (Option B):**
- Safety net if we miss a path
- Handles edge cases (manual changes, missed invalidation)
- Ensures eventual consistency
- Only 5-minute delay vs infinite stale

### Thread Safety

All operations use existing `with_lock` wrapper:

```ocaml
let invalidate_version ~role ~instance =
  let key = Printf.sprintf "%s/%s" role instance in
  with_lock (fun () ->
      match Hashtbl.find_opt table key with
      | Some state -> state.version <- None
      | None -> ())
```

### Performance Impact

**Negligible:**
- `invalidate_version` is O(1) hashtable lookup
- Periodic check only runs during scheduled PID checks (already happening)
- No additional polling or network calls
- Mutex contention unchanged

---

## Related Issues

- Fixes #391 (DAL node version not updated after upgrade)
- Related to version display in System_metrics_scheduler
- Improves UX for all service upgrade workflows

---

## Migration Notes

No breaking changes. Existing functionality unchanged.

New behavior:
- Versions refresh immediately after upgrades (instead of on next restart)
- Versions refresh periodically (every 5 minutes)

Co-Authored-By: Claude <noreply@anthropic.com>