### PR TITLE
fix(ci): ensure opam is initialized in Debian coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -102,6 +102,17 @@ jobs:
           restore-keys: |
             opam-debian-miaou-
       
+      - name: Ensure opam is initialized
+        if: steps.cache-opam.outputs.cache-hit != 'true'
+        run: |
+          # Check if opam root exists, if not initialize it
+          if [ ! -d "/root/.opam/5.1.1" ]; then
+            echo "Initializing opam..."
+            opam init --disable-sandboxing --bare -y
+            opam switch create 5.1.1 ocaml.5.1.1 -y
+          fi
+          eval $(opam env)
+      
       - name: Pin miaou packages
         if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
@@ -109,6 +120,7 @@ jobs:
             echo "ERROR: MIAOU_GIT_URL secret is not configured." >&2
             exit 1
           fi
+          eval $(opam env)
           opam pin add miaou-core "$MIAOU_GIT_URL" --no-action
           opam pin add miaou-driver-term "$MIAOU_GIT_URL" --no-action
           opam pin add miaou-driver-matrix "$MIAOU_GIT_URL" --no-action


### PR DESCRIPTION
## Problem

The Coverage workflow on main is failing with:
```
[ERROR] Opam has not been initialised, please run 'opam init'
```

This breaks the "Build Instrumented Binary (Debian)" job.

## Root Cause

1. The Debian CI image has opam pre-initialized in `/root/.opam`
2. GitHub Actions cache restore creates an empty `/root/.opam` directory when cache misses
3. This overwrites the pre-initialized opam from the Docker image
4. When the "Pin miaou packages" step runs, opam root is empty/uninitialized

## Solution

Add a step to check if opam is initialized and initialize it if needed:
- Check if `/root/.opam/5.1.1` exists (the switch)
- If not, run `opam init` and create the switch
- Add `eval \$(opam env)` to ensure environment is set up

## Impact

- ✅ Fixes red CI on main
- ✅ No changes to functionality
- ✅ Minimal performance impact (only runs on cache miss)

## Testing

CI will validate this fix when it runs on this PR.