### PR TITLE
fix(ci): fix docs-only filter and apply dune fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       needs-integration: ${{ steps.filter.outputs.needs-integration }}
-      docs-only: ${{ steps.filter.outputs.docs-only }}
+      has-source: ${{ steps.filter.outputs.has-source }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -33,26 +33,32 @@ jobs:
               - 'test/integration/**'
               - '.github/workflows/ci.yml'
               - 'Makefile'
-            docs-only:
-              - 'docs/**'
-              - '**/*.md'
+            has-source:
+              - 'src/**'
+              - 'test/**'
+              - 'dune-project'
+              - '*.opam'
+              - '.ocamlformat'
+              - 'Makefile'
+              - 'scripts/**'
+              - '.github/workflows/**'
 
   docs-check:
     name: Build and Test
     needs: changes
-    if: needs.changes.outputs.docs-only == 'true'
+    if: needs.changes.outputs.has-source == 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Documentation-only change
         run: |
-          echo "This PR only modifies documentation files."
+          echo "This change does not modify source code."
           echo "Skipping full build and test pipeline."
           echo "✓ Documentation check passed"
 
   build-and-test:
     name: Build and Test
     needs: changes
-    if: needs.changes.outputs.docs-only == 'false'
+    if: needs.changes.outputs.has-source == 'true'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}-ci-debian:latest

--- a/src/cli/cmd_rpc.ml
+++ b/src/cli/cmd_rpc.ml
@@ -31,8 +31,7 @@ let service_from_url url =
     ()
 
 (** Get public nodes from Taquito *)
-let get_public_nodes () =
-  Octez_manager_ui.Public_nodes_cache.get_services ()
+let get_public_nodes () = Octez_manager_ui.Public_nodes_cache.get_services ()
 
 (** Find a public node by index (1-based) or partial name match *)
 let find_public_node query =
@@ -47,7 +46,10 @@ let find_public_node query =
       List.find_opt
         (fun svc ->
           let name = String.lowercase_ascii svc.Service.instance in
-          String.sub name 0 (min (String.length query_lower) (String.length name))
+          String.sub
+            name
+            0
+            (min (String.length query_lower) (String.length name))
           = query_lower)
         nodes
 
@@ -55,7 +57,9 @@ let find_public_node query =
 let resolve_service instance_opt url_opt public_opt =
   match (instance_opt, url_opt, public_opt) with
   | Some _, Some _, _ | Some _, _, Some _ | _, Some _, Some _ ->
-      Error "Cannot specify multiple target options (use only one of --instance, --url, or --public)"
+      Error
+        "Cannot specify multiple target options (use only one of --instance, \
+         --url, or --public)"
   | None, None, None ->
       Error "Must specify a target: --instance, --url, or --public"
   | Some instance, None, None -> get_service instance
@@ -63,7 +67,12 @@ let resolve_service instance_opt url_opt public_opt =
   | None, None, Some query -> (
       match find_public_node query with
       | Some svc -> Ok svc
-      | None -> Error (Printf.sprintf "Public node '%s' not found. Use 'rpc public-nodes' to list available nodes." query))
+      | None ->
+          Error
+            (Printf.sprintf
+               "Public node '%s' not found. Use 'rpc public-nodes' to list \
+                available nodes."
+               query))
 
 (** List available node instances *)
 let list_instances () =
@@ -253,13 +262,19 @@ let url_arg =
   Arg.(
     value
     & opt (some string) None
-    & info ["u"; "url"] ~doc:"RPC endpoint URL (e.g., https://mainnet.tezos.ecadinfra.com)" ~docv:"URL")
+    & info
+        ["u"; "url"]
+        ~doc:"RPC endpoint URL (e.g., https://mainnet.tezos.ecadinfra.com)"
+        ~docv:"URL")
 
 let public_arg =
   Arg.(
     value
     & opt (some string) None
-    & info ["p"; "public"] ~doc:"Public node (index or name from 'rpc public-nodes')" ~docv:"NODE")
+    & info
+        ["p"; "public"]
+        ~doc:"Public node (index or name from 'rpc public-nodes')"
+        ~docv:"NODE")
 
 (** rpc get command *)
 let get_cmd =
@@ -369,7 +384,8 @@ let public_nodes_cmd =
           if nodes = [] then Printf.printf "No public nodes available.\n"
           else (
             Printf.printf "Available public RPC nodes:\n" ;
-            Printf.printf "  Use -p/--public with index or name (e.g., -p 1 or -p ecad)\n\n" ;
+            Printf.printf
+              "  Use -p/--public with index or name (e.g., -p 1 or -p ecad)\n\n" ;
             List.iteri
               (fun i svc ->
                 Printf.printf
@@ -387,4 +403,6 @@ let public_nodes_cmd =
 let rpc_cmd =
   let doc = "Query RPC endpoints on node instances" in
   let info = Cmd.info "rpc" ~doc in
-  Cmd.group info [get_cmd; list_cmd; interactive_cmd; instances_cmd; public_nodes_cmd]
+  Cmd.group
+    info
+    [get_cmd; list_cmd; interactive_cmd; instances_cmd; public_nodes_cmd]

--- a/src/ui/modal_helpers.ml
+++ b/src/ui/modal_helpers.ml
@@ -1343,7 +1343,7 @@ let show_spinner_modal ~title ~label ~work ~on_complete () =
       | Some close -> close ()
       | None -> ()) ;
       (* Convert Job_manager.status to polymorphic variant for interface *)
-      let result : [ `Succeeded | `Failed of string | `Cancelled ] =
+      let result : [`Succeeded | `Failed of string | `Cancelled] =
         match status with
         | Job_manager.Succeeded -> `Succeeded
         | Job_manager.Failed msg -> `Failed msg
@@ -1372,10 +1372,10 @@ let show_spinner_modal ~title ~label ~work ~on_complete () =
 
     let refresh ps =
       (* Auto-close if work is done *)
-      if !done_ref then (
-        match !spinner_modal_close_ref with
-        | Some close -> close ()
-        | None -> ()) ;
+      (if !done_ref then
+         match !spinner_modal_close_ref with
+         | Some close -> close ()
+         | None -> ()) ;
       ps
 
     let service_select ps _ = ps
@@ -1395,7 +1395,12 @@ let show_spinner_modal ~title ~label ~work ~on_complete () =
     let has_modal _ = true
   end in
   let ui : Miaou.Core.Modal_manager.ui =
-    {title; left = None; max_width = Some (Clamped {ratio = 0.5; min = 40; max = 60}); dim_background = true}
+    {
+      title;
+      left = None;
+      max_width = Some (Clamped {ratio = 0.5; min = 40; max = 60});
+      dim_background = true;
+    }
   in
   spinner_modal_close_ref :=
     Some (fun () -> Miaou.Core.Modal_manager.close_top `Commit) ;

--- a/src/ui/modal_helpers.mli
+++ b/src/ui/modal_helpers.mli
@@ -95,7 +95,7 @@ val select_app_bin_dir_modal :
 val show_spinner_modal :
   title:string ->
   label:string ->
-  work:(unit -> (unit, [ `Msg of string ]) result) ->
-  on_complete:([ `Succeeded | `Failed of string | `Cancelled ] -> unit) ->
+  work:(unit -> (unit, [`Msg of string]) result) ->
+  on_complete:([`Succeeded | `Failed of string | `Cancelled] -> unit) ->
   unit ->
   unit

--- a/src/ui/pages/instances/instances_render.ml
+++ b/src/ui/pages/instances/instances_render.ml
@@ -755,7 +755,8 @@ let table_lines_single state =
       let separator = Widgets.dim (String.make 80 '-') in
       "" :: separator :: external_rows
   in
-  (install_row :: binaries_row :: rpc_row :: "" :: instance_rows) @ external_rows
+  (install_row :: binaries_row :: rpc_row :: "" :: instance_rows)
+  @ external_rows
 
 (** Multi-column matrix layout *)
 let table_lines_matrix ~cols ~visible_height ~column_scroll state =
@@ -820,7 +821,9 @@ let table_lines_matrix ~cols ~visible_height ~column_scroll state =
     trim_end instance_rows
   in
   (* Append external services below the columnar grid *)
-  let result = install_row :: binaries_row :: rpc_row :: "" :: instance_rows_trimmed in
+  let result =
+    install_row :: binaries_row :: rpc_row :: "" :: instance_rows_trimmed
+  in
   if external_line_count > 0 then
     let separator = Widgets.dim (String.make (min cols 120) '-') in
     result @ [""; separator] @ external_lines
@@ -849,7 +852,8 @@ let table_lines ?(cols = 80) ?(visible_height = 20) state =
     let external_rows =
       if external_rows = [] then [] else "" :: external_rows
     in
-    install_row :: binaries_row :: rpc_row :: "" :: "  No managed instances." :: external_rows
+    install_row :: binaries_row :: rpc_row :: "" :: "  No managed instances."
+    :: external_rows
   else if num_columns <= 1 then table_lines_single state
   else
     (* For matrix layout, subtract for menu rows (install + separator) *)

--- a/src/ui/pages/rpc_browser/rpc_browser.ml
+++ b/src/ui/pages/rpc_browser/rpc_browser.ml
@@ -47,9 +47,11 @@ let init () =
         | `Succeeded ->
             (* Clear rpc_describe cache so new OpenAPI entries are used *)
             Rpc_describe.clear_cache () ;
-            Context.toast_info "OpenAPI specs ready - public nodes now browsable"
+            Context.toast_info
+              "OpenAPI specs ready - public nodes now browsable"
         | `Failed msg ->
-            Context.toast_warn (Printf.sprintf "OpenAPI download failed: %s" msg)
+            Context.toast_warn
+              (Printf.sprintf "OpenAPI download failed: %s" msg)
         | `Cancelled -> ())
       () ;
   (* Load local node instances *)
@@ -70,11 +72,11 @@ let init () =
         State.clear_selected_instance () ;
         (* Include selected instance + local nodes (selected first) *)
         let is_same svc =
-          svc.Octez_manager_lib.Service.rpc_addr = service.Octez_manager_lib.Service.rpc_addr
+          svc.Octez_manager_lib.Service.rpc_addr
+          = service.Octez_manager_lib.Service.rpc_addr
         in
         service :: List.filter (fun svc -> not (is_same svc)) local_nodes
-    | None ->
-        local_nodes
+    | None -> local_nodes
   in
   let state = State.init ~instances:nodes in
   state_ref := Some state ;
@@ -247,7 +249,10 @@ let view ps ~focus ~size =
             }
           in
           let left_lines =
-            Rpc_browser_render_list.render ~focus:browser_focus ~state:left_state ~cols:left_width
+            Rpc_browser_render_list.render
+              ~focus:browser_focus
+              ~state:left_state
+              ~cols:left_width
           in
           let left =
             if browser_focus then
@@ -295,15 +300,16 @@ let view ps ~focus ~size =
                   };
             }
           in
-          let lines = Rpc_browser_render_list.render ~focus ~state:left_state ~cols in
+          let lines =
+            Rpc_browser_render_list.render ~focus ~state:left_state ~cols
+          in
           let pager_ids = State.get_pager_ids s in
           let focused = State.get_focused_pager_id s in
           let tabs_plain =
-            pager_ids
-            |> List.sort compare
+            pager_ids |> List.sort compare
             |> List.map (fun id ->
-                   if id = focused then Printf.sprintf "[%d*]" id
-                   else Printf.sprintf "[%d]" id)
+                if id = focused then Printf.sprintf "[%d*]" id
+                else Printf.sprintf "[%d]" id)
             |> String.concat ""
           in
           let header_text = " ▶▶ BROWSER ◀◀  → Pager " ^ tabs_plain ^ " " in
@@ -319,11 +325,10 @@ let view ps ~focus ~size =
           let pager_ids = State.get_pager_ids s in
           let focused = State.get_focused_pager_id s in
           let tabs_plain =
-            pager_ids
-            |> List.sort compare
+            pager_ids |> List.sort compare
             |> List.map (fun id ->
-                   if id = focused then Printf.sprintf "[%d*]" id
-                   else Printf.sprintf "[%d]" id)
+                if id = focused then Printf.sprintf "[%d*]" id
+                else Printf.sprintf "[%d]" id)
             |> String.concat ""
           in
           let header_text = " ← Browser  ▶▶ PAGER " ^ tabs_plain ^ " ◀◀ " in
@@ -371,249 +376,271 @@ let handle_key ps key ~size =
         pending_chord := None ;
         ps
     | None -> (
-        (* Check for C-x prefix *)
-        if key = "C-x" then (
+        if
+          (* Check for C-x prefix *)
+          key = "C-x"
+        then (
           pending_chord := Some "C-x" ;
           ps)
         else
           match s.State.mode with
-    | State.List _ -> (
-        (* Check for shortcut keys (1-9) when at root *)
-        let shortcut_keys = ["1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9"] in
-        let is_shortcut_key =
-          s.State.path = [] && List.exists (fun k -> key = k) shortcut_keys
-        in
-        if is_shortcut_key then
-          let handled = Actions.execute_shortcut ~key s update_state in
-          if handled then
-            match !state_ref with
-            | Some new_s -> Navigation.update (fun _ -> new_s) ps
-            | None -> ps
-          else ps
-        else
-          match Keys.of_string key with
-          | Some Keys.Escape -> back ps
-          | Some Keys.Enter -> (
-              Actions.handle_enter s update_state ;
-              match !state_ref with
-              | Some new_s -> Navigation.update (fun _ -> new_s) ps
-              | None -> ps)
-          | Some Keys.Up | Some (Keys.Char "k") ->
-              let new_state = State.cursor_up s in
-              state_ref := Some new_state ;
-              Navigation.update (fun _ -> new_state) ps
-          | Some Keys.Down | Some (Keys.Char "j") ->
-              let new_state = State.cursor_down s in
-              state_ref := Some new_state ;
-              Navigation.update (fun _ -> new_state) ps
-          | Some (Keys.Char "u") | Some Keys.Backspace -> back ps
-          | Some (Keys.Char "r") -> refresh ps
-          | _ -> ps)
-    | State.Result _ -> (
-        let result_focus = State.get_result_focus s in
-        let is_browser_focused =
-          match result_focus with State.FocusBrowser -> true | _ -> false
-        in
-        (* Handle save key - saves the focused pager's content *)
-        if key = "s" then (
-          match State.get_focused_pager s with
-          | Some slot when slot.State.raw_body <> "" -> (
-              (* Save to file - use raw JSON (unfolded, no colors) *)
-              let filename =
-                let base =
-                  slot.State.request |> String.split_on_char '/'
-                  |> List.filter (fun str -> str <> "")
-                  |> String.concat "_"
-                in
-                Printf.sprintf
-                  "rpc_%s_%d.json"
-                  base
-                  (int_of_float (Unix.time ()))
+          | State.List _ -> (
+              (* Check for shortcut keys (1-9) when at root *)
+              let shortcut_keys =
+                ["1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9"]
               in
-              try
-                let oc = open_out filename in
-                output_string oc slot.State.raw_body ;
-                close_out oc ;
-                let new_state =
-                  State.set_error (Printf.sprintf "Saved to %s" filename) s
+              let is_shortcut_key =
+                s.State.path = []
+                && List.exists (fun k -> key = k) shortcut_keys
+              in
+              if is_shortcut_key then
+                let handled = Actions.execute_shortcut ~key s update_state in
+                if handled then
+                  match !state_ref with
+                  | Some new_s -> Navigation.update (fun _ -> new_s) ps
+                  | None -> ps
+                else ps
+              else
+                match Keys.of_string key with
+                | Some Keys.Escape -> back ps
+                | Some Keys.Enter -> (
+                    Actions.handle_enter s update_state ;
+                    match !state_ref with
+                    | Some new_s -> Navigation.update (fun _ -> new_s) ps
+                    | None -> ps)
+                | Some Keys.Up | Some (Keys.Char "k") ->
+                    let new_state = State.cursor_up s in
+                    state_ref := Some new_state ;
+                    Navigation.update (fun _ -> new_state) ps
+                | Some Keys.Down | Some (Keys.Char "j") ->
+                    let new_state = State.cursor_down s in
+                    state_ref := Some new_state ;
+                    Navigation.update (fun _ -> new_state) ps
+                | Some (Keys.Char "u") | Some Keys.Backspace -> back ps
+                | Some (Keys.Char "r") -> refresh ps
+                | _ -> ps)
+          | State.Result _ -> (
+              let result_focus = State.get_result_focus s in
+              let is_browser_focused =
+                match result_focus with
+                | State.FocusBrowser -> true
+                | _ -> false
+              in
+              (* Handle save key - saves the focused pager's content *)
+              if key = "s" then (
+                match State.get_focused_pager s with
+                | Some slot when slot.State.raw_body <> "" -> (
+                    (* Save to file - use raw JSON (unfolded, no colors) *)
+                    let filename =
+                      let base =
+                        slot.State.request |> String.split_on_char '/'
+                        |> List.filter (fun str -> str <> "")
+                        |> String.concat "_"
+                      in
+                      Printf.sprintf
+                        "rpc_%s_%d.json"
+                        base
+                        (int_of_float (Unix.time ()))
+                    in
+                    try
+                      let oc = open_out filename in
+                      output_string oc slot.State.raw_body ;
+                      close_out oc ;
+                      let new_state =
+                        State.set_error
+                          (Printf.sprintf "Saved to %s" filename)
+                          s
+                      in
+                      state_ref := Some new_state ;
+                      Navigation.update (fun _ -> new_state) ps
+                    with exn ->
+                      let new_state =
+                        State.set_error
+                          (Printf.sprintf
+                             "Save failed: %s"
+                             (Printexc.to_string exn))
+                          s
+                      in
+                      state_ref := Some new_state ;
+                      Navigation.update (fun _ -> new_state) ps)
+                | _ ->
+                    let new_state = State.set_error "No content to save" s in
+                    state_ref := Some new_state ;
+                    Navigation.update (fun _ -> new_state) ps
+                    (* Handle split key - create new pager *))
+              else if key = "S" then (
+                match State.add_pager s with
+                | Some new_state ->
+                    (* Keep focus on browser after creating pager *)
+                    let new_state = State.focus_browser new_state in
+                    state_ref := Some new_state ;
+                    Navigation.update (fun _ -> new_state) ps
+                | None ->
+                    let new_state =
+                      State.set_error "Maximum pagers reached (10)" s
+                    in
+                    state_ref := Some new_state ;
+                    Navigation.update (fun _ -> new_state) ps
+                    (* Handle close pager key *))
+              else if key = "x" then (
+                let focused_id = State.get_focused_pager_id s in
+                match State.remove_pager focused_id s with
+                | Some new_state ->
+                    state_ref := Some new_state ;
+                    Navigation.update (fun _ -> new_state) ps
+                | None ->
+                    let new_state =
+                      State.set_error "Cannot close last pager" s
+                    in
+                    state_ref := Some new_state ;
+                    Navigation.update (fun _ -> new_state) ps
+                (* Handle target instance selection *))
+              else if key = "@" || key = "t" then
+                (* Open modal to select target instance with sections *)
+                let all_instances = State.get_instances s in
+                (* Local instances have non-empty data_dir or app_bin_dir *)
+                let is_local svc =
+                  svc.Octez_manager_lib.Service.data_dir <> ""
+                  || svc.Octez_manager_lib.Service.app_bin_dir <> ""
                 in
-                state_ref := Some new_state ;
-                Navigation.update (fun _ -> new_state) ps
-              with exn ->
-                let new_state =
-                  State.set_error
-                    (Printf.sprintf "Save failed: %s" (Printexc.to_string exn))
-                    s
+                let local = List.filter is_local all_instances in
+                let public = State.public_nodes () in
+                let items =
+                  (if local <> [] then
+                     `Header "── Local Instances ──"
+                     :: List.map (fun svc -> `Instance svc) local
+                   else [])
+                  @
+                  if public <> [] then
+                    `Header "── Public Nodes ──"
+                    :: List.map (fun svc -> `Instance svc) public
+                  else []
                 in
+                if items = [] then (
+                  let new_state = State.set_error "No instances available" s in
+                  state_ref := Some new_state ;
+                  Navigation.update (fun _ -> new_state) ps)
+                else (
+                  Modal_helpers.open_choice_modal
+                    ~title:"Select target instance for pager"
+                    ~items
+                    ~to_string:(function
+                      | `Header h -> h
+                      | `Instance svc ->
+                          let name = svc.Octez_manager_lib.Service.instance in
+                          let network = svc.Octez_manager_lib.Service.network in
+                          Printf.sprintf "  %s (%s)" name network)
+                    ~on_select:(function
+                      | `Header _ -> ()
+                      | `Instance svc -> (
+                          match !state_ref with
+                          | Some current_state ->
+                              let new_state =
+                                State.set_pager_target (Some svc) current_state
+                              in
+                              state_ref := Some new_state ;
+                              update_state new_state
+                          | None -> ()))
+                    () ;
+                  ps)
+                (* Handle shortcut keys 1-9, but not if pager is in input mode *)
+              else if String.length key = 1 && key.[0] >= '1' && key.[0] <= '9'
+              then
+                (* Check if pager is in search/input mode - if so, pass to pager *)
+                let pager_in_input_mode =
+                  match State.get_pager s with
+                  | Some p -> p.Pager.input_mode <> `None
+                  | None -> false
+                in
+                if pager_in_input_mode then
+                  (* Let pager handle digit keys in search mode *)
+                  match State.get_pager s with
+                  | Some pager ->
+                      let win = size.LTerm_geom.rows - 3 in
+                      let pager', _consumed =
+                        Pager.handle_key pager ~key ~win
+                      in
+                      let new_state = State.set_pager pager' s in
+                      state_ref := Some new_state ;
+                      Navigation.update (fun _ -> new_state) ps
+                  | None -> ps
+                else
+                  let handled = Actions.execute_shortcut ~key s update_state in
+                  if handled then
+                    match !state_ref with
+                    | Some new_s -> Navigation.update (fun _ -> new_s) ps
+                    | None -> ps
+                  else ps (* Handle fold keys *)
+              else if key = "f" then (
+                (* Fold all sections *)
+                let new_state = State.fold_all_json s in
                 state_ref := Some new_state ;
                 Navigation.update (fun _ -> new_state) ps)
-          | _ ->
-              let new_state = State.set_error "No content to save" s in
-              state_ref := Some new_state ;
-              Navigation.update (fun _ -> new_state) ps
-              (* Handle split key - create new pager *))
-        else if key = "S" then (
-          match State.add_pager s with
-          | Some new_state ->
-              (* Keep focus on browser after creating pager *)
-              let new_state = State.focus_browser new_state in
-              state_ref := Some new_state ;
-              Navigation.update (fun _ -> new_state) ps
-          | None ->
-              let new_state = State.set_error "Maximum pagers reached (10)" s in
-              state_ref := Some new_state ;
-              Navigation.update (fun _ -> new_state) ps
-              (* Handle close pager key *))
-        else if key = "x" then (
-          let focused_id = State.get_focused_pager_id s in
-          match State.remove_pager focused_id s with
-          | Some new_state ->
-              state_ref := Some new_state ;
-              Navigation.update (fun _ -> new_state) ps
-          | None ->
-              let new_state = State.set_error "Cannot close last pager" s in
-              state_ref := Some new_state ;
-              Navigation.update (fun _ -> new_state) ps
-          (* Handle target instance selection *))
-        else if key = "@" || key = "t" then (
-          (* Open modal to select target instance with sections *)
-          let all_instances = State.get_instances s in
-          (* Local instances have non-empty data_dir or app_bin_dir *)
-          let is_local svc =
-            svc.Octez_manager_lib.Service.data_dir <> ""
-            || svc.Octez_manager_lib.Service.app_bin_dir <> ""
-          in
-          let local = List.filter is_local all_instances in
-          let public = State.public_nodes () in
-          let items =
-            (if local <> [] then
-               `Header "── Local Instances ──"
-               :: List.map (fun svc -> `Instance svc) local
-             else [])
-            @ (if public <> [] then
-                 `Header "── Public Nodes ──"
-                 :: List.map (fun svc -> `Instance svc) public
-               else [])
-          in
-          if items = [] then (
-            let new_state = State.set_error "No instances available" s in
-            state_ref := Some new_state ;
-            Navigation.update (fun _ -> new_state) ps)
-          else (
-            Modal_helpers.open_choice_modal
-              ~title:"Select target instance for pager"
-              ~items
-              ~to_string:(function
-                | `Header h -> h
-                | `Instance svc ->
-                    let name = svc.Octez_manager_lib.Service.instance in
-                    let network = svc.Octez_manager_lib.Service.network in
-                    Printf.sprintf "  %s (%s)" name network)
-              ~on_select:(function
-                | `Header _ -> ()
-                | `Instance svc ->
-                    match !state_ref with
-                    | Some current_state ->
-                        let new_state = State.set_pager_target (Some svc) current_state in
-                        state_ref := Some new_state ;
-                        update_state new_state
-                    | None -> ())
-              () ;
-            ps)
-          (* Handle shortcut keys 1-9, but not if pager is in input mode *))
-        else if String.length key = 1 && key.[0] >= '1' && key.[0] <= '9' then (
-          (* Check if pager is in search/input mode - if so, pass to pager *)
-          let pager_in_input_mode =
-            match State.get_pager s with
-            | Some p -> p.Pager.input_mode <> `None
-            | None -> false
-          in
-          if pager_in_input_mode then
-            (* Let pager handle digit keys in search mode *)
-            match State.get_pager s with
-            | Some pager ->
-                let win = size.LTerm_geom.rows - 3 in
-                let pager', _consumed = Pager.handle_key pager ~key ~win in
-                let new_state = State.set_pager pager' s in
+              else if key = "F" then (
+                (* Unfold all sections *)
+                let new_state = State.unfold_all_json s in
                 state_ref := Some new_state ;
-                Navigation.update (fun _ -> new_state) ps
-            | None -> ps
-          else
-            let handled = Actions.execute_shortcut ~key s update_state in
-            if handled then
-              match !state_ref with
-              | Some new_s -> Navigation.update (fun _ -> new_s) ps
-              | None -> ps
-            else ps)
-          (* Handle fold keys *)
-        else if key = "f" then (
-          (* Fold all sections *)
-          let new_state = State.fold_all_json s in
-          state_ref := Some new_state ;
-          Navigation.update (fun _ -> new_state) ps)
-        else if key = "F" then (
-          (* Unfold all sections *)
-          let new_state = State.unfold_all_json s in
-          state_ref := Some new_state ;
-          Navigation.update (fun _ -> new_state) ps)
-        else if is_browser_focused then
-          (* Browser panel navigation in Result mode *)
-          match Keys.of_string key with
-          | Some Keys.Escape -> back ps
-          | Some (Keys.Char "u") | Some Keys.Backspace -> (
-              (* Navigate back in browser while staying in Result mode *)
-              Actions.navigate_cached_back s update_state ;
-              match !state_ref with
-              | Some new_s -> Navigation.update (fun _ -> new_s) ps
-              | None -> ps)
-          | Some Keys.Up | Some (Keys.Char "k") ->
-              let new_state = State.cached_cursor_up s in
-              state_ref := Some new_state ;
-              Navigation.update (fun _ -> new_state) ps
-          | Some Keys.Down | Some (Keys.Char "j") ->
-              let new_state = State.cached_cursor_down s in
-              state_ref := Some new_state ;
-              Navigation.update (fun _ -> new_state) ps
-          | Some Keys.Enter -> (
-              Actions.handle_cached_enter s update_state ;
-              match !state_ref with
-              | Some new_s -> Navigation.update (fun _ -> new_s) ps
-              | None -> ps)
-          | Some Keys.Right ->
-              (* Switch focus to pager (last focused or 0) *)
-              let pager_id = State.get_focused_pager_id s in
-              let new_state = State.focus_pager pager_id s in
-              state_ref := Some new_state ;
-              Navigation.update (fun _ -> new_state) ps
-          | _ -> ps
-        else
-          (* Pager-focused handling *)
-          match Keys.of_string key with
-          | Some Keys.Escape -> back ps
-          | Some Keys.Left ->
-              (* Switch focus to browser panel *)
-              let new_state = State.focus_browser s in
-              state_ref := Some new_state ;
-              Navigation.update (fun _ -> new_state) ps
-          | Some (Keys.Char " ") -> (
-              (* Toggle fold at cursor position (uses pager cursor mode) *)
-              match State.get_pager s with
-              | Some pager ->
-                  let line = Pager.get_cursor_line pager in
-                  let new_state = State.toggle_fold ~line s in
-                  state_ref := Some new_state ;
-                  Navigation.update (fun _ -> new_state) ps
-              | None -> ps)
-          | _ -> (
-              (* Delegate to pager for all other keys *)
-              match State.get_pager s with
-              | Some pager ->
-                  let win = size.LTerm_geom.rows - 3 in
-                  let pager', _consumed = Pager.handle_key pager ~key ~win in
-                  let new_state = State.set_pager pager' s in
-                  state_ref := Some new_state ;
-                  Navigation.update (fun _ -> new_state) ps
-              | None -> ps)))
+                Navigation.update (fun _ -> new_state) ps)
+              else if is_browser_focused then
+                (* Browser panel navigation in Result mode *)
+                match Keys.of_string key with
+                | Some Keys.Escape -> back ps
+                | Some (Keys.Char "u") | Some Keys.Backspace -> (
+                    (* Navigate back in browser while staying in Result mode *)
+                    Actions.navigate_cached_back s update_state ;
+                    match !state_ref with
+                    | Some new_s -> Navigation.update (fun _ -> new_s) ps
+                    | None -> ps)
+                | Some Keys.Up | Some (Keys.Char "k") ->
+                    let new_state = State.cached_cursor_up s in
+                    state_ref := Some new_state ;
+                    Navigation.update (fun _ -> new_state) ps
+                | Some Keys.Down | Some (Keys.Char "j") ->
+                    let new_state = State.cached_cursor_down s in
+                    state_ref := Some new_state ;
+                    Navigation.update (fun _ -> new_state) ps
+                | Some Keys.Enter -> (
+                    Actions.handle_cached_enter s update_state ;
+                    match !state_ref with
+                    | Some new_s -> Navigation.update (fun _ -> new_s) ps
+                    | None -> ps)
+                | Some Keys.Right ->
+                    (* Switch focus to pager (last focused or 0) *)
+                    let pager_id = State.get_focused_pager_id s in
+                    let new_state = State.focus_pager pager_id s in
+                    state_ref := Some new_state ;
+                    Navigation.update (fun _ -> new_state) ps
+                | _ -> ps
+              else
+                (* Pager-focused handling *)
+                match Keys.of_string key with
+                | Some Keys.Escape -> back ps
+                | Some Keys.Left ->
+                    (* Switch focus to browser panel *)
+                    let new_state = State.focus_browser s in
+                    state_ref := Some new_state ;
+                    Navigation.update (fun _ -> new_state) ps
+                | Some (Keys.Char " ") -> (
+                    (* Toggle fold at cursor position (uses pager cursor mode) *)
+                    match State.get_pager s with
+                    | Some pager ->
+                        let line = Pager.get_cursor_line pager in
+                        let new_state = State.toggle_fold ~line s in
+                        state_ref := Some new_state ;
+                        Navigation.update (fun _ -> new_state) ps
+                    | None -> ps)
+                | _ -> (
+                    (* Delegate to pager for all other keys *)
+                    match State.get_pager s with
+                    | Some pager ->
+                        let win = size.LTerm_geom.rows - 3 in
+                        let pager', _consumed =
+                          Pager.handle_key pager ~key ~win
+                        in
+                        let new_state = State.set_pager pager' s in
+                        state_ref := Some new_state ;
+                        Navigation.update (fun _ -> new_state) ps
+                    | None -> ps)))
 
 let has_modal _ = Miaou.Core.Modal_manager.has_active ()
 

--- a/src/ui/pages/rpc_browser/rpc_browser_actions.ml
+++ b/src/ui/pages/rpc_browser/rpc_browser_actions.ml
@@ -99,13 +99,14 @@ let fetch_entries_sync state =
       (* Expand Dyn entries to include recent values *)
       let expand_entry (e : Rpc_describe.entry) =
         match e.Rpc_describe.kind with
-        | Rpc_describe.Sub -> [{State.name = e.Rpc_describe.name; kind = State.Sub}]
-        | Rpc_describe.Get -> [{State.name = e.Rpc_describe.name; kind = State.Get}]
+        | Rpc_describe.Sub ->
+            [{State.name = e.Rpc_describe.name; kind = State.Sub}]
+        | Rpc_describe.Get ->
+            [{State.name = e.Rpc_describe.name; kind = State.Get}]
         | Rpc_describe.Dyn typ ->
             (* Get recent values for this type, limit to 5 *)
             let recent =
-              State.get_recent_values ~segment_type:typ state
-              |> fun lst ->
+              State.get_recent_values ~segment_type:typ state |> fun lst ->
               if List.length lst > 5 then List.filteri (fun i _ -> i < 5) lst
               else lst
             in
@@ -113,11 +114,15 @@ let fetch_entries_sync state =
             let recent_entries =
               List.map
                 (fun value ->
-                  {State.name = "<>" ^ value; kind = State.DynValue (typ, value)})
+                  {
+                    State.name = "<>" ^ value;
+                    kind = State.DynValue (typ, value);
+                  })
                 recent
             in
             (* Add the original Dyn entry after recent values *)
-            recent_entries @ [{State.name = e.Rpc_describe.name; kind = State.Dyn typ}]
+            recent_entries
+            @ [{State.name = e.Rpc_describe.name; kind = State.Dyn typ}]
       in
       let state_entries = List.concat_map expand_entry entries in
       (* Add [change target] button at the top *)
@@ -196,7 +201,9 @@ let handle_enter state on_update =
             on_update
       | State.DynValue (typ, value) ->
           (* Navigate directly with the recent value, record in history *)
-          let new_state = State.add_dynamic_value ~segment_type:typ ~value state in
+          let new_state =
+            State.add_dynamic_value ~segment_type:typ ~value state
+          in
           let new_state = State.navigate_to value new_state in
           fetch_entries new_state on_update
       | State.ChangeTarget ->
@@ -215,7 +222,8 @@ let handle_enter state on_update =
             match current_target with
             | None -> false
             | Some curr ->
-                curr.Octez_manager_lib.Service.rpc_addr = svc.Octez_manager_lib.Service.rpc_addr
+                curr.Octez_manager_lib.Service.rpc_addr
+                = svc.Octez_manager_lib.Service.rpc_addr
           in
           (* Build items with section headers *)
           let items =
@@ -223,12 +231,14 @@ let handle_enter state on_update =
                `Header "── Local Instances ──"
                :: List.map (fun s -> `Instance s) local
              else [])
-            @ (if public <> [] then
-                 `Header "── Public Nodes ──"
-                 :: List.map (fun s -> `Instance s) public
-               else [])
+            @
+            if public <> [] then
+              `Header "── Public Nodes ──"
+              :: List.map (fun s -> `Instance s) public
+            else []
           in
-          if items = [] then on_update (State.set_error "No instances available" state)
+          if items = [] then
+            on_update (State.set_error "No instances available" state)
           else
             Modal_helpers.open_choice_modal
               ~title:"Select target instance"
@@ -241,10 +251,9 @@ let handle_enter state on_update =
                     let label = Printf.sprintf "%s (%s)" name network in
                     if is_current svc then
                       Miaou_widgets_display.Widgets.fg 14 ("✓ " ^ label)
-                    else
-                      "  " ^ label)
+                    else "  " ^ label)
               ~on_select:(function
-                | `Header _ -> ()  (* Headers not selectable *)
+                | `Header _ -> () (* Headers not selectable *)
                 | `Instance svc ->
                     let new_state = State.set_pager_target (Some svc) state in
                     on_update new_state)
@@ -302,29 +311,35 @@ let fetch_cached_entries state on_update =
       (* Expand Dyn entries to include recent values *)
       let expand_entry (e : Rpc_describe.entry) =
         match e.Rpc_describe.kind with
-        | Rpc_describe.Sub -> [{State.name = e.Rpc_describe.name; kind = State.Sub}]
-        | Rpc_describe.Get -> [{State.name = e.Rpc_describe.name; kind = State.Get}]
+        | Rpc_describe.Sub ->
+            [{State.name = e.Rpc_describe.name; kind = State.Sub}]
+        | Rpc_describe.Get ->
+            [{State.name = e.Rpc_describe.name; kind = State.Get}]
         | Rpc_describe.Dyn typ ->
             let recent =
-              State.get_recent_values ~segment_type:typ state
-              |> fun lst ->
+              State.get_recent_values ~segment_type:typ state |> fun lst ->
               if List.length lst > 5 then List.filteri (fun i _ -> i < 5) lst
               else lst
             in
             let recent_entries =
               List.map
                 (fun value ->
-                  {State.name = "<>" ^ value; kind = State.DynValue (typ, value)})
+                  {
+                    State.name = "<>" ^ value;
+                    kind = State.DynValue (typ, value);
+                  })
                 recent
             in
-            recent_entries @ [{State.name = e.Rpc_describe.name; kind = State.Dyn typ}]
+            recent_entries
+            @ [{State.name = e.Rpc_describe.name; kind = State.Dyn typ}]
       in
       let state_entries = List.concat_map expand_entry entries in
       (* Add [change target] button at the top *)
       let change_target_entry =
         {State.name = "[change target]"; kind = State.ChangeTarget}
       in
-      on_update (State.set_cached_entries (change_target_entry :: state_entries) state)
+      on_update
+        (State.set_cached_entries (change_target_entry :: state_entries) state)
 
 let handle_cached_enter state on_update =
   match State.get_cached_entry state with
@@ -358,7 +373,9 @@ let handle_cached_enter state on_update =
             on_update
       | State.DynValue (typ, value) ->
           (* Navigate directly with the recent value, record in history *)
-          let new_state = State.add_dynamic_value ~segment_type:typ ~value state in
+          let new_state =
+            State.add_dynamic_value ~segment_type:typ ~value state
+          in
           let new_state = State.navigate_cached value new_state in
           fetch_cached_entries new_state on_update
       | State.ChangeTarget ->
@@ -377,7 +394,8 @@ let handle_cached_enter state on_update =
             match current_target with
             | None -> false
             | Some curr ->
-                curr.Octez_manager_lib.Service.rpc_addr = svc.Octez_manager_lib.Service.rpc_addr
+                curr.Octez_manager_lib.Service.rpc_addr
+                = svc.Octez_manager_lib.Service.rpc_addr
           in
           (* Build items with section headers *)
           let items =
@@ -385,12 +403,14 @@ let handle_cached_enter state on_update =
                `Header "── Local Instances ──"
                :: List.map (fun s -> `Instance s) local
              else [])
-            @ (if public <> [] then
-                 `Header "── Public Nodes ──"
-                 :: List.map (fun s -> `Instance s) public
-               else [])
+            @
+            if public <> [] then
+              `Header "── Public Nodes ──"
+              :: List.map (fun s -> `Instance s) public
+            else []
           in
-          if items = [] then on_update (State.set_error "No instances available" state)
+          if items = [] then
+            on_update (State.set_error "No instances available" state)
           else
             Modal_helpers.open_choice_modal
               ~title:"Select target instance"
@@ -403,10 +423,9 @@ let handle_cached_enter state on_update =
                     let label = Printf.sprintf "%s (%s)" name network in
                     if is_current svc then
                       Miaou_widgets_display.Widgets.fg 14 ("✓ " ^ label)
-                    else
-                      "  " ^ label)
+                    else "  " ^ label)
               ~on_select:(function
-                | `Header _ -> ()  (* Headers not selectable *)
+                | `Header _ -> () (* Headers not selectable *)
                 | `Instance svc ->
                     let new_state = State.set_pager_target (Some svc) state in
                     on_update new_state)

--- a/src/ui/pages/rpc_browser/rpc_browser_render_list.ml
+++ b/src/ui/pages/rpc_browser/rpc_browser_render_list.ml
@@ -36,8 +36,7 @@ let render_entry_kind = function
 let render_entry ~cursor ~idx ~focus entry =
   let is_selected = cursor = idx in
   let marker =
-    if is_selected then
-      if focus then Widgets.fg 14 "▸ " else Widgets.dim "▸ "
+    if is_selected then if focus then Widgets.fg 14 "▸ " else Widgets.dim "▸ "
     else "  "
   in
   (* For GET at current path, show [GET] as the name *)
@@ -69,7 +68,8 @@ let render_header ~target ~path =
 
 let render_entries ~cursor ~entries ~focus =
   if entries = [] then [Widgets.dim "  (no entries at this path)"]
-  else List.mapi (fun idx entry -> render_entry ~cursor ~idx ~focus entry) entries
+  else
+    List.mapi (fun idx entry -> render_entry ~cursor ~idx ~focus entry) entries
 
 let render_shortcuts ~state =
   let shortcuts = Rpc_browser_actions.get_shortcuts state in
@@ -114,11 +114,7 @@ let render ~focus ~state ~cols =
     | Some _ as t -> t
     | None -> List.nth_opt state.State.instances state.State.selected_idx
   in
-  let header =
-    render_header
-      ~target
-      ~path:state.State.path
-  in
+  let header = render_header ~target ~path:state.State.path in
   let separator = Widgets.dim (String.make (min 60 cols) '-') in
   match state.State.mode with
   | State.List {entries; cursor; loading} ->
@@ -129,7 +125,8 @@ let render ~focus ~state ~cols =
         if state.State.path = [] then [Widgets.bold "All Endpoints:"] else []
       in
       let content =
-        if loading then [render_loading ()] else render_entries ~cursor ~entries ~focus
+        if loading then [render_loading ()]
+        else render_entries ~cursor ~entries ~focus
       in
       let error_lines = render_error state.State.error in
       let help = render_help () in
@@ -140,4 +137,6 @@ let render ~focus ~state ~cols =
       List.map truncate lines
   | State.Result _ ->
       (* Result mode is handled by a different renderer *)
-      List.map truncate [header; separator; Widgets.dim "  (result mode - use detail renderer)"]
+      List.map
+        truncate
+        [header; separator; Widgets.dim "  (result mode - use detail renderer)"]

--- a/src/ui/pages/rpc_browser/rpc_browser_render_list.mli
+++ b/src/ui/pages/rpc_browser/rpc_browser_render_list.mli
@@ -34,7 +34,8 @@ val render_entry_kind : Rpc_browser_state.entry_kind -> string
     @param idx Entry index
     @param focus Whether the panel has focus (affects cursor highlighting)
     @param entry Entry to render *)
-val render_entry : cursor:int -> idx:int -> focus:bool -> Rpc_browser_state.entry -> string
+val render_entry :
+  cursor:int -> idx:int -> focus:bool -> Rpc_browser_state.entry -> string
 
 (** {1 Status Rendering} *)
 
@@ -51,7 +52,8 @@ val render_error : string option -> string list
     @param state Current RPC Browser state
     @param cols Terminal width (for truncation)
     @return List of rendered lines *)
-val render : focus:bool -> state:Rpc_browser_state.state -> cols:int -> string list
+val render :
+  focus:bool -> state:Rpc_browser_state.state -> cols:int -> string list
 
 (** {1 Help Line} *)
 

--- a/src/ui/pages/rpc_browser/rpc_browser_render_result.ml
+++ b/src/ui/pages/rpc_browser/rpc_browser_render_result.ml
@@ -51,8 +51,7 @@ let render_pager_header ~slot ~is_focused ~is_target =
     | Some svc ->
         let name = svc.Octez_manager_lib.Service.instance in
         (* Truncate long names *)
-        if String.length name > 20 then String.sub name 0 17 ^ "..."
-        else name
+        if String.length name > 20 then String.sub name 0 17 ^ "..." else name
     | None -> "?"
   in
   if is_focused || is_target then
@@ -78,7 +77,13 @@ let render_pager_header ~slot ~is_focused ~is_target =
       | Some s -> Printf.sprintf " %dB" s
       | None -> ""
     in
-    Printf.sprintf "%s @%s GET %s%s%s" marker target_name request_str time_str size_str
+    Printf.sprintf
+      "%s @%s GET %s%s%s"
+      marker
+      target_name
+      request_str
+      time_str
+      size_str
   else
     let id_marker = Printf.sprintf "[%d]" slot.State.id in
     let id_str = Widgets.dim id_marker in
@@ -104,7 +109,13 @@ let render_pager_header ~slot ~is_focused ~is_target =
       | Some s -> Widgets.dim (Printf.sprintf " %dB" s)
       | None -> ""
     in
-    Printf.sprintf "%s %s GET %s%s%s" id_str target_str request_str time_str size_str
+    Printf.sprintf
+      "%s %s GET %s%s%s"
+      id_str
+      target_str
+      request_str
+      time_str
+      size_str
 
 let render_loading () =
   let spinner = Context.render_spinner "" in
@@ -118,7 +129,8 @@ let render_help ~num_pagers =
   let pager_hint = if num_pagers > 1 then "C-x N: pager  " else "" in
   Widgets.dim
     (Printf.sprintf
-       "?: help  %s%s%s1-5: shortcut  Space: fold  f/F: fold  s: save  Esc: back"
+       "?: help  %s%s%s1-5: shortcut  Space: fold  f/F: fold  s: save  Esc: \
+        back"
        split_hint
        close_hint
        pager_hint)
@@ -332,8 +344,8 @@ let split_lines_padded s ~target_lines ~width =
     padded
 
 (** Render a row of pagers horizontally (side-by-side) *)
-let render_pager_row ~pagers ~focused_id ~target_id ~pager_width ~pager_height ~focus
-    ~(result_focus : State.result_focus) =
+let render_pager_row ~pagers ~focused_id ~target_id ~pager_width ~pager_height
+    ~focus ~(result_focus : State.result_focus) =
   if pagers = [] then ""
   else
     let separator_col = Widgets.dim "│" in
@@ -378,8 +390,8 @@ let render_pager_row ~pagers ~focused_id ~target_id ~pager_width ~pager_height ~
     String.concat "\n" combined_lines
 
 (** Render pagers in a grid layout *)
-let render_grid ~pagers ~focused_id ~target_id ~cols ~rows ~grid_cols ~grid_rows ~focus
-    ~(result_focus : State.result_focus) =
+let render_grid ~pagers ~focused_id ~target_id ~cols ~rows ~grid_cols ~grid_rows
+    ~focus ~(result_focus : State.result_focus) =
   let pager_width = cols / grid_cols in
   let pager_height = rows / grid_rows in
   let separator_row = Widgets.dim (String.make cols '-') in
@@ -458,7 +470,12 @@ let render ~state ~cols ~rows ~focus =
           && match result_focus with State.FocusBrowser -> true | _ -> false
         in
         let content =
-          render_single_pager ~slot ~cols ~rows:(rows - 2) ~is_focused ~is_target
+          render_single_pager
+            ~slot
+            ~cols
+            ~rows:(rows - 2)
+            ~is_focused
+            ~is_target
         in
         Printf.sprintf "%s\n%s%s" content error_line help
       else

--- a/src/ui/pages/rpc_browser/rpc_browser_render_result.mli
+++ b/src/ui/pages/rpc_browser/rpc_browser_render_result.mli
@@ -25,7 +25,10 @@ val min_pager_rows : int
     @param is_focused Whether this pager is focused
     @param is_target Whether this pager is the target for next RPC result *)
 val render_pager_header :
-  slot:Rpc_browser_state.pager_slot -> is_focused:bool -> is_target:bool -> string
+  slot:Rpc_browser_state.pager_slot ->
+  is_focused:bool ->
+  is_target:bool ->
+  string
 
 (** {1 Status Rendering} *)
 

--- a/src/ui/pages/rpc_browser/rpc_browser_state.ml
+++ b/src/ui/pages/rpc_browser/rpc_browser_state.ml
@@ -64,7 +64,8 @@ type state = {
   recent_paths : recent_path list;
   cached_entries : entry list;
   cached_cursor : int;
-  target_override : Service.t option;  (** Global target override for RPC calls *)
+  target_override : Service.t option;
+      (** Global target override for RPC calls *)
 }
 
 (* Selected instance override - set by rpc_node_selection page *)
@@ -461,7 +462,11 @@ let set_pager_target target state =
             if p.id = pager_id then {p with target_instance = target} else p)
           pagers
       in
-      {state with mode = Result {pagers = new_pagers; focus; last_pager_id}; target_override = target}
+      {
+        state with
+        mode = Result {pagers = new_pagers; focus; last_pager_id};
+        target_override = target;
+      }
   | List _ -> {state with target_override = target}
 
 let get_pagers state =
@@ -674,7 +679,9 @@ let update_focused_pager_from_foldable state =
                 let pager =
                   Pager.set_cursor_mode pager (Pager.cursor_mode old_p)
                 in
-                let pager = Pager.set_cursor pager (Pager.get_cursor_line old_p) in
+                let pager =
+                  Pager.set_cursor pager (Pager.get_cursor_line old_p)
+                in
                 (* Preserve search query *)
                 Pager.set_search pager old_p.Pager.search
             | None -> Pager.set_cursor_mode pager true

--- a/src/ui/pages/rpc_browser/rpc_browser_state.mli
+++ b/src/ui/pages/rpc_browser/rpc_browser_state.mli
@@ -88,7 +88,8 @@ type state = {
   recent_paths : recent_path list;  (** LRU list of recently used RPC paths *)
   cached_entries : entry list;  (** Cached entries for side-by-side display *)
   cached_cursor : int;  (** Cached cursor position for side-by-side display *)
-  target_override : Service.t option;  (** Global target override for RPC calls *)
+  target_override : Service.t option;
+      (** Global target override for RPC calls *)
 }
 
 (** {1 Selected Instance Override} *)

--- a/src/ui/pages/rpc_node_selection.ml
+++ b/src/ui/pages/rpc_node_selection.ml
@@ -15,7 +15,6 @@ module Widgets = Miaou_widgets_display.Widgets
 module Vsection = Miaou_widgets_layout.Vsection
 module Keys = Miaou.Core.Keys
 module Navigation = Miaou.Core.Navigation
-
 open Octez_manager_lib
 
 let name = "rpc_node_selection"
@@ -163,7 +162,8 @@ let parse_taquito_json (txt : string) : node_item list =
                         | None when provider <> "" -> provider
                         | None -> rpc
                       in
-                      Some {label; rpc_addr = rpc; is_public = true; network = net}
+                      Some
+                        {label; rpc_addr = rpc; is_public = true; network = net}
                 | _ -> None)
               eps
         | _ -> [])
@@ -251,8 +251,12 @@ let back ps = Navigation.back ps
 
 let total_items s =
   (* PUBLIC NODES header + nodes + LOCAL INSTANCES header + instances *)
-  let public_count = if s.public_nodes = [] then 0 else 1 + List.length s.public_nodes in
-  let local_count = if s.local_instances = [] then 0 else 1 + List.length s.local_instances in
+  let public_count =
+    if s.public_nodes = [] then 0 else 1 + List.length s.public_nodes
+  in
+  let local_count =
+    if s.local_instances = [] then 0 else 1 + List.length s.local_instances
+  in
   public_count + local_count
 
 let get_item_at_cursor s =
@@ -307,32 +311,38 @@ let view ps ~focus:_ ~size =
   let lines =
     (* Error/warning *)
     (match s.error with Some e -> [Widgets.yellow e; ""] | None -> [])
-    @ (* PUBLIC NODES section *)
-    [
-      (if s.cursor = public_header_idx then
-         Widgets.bold (Widgets.cyan "> PUBLIC NODES")
-       else Widgets.bold (Widgets.cyan "  PUBLIC NODES"));
-    ]
+    (* PUBLIC NODES section *)
+    @ [
+        (if s.cursor = public_header_idx then
+           Widgets.bold (Widgets.cyan "> PUBLIC NODES")
+         else Widgets.bold (Widgets.cyan "  PUBLIC NODES"));
+      ]
     @ List.mapi
         (fun i item ->
           let idx = 1 + i in
           let prefix = if s.cursor = idx then "> " else "  " in
           let network_str =
-            match item.network with Some n -> Printf.sprintf " [%s]" n | None -> ""
+            match item.network with
+            | Some n -> Printf.sprintf " [%s]" n
+            | None -> ""
           in
           let line =
-            Printf.sprintf "%s%s%s  %s" prefix item.label network_str
+            Printf.sprintf
+              "%s%s%s  %s"
+              prefix
+              item.label
+              network_str
               (Widgets.dim item.rpc_addr)
           in
           if s.cursor = idx then Widgets.bold line else line)
         s.public_nodes
     @ [""]
-    @ (* LOCAL INSTANCES section *)
-    [
-      (if s.cursor = local_header_idx then
-         Widgets.bold (Widgets.green "> LOCAL INSTANCES")
-       else Widgets.bold (Widgets.green "  LOCAL INSTANCES"));
-    ]
+    (* LOCAL INSTANCES section *)
+    @ [
+        (if s.cursor = local_header_idx then
+           Widgets.bold (Widgets.green "> LOCAL INSTANCES")
+         else Widgets.bold (Widgets.green "  LOCAL INSTANCES"));
+      ]
     @
     if s.local_instances = [] then [Widgets.dim "  (no local nodes configured)"]
     else
@@ -341,10 +351,16 @@ let view ps ~focus:_ ~size =
           let idx = local_header_idx + 1 + i in
           let prefix = if s.cursor = idx then "> " else "  " in
           let network_str =
-            match item.network with Some n -> Printf.sprintf " [%s]" n | None -> ""
+            match item.network with
+            | Some n -> Printf.sprintf " [%s]" n
+            | None -> ""
           in
           let line =
-            Printf.sprintf "%s%s%s  %s" prefix item.label network_str
+            Printf.sprintf
+              "%s%s%s  %s"
+              prefix
+              item.label
+              network_str
               (Widgets.dim item.rpc_addr)
           in
           if s.cursor = idx then Widgets.bold line else line)
@@ -354,11 +370,7 @@ let view ps ~focus:_ ~size =
   let header =
     [Widgets.title_highlight " Browse RPCs - Select Node "; ""; hint; ""]
   in
-  Vsection.render
-    ~size
-    ~header
-    ~content_footer:[]
-    ~child:(fun _ ->
+  Vsection.render ~size ~header ~content_footer:[] ~child:(fun _ ->
       let truncate line =
         if Widgets.visible_chars_count line <= cols then line
         else
@@ -393,7 +405,8 @@ let keymap _ps =
     kb "Esc" back "Back";
   ]
 
-let handled_keys () = Keys.[Escape; Enter; Up; Down; Char "j"; Char "k"; Char "r"]
+let handled_keys () =
+  Keys.[Escape; Enter; Up; Down; Char "j"; Char "k"; Char "r"]
 
 let has_modal _ = false
 

--- a/src/ui/public_nodes_cache.ml
+++ b/src/ui/public_nodes_cache.ml
@@ -9,11 +9,7 @@
 
 open Octez_manager_lib
 
-type node_info = {
-  label : string;
-  rpc_addr : string;
-  network : string option;
-}
+type node_info = {label : string; rpc_addr : string; network : string option}
 
 (* Cached public nodes *)
 let cached_nodes : node_info list ref = ref []
@@ -21,10 +17,26 @@ let cached_nodes : node_info list ref = ref []
 (* Curated fallback list *)
 let curated_defaults : node_info list =
   [
-    {label = "ECAD Infra (mainnet)"; rpc_addr = "https://mainnet.tezos.ecadinfra.com"; network = Some "mainnet"};
-    {label = "Tezos Mainnet (ecadlabs)"; rpc_addr = "https://mainnet.api.tez.ie"; network = Some "mainnet"};
-    {label = "Tezos Ghostnet"; rpc_addr = "https://rpc.ghostnet.teztnets.com"; network = Some "ghostnet"};
-    {label = "Tezos Mainnet (SmartPy)"; rpc_addr = "https://mainnet.smartpy.io"; network = Some "mainnet"};
+    {
+      label = "ECAD Infra (mainnet)";
+      rpc_addr = "https://mainnet.tezos.ecadinfra.com";
+      network = Some "mainnet";
+    };
+    {
+      label = "Tezos Mainnet (ecadlabs)";
+      rpc_addr = "https://mainnet.api.tez.ie";
+      network = Some "mainnet";
+    };
+    {
+      label = "Tezos Ghostnet";
+      rpc_addr = "https://rpc.ghostnet.teztnets.com";
+      network = Some "ghostnet";
+    };
+    {
+      label = "Tezos Mainnet (SmartPy)";
+      rpc_addr = "https://mainnet.smartpy.io";
+      network = Some "mainnet";
+    };
   ]
 
 (** Parse Taquito JSON format to extract public nodes *)
@@ -185,5 +197,4 @@ let to_service (info : node_info) : Service.t =
   }
 
 (** Get all public nodes as Service.t list *)
-let get_services () : Service.t list =
-  List.map to_service (get_nodes ())
+let get_services () : Service.t list = List.map to_service (get_nodes ())

--- a/src/ui/rpc_describe.ml
+++ b/src/ui/rpc_describe.ml
@@ -173,7 +173,7 @@ let entries_from_openapi openapi_entries =
         let entry =
           match kind with
           | "__SUB__" -> Some {name; kind = Sub}
-          | "__GET__" -> Some {name = ""; kind = Get}  (* GET at current path *)
+          | "__GET__" -> Some {name = ""; kind = Get} (* GET at current path *)
           | "__DYN__" ->
               (* Extract type from name like "<block_id>" *)
               let typ =
@@ -195,10 +195,10 @@ let fetch_entries (s : Service.t) ~segs =
   | None ->
       (* Try OpenAPI first (works for public nodes without /describe) *)
       let openapi_entries = Rpc_openapi.entries_for ~segs in
-      if openapi_entries <> [] then
+      if openapi_entries <> [] then (
         let entries = entries_from_openapi openapi_entries in
         cache_put ~rpc_addr:s.rpc_addr ~segs ~entries ~source:`None ;
-        (entries, `None)
+        (entries, `None))
       else
         (* Fall back to describe endpoint *)
         let entries, source = fetch_entries_uncached s ~segs in

--- a/src/ui/rpc_openapi.ml
+++ b/src/ui/rpc_openapi.ml
@@ -16,7 +16,7 @@ type endpoint = {template : string; placeholders : string list [@warning "-69"]}
 type node = {
   mutable get : bool;
   statics : (string, node) Hashtbl.t;
-  mutable placeholder_name : string option;  (* e.g., "chain_id", "block_id" *)
+  mutable placeholder_name : string option; (* e.g., "chain_id", "block_id" *)
 }
 
 let current_status = ref NotDownloaded
@@ -47,7 +47,9 @@ let openapi_urls =
 
 (* Memoization for trie building - declared early so download_sync can clear them *)
 let cached_trie : node option ref = ref None
+
 let cached_endpoints : endpoint list ref = ref []
+
 let entries_cache : (string, string list) Hashtbl.t = Hashtbl.create 97
 
 let ensure_dir path =
@@ -192,7 +194,8 @@ let build_trie (eps : endpoint list) : node =
               c
           | None ->
               let c = make_node () in
-              if is_placeholder then c.placeholder_name <- extract_placeholder_name p ;
+              if is_placeholder then
+                c.placeholder_name <- extract_placeholder_name p ;
               Hashtbl.add n.statics key c ;
               c
         in
@@ -367,8 +370,7 @@ let entries_for ~(segs : string list) : string list =
           res)
 
 (** Check if OpenAPI data is available for navigation *)
-let is_available () =
-  match read_spec () with Some _ -> true | None -> false
+let is_available () = match read_spec () with Some _ -> true | None -> false
 
 (** Clear caches (useful when OpenAPI is re-downloaded) *)
 let clear_cache () =

--- a/test/test_cmd_rpc.ml
+++ b/test/test_cmd_rpc.ml
@@ -15,7 +15,10 @@ let test_service_from_url () =
   let url = "https://mainnet.tezos.ecadinfra.com" in
   let svc = Cmd_rpc.service_from_url url in
   Alcotest.(check string) "rpc_addr" url svc.Service.rpc_addr ;
-  Alcotest.(check string) "instance prefix" "url:" (String.sub svc.Service.instance 0 4) ;
+  Alcotest.(check string)
+    "instance prefix"
+    "url:"
+    (String.sub svc.Service.instance 0 4) ;
   Alcotest.(check string) "role" "node" svc.Service.role ;
   Alcotest.(check string) "data_dir empty" "" svc.Service.data_dir
 
@@ -31,27 +34,27 @@ let test_service_from_url_localhost () =
 let test_resolve_service_url_only () =
   let url = "https://mainnet.smartpy.io" in
   match Cmd_rpc.resolve_service None (Some url) None with
-  | Ok svc ->
-      Alcotest.(check string) "rpc_addr" url svc.Service.rpc_addr
+  | Ok svc -> Alcotest.(check string) "rpc_addr" url svc.Service.rpc_addr
   | Error msg -> Alcotest.fail msg
 
 let test_resolve_service_multiple_error () =
   match Cmd_rpc.resolve_service (Some "instance") (Some "url") None with
-  | Error msg ->
-      Alcotest.(check bool) "has error" true (String.length msg > 0)
+  | Error msg -> Alcotest.(check bool) "has error" true (String.length msg > 0)
   | Ok _ -> Alcotest.fail "expected error"
 
 let test_resolve_service_none_error () =
   match Cmd_rpc.resolve_service None None None with
-  | Error msg ->
-      Alcotest.(check bool) "has error" true (String.length msg > 0)
+  | Error msg -> Alcotest.(check bool) "has error" true (String.length msg > 0)
   | Ok _ -> Alcotest.fail "expected error"
 
 let test_resolve_service_public () =
   (* This test depends on having public nodes in cache *)
   match Cmd_rpc.resolve_service None None (Some "1") with
   | Ok svc ->
-      Alcotest.(check bool) "has rpc_addr" true (String.length svc.Service.rpc_addr > 0)
+      Alcotest.(check bool)
+        "has rpc_addr"
+        true
+        (String.length svc.Service.rpc_addr > 0)
   | Error _ ->
       (* Public nodes fetch might fail in test environment, that's ok *)
       ()
@@ -72,7 +75,10 @@ let () =
       ( "resolve_service",
         [
           Alcotest.test_case "url only" `Quick test_resolve_service_url_only;
-          Alcotest.test_case "multiple error" `Quick test_resolve_service_multiple_error;
+          Alcotest.test_case
+            "multiple error"
+            `Quick
+            test_resolve_service_multiple_error;
           Alcotest.test_case "none error" `Quick test_resolve_service_none_error;
           Alcotest.test_case "public node" `Quick test_resolve_service_public;
         ] );

--- a/test/test_public_nodes_cache.ml
+++ b/test/test_public_nodes_cache.ml
@@ -22,7 +22,10 @@ let test_parse_simple_list () =
   Alcotest.(check int) "two nodes" 2 (List.length nodes) ;
   let first = List.hd nodes in
   Alcotest.(check string) "first label" "ECAD Infra" first.label ;
-  Alcotest.(check string) "first rpc" "https://mainnet.ecadinfra.com" first.rpc_addr
+  Alcotest.(check string)
+    "first rpc"
+    "https://mainnet.ecadinfra.com"
+    first.rpc_addr
 
 let test_parse_with_rpc_url () =
   let json =
@@ -33,7 +36,10 @@ let test_parse_with_rpc_url () =
   let nodes = Public_nodes_cache.parse_taquito_json json in
   Alcotest.(check int) "one node" 1 (List.length nodes) ;
   let first = List.hd nodes in
-  Alcotest.(check string) "rpc_url parsed" "https://node.example.com" first.rpc_addr
+  Alcotest.(check string)
+    "rpc_url parsed"
+    "https://node.example.com"
+    first.rpc_addr
 
 let test_parse_taquito_format () =
   let json =
@@ -51,7 +57,10 @@ let test_parse_taquito_format () =
   let nodes = Public_nodes_cache.parse_taquito_json json in
   Alcotest.(check int) "two nodes" 2 (List.length nodes) ;
   let first = List.hd nodes in
-  Alcotest.(check string) "provider name used" "ECAD Infra (mainnet)" first.label
+  Alcotest.(check string)
+    "provider name used"
+    "ECAD Infra (mainnet)"
+    first.label
 
 let test_parse_empty () =
   let json = "[]" in
@@ -74,20 +83,43 @@ let test_parse_missing_rpc () =
 
 let test_to_service () =
   let info : Public_nodes_cache.node_info =
-    {label = "Test Node"; rpc_addr = "https://test.node"; network = Some "mainnet"}
+    {
+      label = "Test Node";
+      rpc_addr = "https://test.node";
+      network = Some "mainnet";
+    }
   in
   let svc = Public_nodes_cache.to_service info in
-  Alcotest.(check string) "instance" "Test Node" svc.Octez_manager_lib.Service.instance ;
-  Alcotest.(check string) "network" "mainnet" svc.Octez_manager_lib.Service.network ;
-  Alcotest.(check string) "rpc_addr" "https://test.node" svc.Octez_manager_lib.Service.rpc_addr ;
-  Alcotest.(check string) "data_dir empty" "" svc.Octez_manager_lib.Service.data_dir
+  Alcotest.(check string)
+    "instance"
+    "Test Node"
+    svc.Octez_manager_lib.Service.instance ;
+  Alcotest.(check string)
+    "network"
+    "mainnet"
+    svc.Octez_manager_lib.Service.network ;
+  Alcotest.(check string)
+    "rpc_addr"
+    "https://test.node"
+    svc.Octez_manager_lib.Service.rpc_addr ;
+  Alcotest.(check string)
+    "data_dir empty"
+    ""
+    svc.Octez_manager_lib.Service.data_dir
 
 let test_to_service_no_network () =
   let info : Public_nodes_cache.node_info =
-    {label = "Unknown Network"; rpc_addr = "https://unknown.node"; network = None}
+    {
+      label = "Unknown Network";
+      rpc_addr = "https://unknown.node";
+      network = None;
+    }
   in
   let svc = Public_nodes_cache.to_service info in
-  Alcotest.(check string) "defaults to mainnet" "mainnet" svc.Octez_manager_lib.Service.network
+  Alcotest.(check string)
+    "defaults to mainnet"
+    "mainnet"
+    svc.Octez_manager_lib.Service.network
 
 (* ============================================================ *)
 (* Test Runner                                                   *)

--- a/test/test_rpc_browser_render_list.ml
+++ b/test/test_rpc_browser_render_list.ml
@@ -88,13 +88,19 @@ let test_entry_selected_focused_has_bold () =
   let entry = {State.name = "chains"; kind = State.Sub} in
   let result = Render.render_entry ~cursor:0 ~idx:0 ~focus:true entry in
   (* Bold ANSI code is \027[1m *)
-  Alcotest.(check bool) "contains bold" true (String.exists (fun c -> c = '\027') result)
+  Alcotest.(check bool)
+    "contains bold"
+    true
+    (String.exists (fun c -> c = '\027') result)
 
 let test_entry_selected_unfocused_has_dim () =
   let entry = {State.name = "chains"; kind = State.Sub} in
   let result = Render.render_entry ~cursor:0 ~idx:0 ~focus:false entry in
   (* Dim ANSI code is \027[2m *)
-  Alcotest.(check bool) "contains ANSI" true (String.exists (fun c -> c = '\027') result)
+  Alcotest.(check bool)
+    "contains ANSI"
+    true
+    (String.exists (fun c -> c = '\027') result)
 
 let test_entry_focus_produces_different_output () =
   let entry = {State.name = "chains"; kind = State.Sub} in

--- a/test/test_rpc_browser_render_result.ml
+++ b/test/test_rpc_browser_render_result.ml
@@ -19,22 +19,30 @@ let make_pager_slot ?(id = 0) ?(request = "") ?(body = "") ?(raw_body = "") () =
 
 let test_render_pager_header_focused () =
   let slot = make_pager_slot ~id:0 ~request:"/chains/main/blocks/head" () in
-  let result = Render.render_pager_header ~slot ~is_focused:true ~is_target:false in
+  let result =
+    Render.render_pager_header ~slot ~is_focused:true ~is_target:false
+  in
   Alcotest.(check bool) "has content" true (String.length result > 0)
 
 let test_render_pager_header_unfocused () =
   let slot = make_pager_slot ~id:1 ~request:"/version" () in
-  let result = Render.render_pager_header ~slot ~is_focused:false ~is_target:false in
+  let result =
+    Render.render_pager_header ~slot ~is_focused:false ~is_target:false
+  in
   Alcotest.(check bool) "has content" true (String.length result > 0)
 
 let test_render_pager_header_target () =
   let slot = make_pager_slot ~id:1 ~request:"/version" () in
-  let result = Render.render_pager_header ~slot ~is_focused:false ~is_target:true in
+  let result =
+    Render.render_pager_header ~slot ~is_focused:false ~is_target:true
+  in
   Alcotest.(check bool) "has content" true (String.length result > 0)
 
 let test_render_pager_header_empty () =
   let slot = make_pager_slot ~id:2 () in
-  let result = Render.render_pager_header ~slot ~is_focused:true ~is_target:false in
+  let result =
+    Render.render_pager_header ~slot ~is_focused:true ~is_target:false
+  in
   Alcotest.(check bool) "has content" true (String.length result > 0)
 
 (* ============================================================ *)

--- a/test/test_rpc_browser_state.ml
+++ b/test/test_rpc_browser_state.ml
@@ -239,8 +239,7 @@ let test_set_pager_target_list_mode () =
   let state = State.init ~instances:[] in
   let state' = State.set_pager_target (Some target) state in
   match state'.target_override with
-  | Some svc ->
-      Alcotest.(check string) "target set" "public-node" svc.instance
+  | Some svc -> Alcotest.(check string) "target set" "public-node" svc.instance
   | None -> Alcotest.fail "expected target_override to be set"
 
 let test_get_pager_target_list_mode () =
@@ -248,8 +247,7 @@ let test_get_pager_target_list_mode () =
   let state = State.init ~instances:[] in
   let state' = State.set_pager_target (Some target) state in
   match State.get_pager_target state' with
-  | Some svc ->
-      Alcotest.(check string) "got target" "public-node" svc.instance
+  | Some svc -> Alcotest.(check string) "got target" "public-node" svc.instance
   | None -> Alcotest.fail "expected target from get_pager_target"
 
 let test_target_override_fallback () =
@@ -272,7 +270,10 @@ let test_new_pager_inherits_target () =
   | Some pager -> (
       match pager.target_instance with
       | Some svc ->
-          Alcotest.(check string) "pager inherits target" "public-node" svc.instance
+          Alcotest.(check string)
+            "pager inherits target"
+            "public-node"
+            svc.instance
       | None -> Alcotest.fail "expected pager to have target_instance")
   | None -> Alcotest.fail "expected focused pager"
 
@@ -288,7 +289,10 @@ let test_add_pager_inherits_target () =
       | Some pager -> (
           match pager.target_instance with
           | Some svc ->
-              Alcotest.(check string) "new pager inherits target" "public-node" svc.instance
+              Alcotest.(check string)
+                "new pager inherits target"
+                "public-node"
+                svc.instance
           | None -> Alcotest.fail "expected new pager to have target_instance")
       | None -> Alcotest.fail "expected focused pager")
   | None -> Alcotest.fail "expected add_pager to succeed"
@@ -347,10 +351,22 @@ let () =
       ( "target_override",
         [
           Alcotest.test_case "initial" `Quick test_target_override_initial;
-          Alcotest.test_case "set in list mode" `Quick test_set_pager_target_list_mode;
-          Alcotest.test_case "get in list mode" `Quick test_get_pager_target_list_mode;
+          Alcotest.test_case
+            "set in list mode"
+            `Quick
+            test_set_pager_target_list_mode;
+          Alcotest.test_case
+            "get in list mode"
+            `Quick
+            test_get_pager_target_list_mode;
           Alcotest.test_case "fallback" `Quick test_target_override_fallback;
-          Alcotest.test_case "enter result inherits" `Quick test_new_pager_inherits_target;
-          Alcotest.test_case "add pager inherits" `Quick test_add_pager_inherits_target;
+          Alcotest.test_case
+            "enter result inherits"
+            `Quick
+            test_new_pager_inherits_target;
+          Alcotest.test_case
+            "add pager inherits"
+            `Quick
+            test_add_pager_inherits_target;
         ] );
     ]


### PR DESCRIPTION
## Summary
- The `docs-only` filter in CI used `dorny/paths-filter` which returns `true` when **any** file matches the pattern, not when **only** those files changed. This caused builds to be skipped on push events that included both source and documentation changes (e.g. `CLAUDE.md` pushed alongside `.ml` files).
- Replace with a `has-source` filter that explicitly detects when source code is changed. Build now runs whenever source files are present, only skips for pure doc changes.
- Apply `dune fmt` to fix 21 files committed unformatted due to this CI bug.

## Test plan
- [ ] CI runs the full build (not docs-only shortcut) for this PR
- [ ] `fmt-check` passes
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)