### PR TITLE
fix(ci): add missing opam env for release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,7 @@ jobs:
 
       - name: Build static binary
         run: |
+          eval $(opam env)
           echo '(-ccopt -static)' > static_flags.sexp
           dune build --release
 


### PR DESCRIPTION
## Summary
- Add missing `eval $(opam env)` to the release build step
- This was causing v0.2.0 tag release job to fail

## Test plan
- CI should pass, tag build should work