### PR TITLE
fix: use public gist for coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/trilitech/octez-manager/actions/workflows/coverage.yml"><img src="https://github.com/trilitech/octez-manager/actions/workflows/coverage.yml/badge.svg?branch=main" alt="CI"></a>
-  <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fmathiasbourgoin%2Fcb7983cb493dd84d7e444ac6efaec19c%2Fraw%2Foctez-manager-coverage.json" alt="Coverage">
+  <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fmathiasbourgoin%2Fd7e91c883186314cdbf0ea6844291bd0%2Fraw%2Foctez-manager-coverage.json" alt="Coverage">
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- The coverage badge showed "resource not found" because the gist was created as private (secret)
- Shields.io fetches the gist raw URL unauthenticated, so private gists return 404
- Recreated the gist as public and updated the README badge URL
- Updated `COVERAGE_GIST_ID` repo variable to the new gist ID

## Test plan

- [x] New gist is publicly accessible: `curl -s https://gist.githubusercontent.com/mathiasbourgoin/d7e91c883186314cdbf0ea6844291bd0/raw/octez-manager-coverage.json` returns valid JSON
- [ ] Badge renders correctly on README after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)