### PR TITLE
docs: add missing changelog entry for PR #496 to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `?` help shortcut now works from all screens
 - Imported services no longer appear in unmanaged instances list
 - Failed systemd services now detected and displayed correctly
+- Nonexistent client config path removed from baker/accuser instance details (fixes #483)
 - Clean exit without hanging on quit
 
 ## [0.1.1] - 2026-01-15


### PR DESCRIPTION
## Summary

Adds missing changelog entry for PR #496 which was merged before v0.2.0 release but wasn't documented in the changelog.

## Changes

Added to `[0.2.0]` > `Fixed` section:
- **PR #496**: Nonexistent client config path removed from baker/accuser instance details (fixes #483)

## Context

PR #496 was merged on 2026-01-27 (before the v0.2.0 release on 2026-01-29 15:32) and fixed a UI bug where the baker/accuser details showed a non-existent "Client Config" path. This change should have been included in v0.2.0 changelog but was missed.

Other PRs merged around the same time (#491, #497, #498) are already in the v0.2.0 changelog under more general descriptions:
- "Import wizard navigation and error handling improvements" (covers #491)
- "Failed systemd services now detected and displayed correctly" (covers #498)
- "Tallinnnet network detection support" (partially covers #497)

## Note

This supersedes the closed PR #532 which incorrectly tried to add these entries to [Unreleased] instead of v0.2.0.