### PR TITLE
fix(ui): force immediate refresh after instance removal

### DIFF
--- a/src/ui/data.ml
+++ b/src/ui/data.ml
@@ -172,6 +172,8 @@ let schedule_refresh ?detail () =
           ~finally:(fun () -> Atomic.set refresh_inflight false)
           (fun () -> ignore (refresh_cache ?detail ())))
 
+let force_refresh () = ignore (refresh_cache ())
+
 let load_service_states ?detail () =
   match detail with
   | Some true ->

--- a/src/ui/data.mli
+++ b/src/ui/data.mli
@@ -27,6 +27,8 @@ end
 
 val load_service_states : ?detail:bool -> unit -> Service_state.t list
 
+val force_refresh : unit -> unit
+
 val summarize : Service_state.t list -> Summary.t
 
 val diagnostics_lines : Service_state.t list -> string list

--- a/src/ui/pages/instances/instances_actions.ml
+++ b/src/ui/pages/instances/instances_actions.ml
@@ -34,6 +34,8 @@ let run_unit_action ~verb ~instance action =
       match status with
       | Job_manager.Succeeded ->
           Context.toast_success (Printf.sprintf "%s: %s finished" instance verb) ;
+          (* Force immediate data refresh for removal/purge operations *)
+          if verb = "remove" || verb = "purge" then Data.force_refresh () ;
           Context.mark_instances_dirty ()
       | Job_manager.Failed msg ->
           (* Record failure for display in status line *)

--- a/test/test_data.ml
+++ b/test/test_data.ml
@@ -297,6 +297,27 @@ let test_formatted_timestamp () =
   check bool "has colons" true (String.contains ts ':') ;
   check int "length" 19 (String.length ts)
 
+(* ── force_refresh ───────────────────────────────────────────── *)
+
+let test_force_refresh_requires_capability () =
+  (* force_refresh requires service_manager capability *)
+  (* Without setup, it should fail gracefully (not crash with uncaught exception) *)
+  try
+    Data.force_refresh () ;
+    (* If it succeeds, that's also fine (capability might be available) *)
+    check bool "force_refresh completes or fails gracefully" true true
+  with
+  | Failure msg when String.starts_with ~prefix:"capability missing" msg ->
+      (* Expected when capability is not available *)
+      check bool "expected capability missing error" true true
+  | exn ->
+      (* Unexpected exception - test should fail *)
+      check
+        bool
+        (Printf.sprintf "unexpected exception: %s" (Printexc.to_string exn))
+        false
+        true
+
 (* ── Suite ───────────────────────────────────────────────────── *)
 
 let () =
@@ -351,4 +372,11 @@ let () =
         ] );
       ( "formatted_timestamp",
         [test_case "format" `Quick test_formatted_timestamp] );
+      ( "force_refresh",
+        [
+          test_case
+            "requires capability"
+            `Quick
+            test_force_refresh_requires_capability;
+        ] );
     ]


### PR DESCRIPTION
## Summary

Fixes the bug where removed instances don't immediately disappear from the TUI. After removing or purging an instance, the UI now forces an immediate data refresh instead of waiting for the next scheduled refresh cycle (which has a 5-second TTL).

## Changes

- **src/ui/data.ml**: Add `force_refresh()` function that bypasses cache and immediately refreshes service states
- **src/ui/data.mli**: Export the new function
- **src/ui/pages/instances/instances_actions.ml**: Call `Data.force_refresh()` after successful remove/purge operations (in addition to marking instances dirty)
- **test/test_data.ml**: Add test to verify `force_refresh()` doesn't crash unexpectedly

## Why This Fix Works

The existing code already called `Context.mark_instances_dirty()` after removal, but this only sets a flag that's checked during the next render cycle. The actual data refresh still waited for the TTL-based cache to expire (5 seconds). By calling `force_refresh()`, we bypass the cache and immediately reload service states from systemd, ensuring the removed instance disappears right away.

## Testing

- Unit test added in `test/test_data.ml` verifying the new function doesn't crash
- Manual testing: Remove an instance in the TUI and verify it disappears immediately (not after 5 seconds)

Co-Authored-By: Claude <noreply@anthropic.com>