### PR TITLE
fix(ci): check if opam actually works instead of directory existence (v3)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -105,14 +105,14 @@ jobs:
       - name: Ensure opam is initialized
         if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
-          # Check if opam root exists, if not initialize it
-          if [ ! -d "/root/.opam/5.1.1" ]; then
-            echo "Initializing opam..."
-            opam init --disable-sandboxing --bare -y
-            opam switch create 5.1.1 ocaml.5.1.1 -y
+          # Check if opam actually works, not just if directory exists
+          if opam switch list 2>&1 | grep -q "5.1.1"; then
+            echo "Opam switch 5.1.1 exists, using it..."
             eval $(opam env)
           else
-            echo "Opam already initialized, setting environment..."
+            echo "Initializing opam and creating switch 5.1.1..."
+            opam init --disable-sandboxing --bare -y || true
+            opam switch create 5.1.1 ocaml.5.1.1 -y
             eval $(opam env)
           fi
       


### PR DESCRIPTION
## Problem

PRs #450 and #451 didn't fix the issue. Coverage workflow still fails with:
```
[ERROR] Opam has not been initialised, please run 'opam init'
```

## Root Cause (Take 3)

The previous fixes checked if `/root/.opam/5.1.1` directory exists, but:
- The directory EXISTS (from the Docker image)
- When cache restore runs, it creates/modifies the directory
- But opam's internal state is BROKEN
- So `eval $(opam env)` fails even though directory exists

## Solution

Check if opam ACTUALLY WORKS by running `opam switch list`:
```bash
if opam switch list 2>&1 | grep -q "5.1.1"; then
  # Opam works, use it
  eval $(opam env)
else
  # Opam broken, reinitialize
  opam init --disable-sandboxing --bare -y || true
  opam switch create 5.1.1 ocaml.5.1.1 -y
  eval $(opam env)
fi
```

Added `|| true` to opam init in case it's partially initialized.

## Testing

CI will validate this fix.

Supersedes: #450, #451

**This is the 3rd attempt. If this doesn't work, we may need to disable the Debian coverage build entirely and investigate separately.**