### PR TITLE
fix(ci): always run opam setup in Debian coverage job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -99,7 +99,6 @@ jobs:
           key: opam-debian-miaou-${{ hashFiles('.github/miaou-version') }}
       
       - name: Ensure opam is initialized
-        if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
           # Check if opam actually works, not just if directory exists
           if opam switch list 2>&1 | grep -q "5.1.1"; then
@@ -113,7 +112,6 @@ jobs:
           fi
       
       - name: Pin miaou packages
-        if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
           if [ -z "$MIAOU_GIT_URL" ]; then
             echo "ERROR: MIAOU_GIT_URL secret is not configured." >&2
@@ -127,7 +125,6 @@ jobs:
           opam install miaou-core miaou-driver-term miaou-driver-matrix miaou-runner eio_posix
       
       - name: Install project dependencies
-        if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
           eval $(opam env)
           git config --global --add safe.directory "$PWD"


### PR DESCRIPTION
Fixes recurring Debian build failures in coverage workflow.

## Problem
The Debian coverage job keeps failing with 'opam not initialized' errors even when cache exists. The cache is unreliable across different workflow runs.

## Solution
Remove the `if: cache-hit != 'true'` conditionals so opam initialization, package pinning, and dependency installation ALWAYS run.

This ensures:
- Opam is always properly initialized
- Packages are always pinned correctly
- Dependencies are always available

## Trade-off
Slightly longer build times (~2-3 min) but much more reliable builds.

## Testing
Will verify Debian build passes with this change.