### PR TITLE
fix(ci): move eval opam env inside conditional blocks (v2)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -110,8 +110,11 @@ jobs:
             echo "Initializing opam..."
             opam init --disable-sandboxing --bare -y
             opam switch create 5.1.1 ocaml.5.1.1 -y
+            eval $(opam env)
+          else
+            echo "Opam already initialized, setting environment..."
+            eval $(opam env)
           fi
-          eval $(opam env)
       
       - name: Pin miaou packages
         if: steps.cache-opam.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Problem

PR #450's fix didn't work. The Coverage workflow is still failing with:
```
[ERROR] Opam has not been initialised, please run 'opam init'
```

## Root Cause (Take 2)

The previous fix had `eval $(opam env)` OUTSIDE the if block:
```bash
if [ ! -d "/root/.opam/5.1.1" ]; then
  opam init ...
  opam switch create ...
fi
eval $(opam env)  # ← This runs even when opam isn't initialized!
```

So when the directory doesn't exist, it tries to eval before initializing.

## Solution

Move `eval $(opam env)` INSIDE both branches:
```bash
if [ ! -d "/root/.opam/5.1.1" ]; then
  opam init ...
  opam switch create ...
  eval $(opam env)  # ← Only after init
else
  eval $(opam env)  # ← Only when already exists
fi
```

## Testing

CI will validate this works.

Supersedes: #450