### PR TITLE
fix(ci): add missing opam env for completions check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
 
       - name: Check completions are up to date
         run: |
+          eval $(opam env)
           mkdir -p /tmp/completions-check
           dune exec -- octez-manager-gen-completion --out-dir /tmp/completions-check
           if ! diff -q completions/octez-manager.bash /tmp/completions-check/octez-manager.bash >/dev/null 2>&1 || \


### PR DESCRIPTION
## Summary
- Add missing `eval $(opam env)` to the completions check CI step
- This was causing v0.2.0 tag CI to fail with "miaou-core.lib not found"

## Test plan
- CI should pass