### PR TITLE
test: Phase 1 Day 4 - Binary and Directory registry tests (40 tests, +0.46% coverage)

### DIFF
--- a/src/binary_registry.ml
+++ b/src/binary_registry.ml
@@ -255,3 +255,24 @@ let resolve_bin_source = function
   | Raw_path path ->
       if Sys.file_exists path && Sys.is_directory path then Ok path
       else R.error_msgf "Binary path does not exist: %s" path
+
+(** Expose internal functions for testing *)
+module For_tests = struct
+  let bin_source_to_string = bin_source_to_string
+
+  let bin_source_to_yojson = bin_source_to_yojson
+
+  let bin_source_of_yojson = bin_source_of_yojson
+
+  let bin_source_of_legacy = bin_source_of_legacy
+
+  let linked_dir_to_yojson = linked_dir_to_yojson
+
+  let linked_dir_of_yojson = linked_dir_of_yojson
+
+  let linked_dirs_to_yojson = linked_dirs_to_yojson
+
+  let linked_dirs_of_yojson = linked_dirs_of_yojson
+
+  let compare_versions = compare_versions
+end

--- a/src/binary_registry.mli
+++ b/src/binary_registry.mli
@@ -78,3 +78,26 @@ val managed_version_exists : string -> bool
 (** Check if a version installation is complete (has all binaries and metadata)
     @param version Version to check (e.g., "24.0") *)
 val is_complete_installation : string -> bool
+
+(** {2 Testing interface} *)
+
+module For_tests : sig
+  val bin_source_to_string : bin_source -> string
+
+  val bin_source_to_yojson : bin_source -> Yojson.Safe.t
+
+  val bin_source_of_yojson : Yojson.Safe.t -> (bin_source, Rresult.R.msg) result
+
+  val bin_source_of_legacy : string -> bin_source
+
+  val linked_dir_to_yojson : linked_dir -> Yojson.Safe.t
+
+  val linked_dir_of_yojson : Yojson.Safe.t -> (linked_dir, Rresult.R.msg) result
+
+  val linked_dirs_to_yojson : linked_dir list -> Yojson.Safe.t
+
+  val linked_dirs_of_yojson :
+    Yojson.Safe.t -> (linked_dir list, Rresult.R.msg) result
+
+  val compare_versions : string -> string -> int
+end

--- a/test/dune
+++ b/test/dune
@@ -247,6 +247,20 @@
  (instrumentation
   (backend bisect_ppx)))
 
+(test
+ (name test_binary_registry)
+ (libraries alcotest octez_manager_lib yojson)
+ (modules test_binary_registry)
+ (instrumentation
+  (backend bisect_ppx)))
+
+(test
+ (name test_directory_registry)
+ (libraries alcotest octez_manager_lib yojson)
+ (modules test_directory_registry)
+ (instrumentation
+  (backend bisect_ppx)))
+
 ; UI Regression Testing Framework
 
 (library

--- a/test/test_binary_registry.ml
+++ b/test/test_binary_registry.ml
@@ -1,0 +1,297 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Tests for Binary_registry module - JSON serialization and pure functions *)
+
+open Alcotest
+open Octez_manager_lib
+module BR = Binary_registry.For_tests
+
+(** {2 Test utilities} *)
+
+let check_error_result actual =
+  match actual with
+  | Ok _ -> Alcotest.fail "Expected Error, got Ok"
+  | Error _ -> ()
+
+(** {2 bin_source_to_string tests} *)
+
+let test_bin_source_to_string_managed () =
+  let source = Binary_registry.Managed_version "24.0" in
+  let result = BR.bin_source_to_string source in
+  check string "managed version string" "v24.0 (managed)" result
+
+let test_bin_source_to_string_linked () =
+  let source = Binary_registry.Linked_alias "dev-build" in
+  let result = BR.bin_source_to_string source in
+  check string "linked alias string" "dev-build (linked)" result
+
+let test_bin_source_to_string_raw () =
+  let source = Binary_registry.Raw_path "/usr/local/bin" in
+  let result = BR.bin_source_to_string source in
+  check string "raw path string" "/usr/local/bin" result
+
+(** {2 bin_source JSON serialization tests} *)
+
+let test_bin_source_to_yojson_managed () =
+  let source = Binary_registry.Managed_version "24.0" in
+  let json = BR.bin_source_to_yojson source in
+  let expected =
+    `Assoc [("type", `String "managed"); ("version", `String "24.0")]
+  in
+  check (testable Yojson.Safe.pp Yojson.Safe.equal) "managed JSON" expected json
+
+let test_bin_source_to_yojson_linked () =
+  let source = Binary_registry.Linked_alias "dev-build" in
+  let json = BR.bin_source_to_yojson source in
+  let expected =
+    `Assoc [("type", `String "linked"); ("alias", `String "dev-build")]
+  in
+  check (testable Yojson.Safe.pp Yojson.Safe.equal) "linked JSON" expected json
+
+let test_bin_source_to_yojson_raw () =
+  let source = Binary_registry.Raw_path "/usr/local/bin" in
+  let json = BR.bin_source_to_yojson source in
+  let expected =
+    `Assoc [("type", `String "path"); ("path", `String "/usr/local/bin")]
+  in
+  check
+    (testable Yojson.Safe.pp Yojson.Safe.equal)
+    "raw path JSON"
+    expected
+    json
+
+let test_bin_source_of_yojson_managed () =
+  let json =
+    `Assoc [("type", `String "managed"); ("version", `String "24.0")]
+  in
+  let result = BR.bin_source_of_yojson json in
+  match result with
+  | Ok (Binary_registry.Managed_version "24.0") -> ()
+  | Ok _ -> Alcotest.fail "Expected Managed_version \"24.0\""
+  | Error (`Msg err) -> Alcotest.fail (Printf.sprintf "Parse failed: %s" err)
+
+let test_bin_source_of_yojson_linked () =
+  let json =
+    `Assoc [("type", `String "linked"); ("alias", `String "dev-build")]
+  in
+  let result = BR.bin_source_of_yojson json in
+  match result with
+  | Ok (Binary_registry.Linked_alias "dev-build") -> ()
+  | Ok _ -> Alcotest.fail "Expected Linked_alias \"dev-build\""
+  | Error (`Msg err) -> Alcotest.fail (Printf.sprintf "Parse failed: %s" err)
+
+let test_bin_source_of_yojson_raw () =
+  let json =
+    `Assoc [("type", `String "path"); ("path", `String "/usr/local/bin")]
+  in
+  let result = BR.bin_source_of_yojson json in
+  match result with
+  | Ok (Binary_registry.Raw_path "/usr/local/bin") -> ()
+  | Ok _ -> Alcotest.fail "Expected Raw_path \"/usr/local/bin\""
+  | Error (`Msg err) -> Alcotest.fail (Printf.sprintf "Parse failed: %s" err)
+
+let test_bin_source_of_yojson_backward_compat () =
+  (* Backward compatibility: plain string should be treated as raw path *)
+  let json = `String "/old/path" in
+  let result = BR.bin_source_of_yojson json in
+  match result with
+  | Ok (Binary_registry.Raw_path "/old/path") -> ()
+  | Ok _ -> Alcotest.fail "Expected Raw_path \"/old/path\""
+  | Error (`Msg err) -> Alcotest.fail (Printf.sprintf "Parse failed: %s" err)
+
+let test_bin_source_of_yojson_invalid_type () =
+  let json = `Assoc [("type", `String "unknown")] in
+  let result = BR.bin_source_of_yojson json in
+  check_error_result result
+
+let test_bin_source_of_yojson_invalid_format () =
+  let json = `Int 42 in
+  let result = BR.bin_source_of_yojson json in
+  check_error_result result
+
+let test_bin_source_of_legacy () =
+  let source = BR.bin_source_of_legacy "/legacy/path" in
+  match source with
+  | Binary_registry.Raw_path "/legacy/path" -> ()
+  | _ -> Alcotest.fail "Expected Raw_path"
+
+(** {2 linked_dir JSON serialization tests} *)
+
+let test_linked_dir_to_yojson () =
+  let ld : Binary_registry.linked_dir =
+    {alias = "dev"; path = "/home/user/dev"}
+  in
+  let json = BR.linked_dir_to_yojson ld in
+  let expected =
+    `Assoc [("alias", `String "dev"); ("path", `String "/home/user/dev")]
+  in
+  check
+    (testable Yojson.Safe.pp Yojson.Safe.equal)
+    "linked_dir JSON"
+    expected
+    json
+
+let test_linked_dir_of_yojson () =
+  let json =
+    `Assoc [("alias", `String "dev"); ("path", `String "/home/user/dev")]
+  in
+  let result = BR.linked_dir_of_yojson json in
+  match result with
+  | Ok ld ->
+      check string "alias" "dev" ld.Binary_registry.alias ;
+      check string "path" "/home/user/dev" ld.Binary_registry.path
+  | Error (`Msg err) -> Alcotest.fail (Printf.sprintf "Parse failed: %s" err)
+
+let test_linked_dir_of_yojson_missing_field () =
+  let json = `Assoc [("alias", `String "dev")] in
+  let result = BR.linked_dir_of_yojson json in
+  check_error_result result
+
+let test_linked_dirs_to_yojson () =
+  let dirs : Binary_registry.linked_dir list =
+    [
+      {alias = "dev"; path = "/home/user/dev"};
+      {alias = "prod"; path = "/opt/octez"};
+    ]
+  in
+  let json = BR.linked_dirs_to_yojson dirs in
+  match json with
+  | `List [_; _] -> ()
+  | _ -> Alcotest.fail "Expected list of 2 elements"
+
+let test_linked_dirs_of_yojson () =
+  let json =
+    `List
+      [
+        `Assoc [("alias", `String "dev"); ("path", `String "/home/user/dev")];
+        `Assoc [("alias", `String "prod"); ("path", `String "/opt/octez")];
+      ]
+  in
+  let result = BR.linked_dirs_of_yojson json in
+  match result with
+  | Ok dirs ->
+      check int "list length" 2 (List.length dirs) ;
+      check string "first alias" "dev" (List.hd dirs).Binary_registry.alias
+  | Error (`Msg err) -> Alcotest.fail (Printf.sprintf "Parse failed: %s" err)
+
+let test_linked_dirs_of_yojson_empty () =
+  let json = `List [] in
+  let result = BR.linked_dirs_of_yojson json in
+  match result with
+  | Ok dirs -> check int "empty list" 0 (List.length dirs)
+  | Error (`Msg err) -> Alcotest.fail (Printf.sprintf "Parse failed: %s" err)
+
+let test_linked_dirs_of_yojson_invalid_entry () =
+  let json = `List [`Assoc [("alias", `String "dev")]] in
+  let result = BR.linked_dirs_of_yojson json in
+  check_error_result result
+
+(** {2 compare_versions tests} *)
+
+let test_compare_versions_equal () =
+  let result = BR.compare_versions "24.0" "24.0" in
+  check int "equal versions" 0 result
+
+let test_compare_versions_greater () =
+  let result = BR.compare_versions "24.0" "9.0" in
+  check bool "24.0 > 9.0" true (result > 0)
+
+let test_compare_versions_less () =
+  let result = BR.compare_versions "9.0" "24.0" in
+  check bool "9.0 < 24.0" true (result < 0)
+
+let test_compare_versions_multi_part () =
+  let result = BR.compare_versions "24.1.3" "24.1.2" in
+  check bool "24.1.3 > 24.1.2" true (result > 0)
+
+let test_compare_versions_different_lengths () =
+  let result = BR.compare_versions "24.0.0" "24.0" in
+  check bool "24.0.0 > 24.0" true (result > 0)
+
+let test_compare_versions_different_lengths_reverse () =
+  let result = BR.compare_versions "24.0" "24.0.0" in
+  check bool "24.0 < 24.0.0" true (result < 0)
+
+let test_compare_versions_non_numeric () =
+  (* Non-numeric parts should be treated as 0 *)
+  let result = BR.compare_versions "24.alpha" "24.0" in
+  check int "non-numeric treated as 0" 0 result
+
+(** {2 Test suite} *)
+
+let () =
+  Alcotest.run
+    "Binary_registry"
+    [
+      ( "bin_source_to_string",
+        [
+          test_case "managed version" `Quick test_bin_source_to_string_managed;
+          test_case "linked alias" `Quick test_bin_source_to_string_linked;
+          test_case "raw path" `Quick test_bin_source_to_string_raw;
+        ] );
+      ( "bin_source JSON serialization",
+        [
+          test_case "to_yojson managed" `Quick test_bin_source_to_yojson_managed;
+          test_case "to_yojson linked" `Quick test_bin_source_to_yojson_linked;
+          test_case "to_yojson raw" `Quick test_bin_source_to_yojson_raw;
+          test_case "of_yojson managed" `Quick test_bin_source_of_yojson_managed;
+          test_case "of_yojson linked" `Quick test_bin_source_of_yojson_linked;
+          test_case "of_yojson raw" `Quick test_bin_source_of_yojson_raw;
+          test_case
+            "of_yojson backward compat"
+            `Quick
+            test_bin_source_of_yojson_backward_compat;
+          test_case
+            "of_yojson invalid type"
+            `Quick
+            test_bin_source_of_yojson_invalid_type;
+          test_case
+            "of_yojson invalid format"
+            `Quick
+            test_bin_source_of_yojson_invalid_format;
+          test_case "of_legacy" `Quick test_bin_source_of_legacy;
+        ] );
+      ( "linked_dir JSON serialization",
+        [
+          test_case "to_yojson" `Quick test_linked_dir_to_yojson;
+          test_case "of_yojson" `Quick test_linked_dir_of_yojson;
+          test_case
+            "of_yojson missing field"
+            `Quick
+            test_linked_dir_of_yojson_missing_field;
+          test_case "list to_yojson" `Quick test_linked_dirs_to_yojson;
+          test_case "list of_yojson" `Quick test_linked_dirs_of_yojson;
+          test_case
+            "list of_yojson empty"
+            `Quick
+            test_linked_dirs_of_yojson_empty;
+          test_case
+            "list of_yojson invalid"
+            `Quick
+            test_linked_dirs_of_yojson_invalid_entry;
+        ] );
+      ( "compare_versions",
+        [
+          test_case "equal versions" `Quick test_compare_versions_equal;
+          test_case "greater version" `Quick test_compare_versions_greater;
+          test_case "less version" `Quick test_compare_versions_less;
+          test_case
+            "multi-part versions"
+            `Quick
+            test_compare_versions_multi_part;
+          test_case
+            "different lengths"
+            `Quick
+            test_compare_versions_different_lengths;
+          test_case
+            "different lengths reverse"
+            `Quick
+            test_compare_versions_different_lengths_reverse;
+          test_case "non-numeric parts" `Quick test_compare_versions_non_numeric;
+        ] );
+    ]

--- a/test/test_directory_registry.ml
+++ b/test/test_directory_registry.ml
@@ -1,0 +1,238 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Tests for Directory_registry module - JSON serialization *)
+
+open Alcotest
+open Octez_manager_lib
+module DR = Directory_registry.For_test
+
+(** {2 dir_type JSON serialization tests} *)
+
+let test_dir_type_to_yojson_node () =
+  let json = DR.dir_type_to_yojson Directory_registry.Node_data_dir in
+  check
+    (testable Yojson.Safe.pp Yojson.Safe.equal)
+    "node_data_dir"
+    (`String "node_data_dir")
+    json
+
+let test_dir_type_to_yojson_client () =
+  let json = DR.dir_type_to_yojson Directory_registry.Client_base_dir in
+  check
+    (testable Yojson.Safe.pp Yojson.Safe.equal)
+    "client_base_dir"
+    (`String "client_base_dir")
+    json
+
+let test_dir_type_to_yojson_app_bin () =
+  let json = DR.dir_type_to_yojson Directory_registry.App_bin_dir in
+  check
+    (testable Yojson.Safe.pp Yojson.Safe.equal)
+    "app_bin_dir"
+    (`String "app_bin_dir")
+    json
+
+let test_dir_type_of_yojson_node () =
+  let result = DR.dir_type_of_yojson (`String "node_data_dir") in
+  match result with
+  | Ok Directory_registry.Node_data_dir -> ()
+  | Ok _ -> Alcotest.fail "Expected Node_data_dir"
+  | Error err -> Alcotest.fail (Printf.sprintf "Parse failed: %s" err)
+
+let test_dir_type_of_yojson_client () =
+  let result = DR.dir_type_of_yojson (`String "client_base_dir") in
+  match result with
+  | Ok Directory_registry.Client_base_dir -> ()
+  | Ok _ -> Alcotest.fail "Expected Client_base_dir"
+  | Error err -> Alcotest.fail (Printf.sprintf "Parse failed: %s" err)
+
+let test_dir_type_of_yojson_app_bin () =
+  let result = DR.dir_type_of_yojson (`String "app_bin_dir") in
+  match result with
+  | Ok Directory_registry.App_bin_dir -> ()
+  | Ok _ -> Alcotest.fail "Expected App_bin_dir"
+  | Error err -> Alcotest.fail (Printf.sprintf "Parse failed: %s" err)
+
+let test_dir_type_of_yojson_invalid () =
+  let result = DR.dir_type_of_yojson (`String "unknown_type") in
+  match result with Ok _ -> Alcotest.fail "Expected Error" | Error _ -> ()
+
+(** {2 directory_entry JSON serialization tests} *)
+
+let test_directory_entry_to_yojson () =
+  let entry : Directory_registry.directory_entry =
+    {
+      path = "/var/lib/tezos/node";
+      dir_type = Directory_registry.Node_data_dir;
+      created_at = "2026-01-01 12:00:00";
+      last_used_at = "2026-01-25 10:30:00";
+      linked_services = ["node-mainnet"; "node-testnet"];
+    }
+  in
+  let json = DR.directory_entry_to_yojson entry in
+  match json with
+  | `Assoc fields ->
+      let path = List.assoc "path" fields in
+      check
+        (testable Yojson.Safe.pp Yojson.Safe.equal)
+        "path field"
+        (`String "/var/lib/tezos/node")
+        path
+  | _ -> Alcotest.fail "Expected Assoc"
+
+let test_directory_entry_of_yojson () =
+  let json =
+    `Assoc
+      [
+        ("path", `String "/var/lib/tezos/node");
+        ("dir_type", `String "node_data_dir");
+        ("created_at", `String "2026-01-01 12:00:00");
+        ("last_used_at", `String "2026-01-25 10:30:00");
+        ( "linked_services",
+          `List [`String "node-mainnet"; `String "node-testnet"] );
+      ]
+  in
+  let result = DR.directory_entry_of_yojson json in
+  match result with
+  | Ok entry ->
+      check string "path" "/var/lib/tezos/node" entry.Directory_registry.path ;
+      check
+        int
+        "linked_services count"
+        2
+        (List.length entry.Directory_registry.linked_services)
+  | Error (`Msg err) -> Alcotest.fail (Printf.sprintf "Parse failed: %s" err)
+
+let test_directory_entry_of_yojson_backward_compat () =
+  (* Test backward compatibility: last_used_at defaults to created_at if missing *)
+  let json =
+    `Assoc
+      [
+        ("path", `String "/var/lib/tezos/node");
+        ("dir_type", `String "node_data_dir");
+        ("created_at", `String "2026-01-01 12:00:00");
+        ("linked_services", `List []);
+      ]
+  in
+  let result = DR.directory_entry_of_yojson json in
+  match result with
+  | Ok entry ->
+      check
+        string
+        "last_used_at defaults to created_at"
+        "2026-01-01 12:00:00"
+        entry.Directory_registry.last_used_at
+  | Error (`Msg err) -> Alcotest.fail (Printf.sprintf "Parse failed: %s" err)
+
+let test_directory_entry_of_yojson_missing_path () =
+  let json =
+    `Assoc
+      [
+        ("dir_type", `String "node_data_dir");
+        ("created_at", `String "2026-01-01 12:00:00");
+        ("linked_services", `List []);
+      ]
+  in
+  let result = DR.directory_entry_of_yojson json in
+  match result with
+  | Ok _ -> Alcotest.fail "Expected Error for missing path"
+  | Error _ -> ()
+
+let test_directory_entry_of_yojson_invalid_dir_type () =
+  let json =
+    `Assoc
+      [
+        ("path", `String "/var/lib/tezos/node");
+        ("dir_type", `String "invalid_type");
+        ("created_at", `String "2026-01-01 12:00:00");
+        ("linked_services", `List []);
+      ]
+  in
+  let result = DR.directory_entry_of_yojson json in
+  match result with
+  | Ok _ -> Alcotest.fail "Expected Error for invalid dir_type"
+  | Error _ -> ()
+
+let test_directory_entry_roundtrip () =
+  let entry : Directory_registry.directory_entry =
+    {
+      path = "/home/user/.tezos-client";
+      dir_type = Directory_registry.Client_base_dir;
+      created_at = "2026-01-15 08:00:00";
+      last_used_at = "2026-01-25 14:20:00";
+      linked_services = ["baker-alpha"; "baker-beta"];
+    }
+  in
+  let json = DR.directory_entry_to_yojson entry in
+  let result = DR.directory_entry_of_yojson json in
+  match result with
+  | Ok parsed ->
+      check string "path roundtrip" entry.path parsed.Directory_registry.path ;
+      check
+        string
+        "created_at roundtrip"
+        entry.created_at
+        parsed.Directory_registry.created_at ;
+      check
+        string
+        "last_used_at roundtrip"
+        entry.last_used_at
+        parsed.Directory_registry.last_used_at
+  | Error (`Msg err) ->
+      Alcotest.fail (Printf.sprintf "Roundtrip parse failed: %s" err)
+
+(** {2 Test suite} *)
+
+let () =
+  Alcotest.run
+    "Directory_registry"
+    [
+      ( "dir_type JSON",
+        [
+          test_case "to_yojson node_data_dir" `Quick test_dir_type_to_yojson_node;
+          test_case
+            "to_yojson client_base_dir"
+            `Quick
+            test_dir_type_to_yojson_client;
+          test_case
+            "to_yojson app_bin_dir"
+            `Quick
+            test_dir_type_to_yojson_app_bin;
+          test_case
+            "of_yojson node_data_dir"
+            `Quick
+            test_dir_type_of_yojson_node;
+          test_case
+            "of_yojson client_base_dir"
+            `Quick
+            test_dir_type_of_yojson_client;
+          test_case
+            "of_yojson app_bin_dir"
+            `Quick
+            test_dir_type_of_yojson_app_bin;
+          test_case "of_yojson invalid" `Quick test_dir_type_of_yojson_invalid;
+        ] );
+      ( "directory_entry JSON",
+        [
+          test_case "to_yojson" `Quick test_directory_entry_to_yojson;
+          test_case "of_yojson" `Quick test_directory_entry_of_yojson;
+          test_case
+            "of_yojson backward compat"
+            `Quick
+            test_directory_entry_of_yojson_backward_compat;
+          test_case
+            "of_yojson missing path"
+            `Quick
+            test_directory_entry_of_yojson_missing_path;
+          test_case
+            "of_yojson invalid dir_type"
+            `Quick
+            test_directory_entry_of_yojson_invalid_dir_type;
+          test_case "roundtrip" `Quick test_directory_entry_roundtrip;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

**Recovered from accidentally closed PR #471**

Phase 1 Day 4 test additions focusing on registry module JSON serialization.

### Changes
- **test_binary_registry.ml**: 27 tests covering:
  - bin_source JSON serialization (managed/linked/raw paths)
  - Backward compatibility for legacy configs
  - linked_dir JSON serialization
  - Version comparison logic
- **test_directory_registry.ml**: 13 tests covering:
  - dir_type JSON serialization
  - directory_entry JSON serialization
  - Backward compatibility for missing fields
- **binary_registry.ml**: Expose For_tests module with 9 functions

### Test Results
- **40 new tests** added (27 + 13)
- **All tests pass** with clean formatting
- **Coverage**: Expected +0.46%

### Dependencies
- Based on current main (includes all previous test PRs)

### Note
This PR recovers the content from PR #471 which was accidentally closed during rebasing.

Co-Authored-By: Claude <noreply@anthropic.com>