### PR TITLE
fix(ui): remove nonexistent client config path from baker/accuser details

### DIFF
--- a/src/cli/cli_output.ml
+++ b/src/cli/cli_output.ml
@@ -263,20 +263,12 @@ let print_service_details svc =
         (Filename.concat svc.data_dir "identity.json")
   | "baker" ->
       let base_dir = lookup "OCTEZ_BAKER_BASE_DIR" in
-      if base_dir <> "" then (
-        Format.printf "  %-16s: %s@." "Base Directory" base_dir ;
-        Format.printf
-          "  %-16s: %s@."
-          "Client Config"
-          (Filename.concat base_dir "config"))
+      if base_dir <> "" then
+        Format.printf "  %-16s: %s@." "Base Directory" base_dir
   | "accuser" ->
       let base_dir = lookup "OCTEZ_CLIENT_BASE_DIR" in
-      if base_dir <> "" then (
-        Format.printf "  %-16s: %s@." "Base Directory" base_dir ;
-        Format.printf
-          "  %-16s: %s@."
-          "Client Config"
-          (Filename.concat base_dir "config"))
+      if base_dir <> "" then
+        Format.printf "  %-16s: %s@." "Base Directory" base_dir
   | "dal-node" | "dal" ->
       let dal_dir = lookup "OCTEZ_DAL_DATA_DIR" in
       if dal_dir <> "" then (

--- a/src/ui/pages/instance_details.ml
+++ b/src/ui/pages/instance_details.ml
@@ -150,12 +150,10 @@ let view_details svc =
         ]
     | "baker" ->
         let base_dir = lookup "OCTEZ_BAKER_BASE_DIR" in
-        let client_config = Filename.concat base_dir "config" in
-        [("Base Directory", base_dir); ("Client Config", client_config)]
+        [("Base Directory", base_dir)]
     | "accuser" ->
         let base_dir = lookup "OCTEZ_CLIENT_BASE_DIR" in
-        let client_config = Filename.concat base_dir "config" in
-        [("Base Directory", base_dir); ("Client Config", client_config)]
+        [("Base Directory", base_dir)]
     | "dal-node" | "dal" ->
         let data_dir = lookup "OCTEZ_DAL_DATA_DIR" in
         let config_file = Filename.concat data_dir "config.json" in


### PR DESCRIPTION
Fixes #483

The UI and CLI were displaying a Client Config path for bakers and accusers pointing to `<base_dir>/config`, but this file doesn't actually exist in Octez client directories.

## Changes

- Removed the nonexistent "Client Config" line from baker/accuser details in the TUI (`instance_details.ml`)
- Removed the nonexistent "Client Config" line from baker/accuser CLI output (`cli_output.ml`)
- Now only shows the "Base Directory" which actually exists and contains the wallet files (public_keys, secret_keys, contracts, etc.)

## Testing

- Before: UI showed `/home/valentin/.local/share/octez/baker-shadownet/config` which doesn't exist
- After: UI only shows `/home/valentin/.local/share/octez/baker-shadownet` which does exist