### PR TITLE
fix(ci): add -no-pie flag to static builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Build
         run: |
           eval $(opam env)
-          echo '(-ccopt -static)' > static_flags.sexp
+          echo '(-ccopt "-static -no-pie")' > static_flags.sexp
           dune build --release
 
       - name: Test
@@ -302,7 +302,7 @@ jobs:
       - name: Build static binary
         run: |
           eval $(opam env)
-          echo '(-ccopt -static)' > static_flags.sexp
+          echo '(-ccopt "-static -no-pie")' > static_flags.sexp
           dune build --release
 
       - name: Prepare release artifact


### PR DESCRIPTION
## Summary
- Add `-no-pie` flag to static build linker options
- The CI image was updated with newer Alpine/OCaml which produces `static-pie` binaries
- Static-pie binaries segfault on some systems (v0.2.0 release is broken)

## Root cause
```
v0.1.1: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
v0.2.0: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked  # BROKEN
```

## Test plan
- CI should pass
- After merge, retag v0.2.0 and verify binary is `statically linked` (not `static-pie`)