### PR TITLE
Fix #541: Move StartLimitIntervalSec and StartLimitBurst to [Unit] section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Renamed "linked directories" to "registered directories" (CLI commands: `binaries link` → `binaries register`, `binaries unlink` → `binaries unregister`)
 
+### Fixed
+
+- Systemd service template warnings about unknown keys `StartLimitIntervalSec` and `StartLimitBurst` in [Service] section (moved to [Unit] section)
+
 ### Removed
 
 - Ghostnet support - Ghostnet testnet has been deprecated and is no longer available as a network option

--- a/src/systemd.ml
+++ b/src/systemd.ml
@@ -286,7 +286,9 @@ let unit_template ~user_mode ~role ~app_bin_dir ~user ?prestart () =
       "[Unit]\n\
        Description=Octez %s (%%i)\n\
        After=network-online.target\n\
-       Wants=network-online.target\n\n\
+       Wants=network-online.target\n\
+       StartLimitBurst=10\n\
+       StartLimitIntervalSec=300s\n\n\
        [Service]\n\
        Environment=APP_BIN_DIR=%s\n\
        Environment=ROLE=%s\n\
@@ -308,8 +310,6 @@ let unit_template ~user_mode ~role ~app_bin_dir ~user ?prestart () =
   let common_hardening =
     "Restart=on-failure\n\
      RestartSec=5s\n\
-     StartLimitBurst=10\n\
-     StartLimitIntervalSec=300s\n\
      NoNewPrivileges=yes\n\
      PrivateTmp=yes\n\
      ProtectSystem=strict\n\


### PR DESCRIPTION
## Summary

Fixes #541

Moves `StartLimitIntervalSec` and `StartLimitBurst` from the `[Service]` section to the `[Unit]` section in systemd service templates, eliminating warnings about unknown keys.

## Problem

systemd was logging warnings when starting baker/accuser services:
```
Unknown key name 'StartLimitIntervalSec' in section 'Service'
Unknown key name 'StartLimitBurst' in section 'Service'
```

## Root Cause

These keys were placed in the `[Service]` section but according to systemd documentation they belong in the `[Unit]` section.

## Solution

- Moved `StartLimitBurst=10` and `StartLimitIntervalSec=300s` from `common_hardening` (Service section) to `header_common` (Unit section)
- These keys now appear in the correct `[Unit]` section of all generated systemd service files

## Testing

- ✅ `dune build` - Passes
- ✅ `dune runtest` - All 211 tests pass
- ✅ `dune fmt` - Code formatted
- ✅ `check-copyright.sh` - All headers correct

## Impact

All service types affected (node, baker, accuser, DAL node). Users will need to reinstall services or manually update their systemd unit files to eliminate the warnings.