### PR TITLE
docs: add copyright check to pre-commit verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,12 +24,15 @@ docs/                     # Documentation site (Astro)
 Before any commit:
 
 ```bash
-dune build          # Verify compilation
-dune runtest        # Run tests
-dune fmt            # Format code (MUST pass before commit)
+dune build                      # Verify compilation
+dune runtest                    # Run tests
+dune fmt                        # Format code (MUST pass before commit)
+./scripts/check-copyright.sh    # Verify copyright headers (MUST pass before commit)
 ```
 
-**Critical:** Every commit must be properly formatted. Do not create separate "formatting" commits.
+**Critical:** 
+- Every commit must be properly formatted. Do not create separate "formatting" commits.
+- Every commit must have correct copyright headers. Run `./scripts/check-copyright.sh --fix` to automatically update headers if needed.
 
 ## Integration Tests
 


### PR DESCRIPTION
## Summary

This PR updates `AGENTS.md` to include copyright header verification in the pre-commit checklist, ensuring AI agents and contributors catch copyright issues before pushing.

## Problem

The current `AGENTS.md` lists the pre-commit verification steps but doesn't include the copyright check:
- `dune build`
- `dune runtest`
- `dune fmt`

This means AI agents and contributors may push code without verifying copyright headers, leading to CI failures like the one in PR #475.

## Changes

### Updated Build & Verification Section

Added `./scripts/check-copyright.sh` to the pre-commit checklist with clear documentation:

```bash
dune build                      # Verify compilation
dune runtest                    # Run tests
dune fmt                        # Format code (MUST pass before commit)
./scripts/check-copyright.sh    # Verify copyright headers (MUST pass before commit)
```

Also documented the `--fix` flag for automatically updating headers.

## Benefits

- **Prevents CI failures**: Catches copyright issues locally before pushing
- **Saves time**: No need to wait for CI to discover copyright problems
- **Consistent workflow**: All verification steps documented in one place
- **Self-documenting**: Includes instructions for fixing copyright issues

## Related

- Addresses the CI failure in PR #475
- Follows the pattern established in `.github/workflows/ci.yml` which runs the copyright check

Co-Authored-By: Claude <noreply@anthropic.com>