### PR TITLE
chore: add CLAUDE.md to reference AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+Read and follow the guidelines in @AGENTS.md for all development work on this project.


### PR DESCRIPTION
## Summary
- Add CLAUDE.md that directs Claude Code to read AGENTS.md

Claude Code automatically reads `CLAUDE.md` but not `AGENTS.md`. This small file ensures the full guidelines are loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)