### PR TITLE
docs: add PR requirements section with changelog mandate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,6 +405,19 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 
 Keep the first line under 72 characters.
 
+## Pull Request Requirements
+
+All pull requests must include:
+
+1. **Changelog entry** - Add an entry to `CHANGELOG.md` under the `[Unreleased]` section
+   - Use the appropriate category: `Added`, `Changed`, `Fixed`, `Deprecated`, `Removed`, or `Security`
+   - Write user-facing descriptions (what changed, not how it was implemented)
+   - Reference the issue number if applicable
+   - Example: `- Node sync status now displays bootstrap phase (fixes #123)`
+   - Small internal refactorings or documentation-only changes may skip this if they don't affect users
+
+2. **Tests** (for bug fixes) - See "Bug Fix PRs" section below
+
 ## Git Hygiene
 
 - **Always use pull requests** - never push directly to main


### PR DESCRIPTION
## Summary

Adds a new "Pull Request Requirements" section to AGENTS.md documenting that all PRs must include a changelog entry.

## Changes

- New section in AGENTS.md before "Git Hygiene"
- Documents changelog requirement under `[Unreleased]` section
- Lists appropriate categories (Added, Changed, Fixed, etc.)
- Explains that small internal changes may skip changelog
- References "Bug Fix PRs" section for test requirements

## Rationale

PR #518 was missing a changelog entry, which was caught during review. This formalizes the requirement so it's clear to all contributors (human and AI) that changelog entries are mandatory for user-facing changes.

Fixes missing documentation for changelog requirement.