### PR TITLE
fix: add tallinnnet chain_id for network detection

### DIFF
--- a/src/external_service_detector.ml
+++ b/src/external_service_detector.ml
@@ -253,6 +253,7 @@ let chain_id_to_network = function
   | "NetXdQprcVkpaWU" -> Some "mainnet"
   | "NetXnHfVqm9iesp" -> Some "ghostnet"
   | "NetXsqzbfFenSTS" -> Some "shadownet"
+  | "NetXe8DbhW9A1eS" -> Some "tallinnnet"
   | _ -> None
 
 (** Probe RPC endpoint to get chain_id and detect network.

--- a/test/test_external_service_extended.ml
+++ b/test/test_external_service_extended.ml
@@ -146,6 +146,11 @@ let test_chain_id_shadownet () =
   | Some network -> check string "shadownet chain id" "shadownet" network
   | None -> fail "should recognize shadownet"
 
+let test_chain_id_tallinnnet () =
+  match ESD.chain_id_to_network "NetXe8DbhW9A1eS" with
+  | Some network -> check string "tallinnnet chain id" "tallinnnet" network
+  | None -> fail "should recognize tallinnnet"
+
 let test_chain_id_unknown () =
   let result = ESD.chain_id_to_network "NetUnknownChainId" in
   check bool "unknown chain id" true (Option.is_none result)
@@ -216,6 +221,7 @@ let chain_id_tests =
     ("chain id mainnet", `Quick, test_chain_id_mainnet);
     ("chain id ghostnet", `Quick, test_chain_id_ghostnet);
     ("chain id shadownet", `Quick, test_chain_id_shadownet);
+    ("chain id tallinnnet", `Quick, test_chain_id_tallinnnet);
     ("chain id unknown", `Quick, test_chain_id_unknown);
     ("chain id empty", `Quick, test_chain_id_empty);
     ("chain id case sensitive", `Quick, test_chain_id_case_sensitive);


### PR DESCRIPTION
## Summary
- Add `NetXe8DbhW9A1eS` -> `tallinnnet` mapping to `chain_id_to_network`
- Enables importing external tallinnnet services without `--network` flag

## Test plan
- [x] Unit test added for tallinnnet chain_id mapping
- [ ] Import external tallinnnet node without `--network` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)