### PR TITLE
docs: add missing changelog entry for PR #496 to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Failed systemd services now correctly detected and displayed in external services list (fixes #489)
+- Network detection now correctly probes connected node endpoint for DAL/baker/accuser services (fixes #488)
+- Removed nonexistent client config path from baker/accuser instance details (fixes #483)
+- Import wizard now correctly handles multiple edge cases (fixes #490):
+  - Network name matching is now case-insensitive
+  - Accusers running as `octez-baker run accuser` now properly identified
+  - Baker "with local node" mode now preserved after import
+  - Extra arguments now correctly displayed in CLI, TUI details, and edit forms
+  - Environment variables now consistent across all service types
+  - Duplicate environment variables removed from accuser configuration
+
 ## [0.2.0] - 2026-01-29
 
 ### Added


### PR DESCRIPTION
## Summary

Adds missing changelog entry for PR #496 which was merged before v0.2.0 release but wasn't documented in the changelog.

## Changes

Added to `[0.2.0]` > `Fixed` section:
- **PR #496**: Nonexistent client config path removed from baker/accuser instance details (fixes #483)

## Context

PR #496 was merged on 2026-01-27 (before the v0.2.0 release on 2026-01-29 15:32) and fixed a UI bug where the baker/accuser details showed a non-existent "Client Config" path. This change should have been included in v0.2.0 changelog but was missed.

Other PRs merged around the same time (#491, #497, #498) are already in the v0.2.0 changelog under more general descriptions:
- "Import wizard navigation and error handling improvements" (covers #491)
- "Failed systemd services now detected and displayed correctly" (covers #498)
- "Tallinnnet network detection support" (partially covers #497)