### PR TITLE
fix(installer): remove obsolete logrotate sync calls

### DIFF
--- a/src/installer/dal_node.ml
+++ b/src/installer/dal_node.ml
@@ -153,8 +153,6 @@ let install_daemon ?(quiet = false) (request : daemon_request) =
         | Error _ -> Ok () (* Error finding parent, skip *))
     | None -> Ok ()
   in
-  let* services = Service_registry.list () in
-  let* () = Systemd.sync_logrotate (logrotate_specs_of services) in
   let* () =
     if request.auto_enable then
       Systemd.enable

--- a/src/installer/node.ml
+++ b/src/installer/node.ml
@@ -210,10 +210,6 @@ let install_node ?(quiet = false) ?on_log (request : node_request) =
         ())
     else Ok ()
   in
-  log "Listing services for logrotate...\n" ;
-  let* services = Service_registry.list () in
-  log "Syncing logrotate...\n" ;
-  let* () = Systemd.sync_logrotate (logrotate_specs_of services) in
   log "Enabling service...\n" ;
   let* () =
     if request.auto_enable then

--- a/src/installer/removal.ml
+++ b/src/installer/removal.ml
@@ -55,9 +55,7 @@ let remove_service ?(quiet = false) ~delete_data_dir ~instance () =
         | true -> Common.remove_tree svc.data_dir
         | false -> Ok ()
       in
-      let* () = Service_registry.remove ~instance in
-      let* services = Service_registry.list () in
-      Systemd.sync_logrotate (logrotate_specs_of services)
+      Service_registry.remove ~instance
 
 let purge_service ?(quiet = false) ~prompt_yes_no ~instance () =
   let* svc_opt = Service_registry.find ~instance in
@@ -237,9 +235,7 @@ let cleanup_renamed_instance ?(quiet = false) ~old_instance ~new_instance () =
         Filename.concat (Common.env_instances_base_dir ()) old_instance
       in
       let _ = Common.remove_tree old_env_dir in
-      (* Sync logrotate *)
-      let* services = Service_registry.list () in
-      Systemd.sync_logrotate (logrotate_specs_of services)
+      Ok ()
 
 let cleanup_dependencies () =
   let* services = Service_registry.list () in


### PR DESCRIPTION
## Summary

- Remove all `sync_logrotate` calls from installers
- Remove user-facing log messages about logrotate
- Remove obsolete comment about syncing logrotate

## Context

The `sync_logrotate` function was made a no-op in commit 844a799b when we switched to journald-only logging. However, the call sites and user-facing messages were never cleaned up, causing confusing "Syncing logrotate..." messages during installation.

## Changes

- **node.ml**: Removed log messages "Listing services for logrotate..." and "Syncing logrotate..."
- **dal_node.ml**: Removed silent `sync_logrotate` call
- **removal.ml**: Removed two `sync_logrotate` calls and obsolete comment

Fixes #513