### PR TITLE
fix: filter out Octez versions < 23.0 from binaries page

### DIFF
--- a/src/ui/pages/binaries/binaries_page.ml
+++ b/src/ui/pages/binaries/binaries_page.ml
@@ -141,6 +141,13 @@ let load_available_versions () =
   | Some versions ->
       (* Filter to only the 2 latest major versions *)
       let filtered_versions = filter_latest_n_major_versions 2 versions in
+      (* Filter out versions < 23.0 *)
+      let filtered_versions =
+        List.filter
+          (fun (v : Binary_downloader.version_info) ->
+            Binary_registry.compare_versions v.version "23.0" >= 0)
+          filtered_versions
+      in
       (* Filter out already installed versions *)
       let managed =
         match Binary_registry.list_managed_versions () with


### PR DESCRIPTION
## Summary

Filter out Octez versions < 23.0 from the "Available for Download" list in the binaries management page.

## Changes

- Modified `load_available_versions()` in `src/ui/pages/binaries/binaries_page.ml` to filter out versions < 23.0
- Filter is applied after major version filtering and before checking for already-installed versions

## Implementation

The fix adds a single filter step:

```ocaml
(* Filter out versions < 23.0 *)
let filtered_versions =
  List.filter
    (fun (v : Binary_downloader.version_info) ->
      Binary_registry.compare_versions v.version "23.0" >= 0)
    filtered_versions
in
```

## Testing

- All existing tests pass (212 tests)
- Build and formatting checks pass

Fixes #511