### PR TITLE
test(coverage): add pure unit tests for UI page modules

### DIFF
--- a/src/ui/pages/log_viewer_page.ml
+++ b/src/ui/pages/log_viewer_page.ml
@@ -440,6 +440,12 @@ module Page_Impl : Miaou.Core.Tui_page.PAGE_SIG = struct
   let has_modal = has_modal
 end
 
+module For_tests = struct
+  let source_label = function
+    | Log_viewer.Journald -> "journald"
+    | Log_viewer.DailyLogs -> "daily logs"
+end
+
 module Page =
   Monitored_page.Make
     (Page_Impl)

--- a/src/ui/pages/log_viewer_page.mli
+++ b/src/ui/pages/log_viewer_page.mli
@@ -10,3 +10,9 @@ val name : string
 module Page : Miaou.Core.Tui_page.PAGE_SIG
 
 val register : unit -> unit
+
+(** Functions exposed for testing. *)
+module For_tests : sig
+  (** Convert log source to display label. *)
+  val source_label : Octez_manager_lib.Log_viewer.log_source -> string
+end

--- a/test/dune
+++ b/test/dune
@@ -822,6 +822,41 @@
  (instrumentation
   (backend bisect_ppx)))
 
+; Pure coverage tests for UI pages
+
+(test
+ (name test_flows_pure)
+ (libraries
+  alcotest
+  qcheck-core
+  qcheck-alcotest
+  octez_manager_lib
+  octez-manager.ui)
+ (modules test_flows_pure)
+ (instrumentation
+  (backend bisect_ppx)))
+
+(test
+ (name test_snapshots_pure)
+ (libraries alcotest octez_manager_lib octez-manager.ui miaou-core.lib)
+ (modules test_snapshots_pure)
+ (instrumentation
+  (backend bisect_ppx)))
+
+(test
+ (name test_import_wizard_pure)
+ (libraries alcotest octez_manager_lib octez-manager.ui miaou-core.lib)
+ (modules test_import_wizard_pure)
+ (instrumentation
+  (backend bisect_ppx)))
+
+(test
+ (name test_log_viewer_page_pure)
+ (libraries alcotest octez_manager_lib octez-manager.ui)
+ (modules test_log_viewer_page_pure)
+ (instrumentation
+  (backend bisect_ppx)))
+
 ; Fuzz tests (adversarial generators, high iteration count)
 
 (test

--- a/test/test_flows_pure.ml
+++ b/test/test_flows_pure.ml
@@ -1,0 +1,217 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+open Octez_manager_ui
+
+(* ============================================================ *)
+(* is_valid_instance_char Tests                                  *)
+(* ============================================================ *)
+
+let test_valid_lowercase () =
+  Alcotest.(check bool) "lowercase" true (Flows.is_valid_instance_char 'a') ;
+  Alcotest.(check bool) "lowercase z" true (Flows.is_valid_instance_char 'z')
+
+let test_valid_uppercase () =
+  Alcotest.(check bool) "uppercase" true (Flows.is_valid_instance_char 'A') ;
+  Alcotest.(check bool) "uppercase Z" true (Flows.is_valid_instance_char 'Z')
+
+let test_valid_digits () =
+  Alcotest.(check bool) "digit 0" true (Flows.is_valid_instance_char '0') ;
+  Alcotest.(check bool) "digit 9" true (Flows.is_valid_instance_char '9')
+
+let test_valid_special () =
+  Alcotest.(check bool) "dash" true (Flows.is_valid_instance_char '-') ;
+  Alcotest.(check bool) "underscore" true (Flows.is_valid_instance_char '_') ;
+  Alcotest.(check bool) "dot" true (Flows.is_valid_instance_char '.')
+
+let test_invalid_space () =
+  Alcotest.(check bool) "space" false (Flows.is_valid_instance_char ' ')
+
+let test_invalid_special_chars () =
+  Alcotest.(check bool) "at" false (Flows.is_valid_instance_char '@') ;
+  Alcotest.(check bool) "hash" false (Flows.is_valid_instance_char '#') ;
+  Alcotest.(check bool) "slash" false (Flows.is_valid_instance_char '/') ;
+  Alcotest.(check bool) "colon" false (Flows.is_valid_instance_char ':') ;
+  Alcotest.(check bool) "bang" false (Flows.is_valid_instance_char '!')
+
+let test_invalid_null () =
+  Alcotest.(check bool) "null" false (Flows.is_valid_instance_char '\000')
+
+(* ============================================================ *)
+(* instance_has_valid_chars Tests                                *)
+(* ============================================================ *)
+
+let test_valid_name_simple () =
+  Alcotest.(check bool) "simple" true (Flows.instance_has_valid_chars "my-node")
+
+let test_valid_name_complex () =
+  Alcotest.(check bool)
+    "complex"
+    true
+    (Flows.instance_has_valid_chars "node-01.mainnet_v2")
+
+let test_valid_name_empty () =
+  Alcotest.(check bool) "empty" true (Flows.instance_has_valid_chars "")
+
+let test_valid_name_single_char () =
+  Alcotest.(check bool) "single" true (Flows.instance_has_valid_chars "a")
+
+let test_invalid_name_space () =
+  Alcotest.(check bool)
+    "with space"
+    false
+    (Flows.instance_has_valid_chars "my node")
+
+let test_invalid_name_special () =
+  Alcotest.(check bool) "with @" false (Flows.instance_has_valid_chars "node@1")
+
+let test_invalid_name_unicode () =
+  Alcotest.(check bool)
+    "unicode"
+    false
+    (Flows.instance_has_valid_chars "n\xc3\xb6de")
+
+(* ============================================================ *)
+(* strip_node_prefix Tests                                       *)
+(* ============================================================ *)
+
+let test_strip_node_prefix_present () =
+  Alcotest.(check string)
+    "strip node-"
+    "shadownet"
+    (Flows.strip_node_prefix "node-shadownet")
+
+let test_strip_node_prefix_absent () =
+  Alcotest.(check string)
+    "no strip baker"
+    "baker-shadownet"
+    (Flows.strip_node_prefix "baker-shadownet")
+
+let test_strip_node_prefix_empty () =
+  Alcotest.(check string) "empty" "" (Flows.strip_node_prefix "")
+
+let test_strip_node_prefix_just_prefix () =
+  Alcotest.(check string) "just node-" "" (Flows.strip_node_prefix "node-")
+
+let test_strip_node_prefix_no_dash () =
+  Alcotest.(check string)
+    "nodefoo (no dash)"
+    "nodefoo"
+    (Flows.strip_node_prefix "nodefoo")
+
+let test_strip_node_prefix_nested () =
+  Alcotest.(check string)
+    "nested"
+    "node-inner"
+    (Flows.strip_node_prefix "node-node-inner")
+
+(* ============================================================ *)
+(* invalid_instance_name_error_msg Tests                         *)
+(* ============================================================ *)
+
+let contains_substring haystack needle =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  if nlen > hlen then false
+  else
+    let rec aux i =
+      if i > hlen - nlen then false
+      else if String.sub haystack i nlen = needle then true
+      else aux (i + 1)
+    in
+    aux 0
+
+let test_error_msg_not_empty () =
+  Alcotest.(check bool)
+    "not empty"
+    true
+    (String.length Flows.invalid_instance_name_error_msg > 0)
+
+let test_error_msg_contains_invalid () =
+  let msg = String.lowercase_ascii Flows.invalid_instance_name_error_msg in
+  Alcotest.(check bool)
+    "mentions invalid"
+    true
+    (contains_substring msg "invalid")
+
+(* ============================================================ *)
+(* PBT: instance_has_valid_chars consistent with                 *)
+(*      is_valid_instance_char                                   *)
+(* ============================================================ *)
+
+let test_valid_chars_consistency =
+  QCheck.Test.make
+    ~name:"instance_has_valid_chars consistent with is_valid_instance_char"
+    ~count:500
+    QCheck.string
+    (fun s ->
+      let by_forall = String.for_all Flows.is_valid_instance_char s in
+      let by_fn = Flows.instance_has_valid_chars s in
+      by_forall = by_fn)
+
+let test_strip_prefix_no_crash =
+  QCheck.Test.make
+    ~name:"strip_node_prefix never crashes"
+    ~count:500
+    QCheck.string
+    (fun s ->
+      let _ = Flows.strip_node_prefix s in
+      true)
+
+(* ============================================================ *)
+(* Test Runner                                                   *)
+(* ============================================================ *)
+
+let () =
+  Alcotest.run
+    "Flows (pure)"
+    [
+      ( "is_valid_instance_char",
+        [
+          Alcotest.test_case "lowercase" `Quick test_valid_lowercase;
+          Alcotest.test_case "uppercase" `Quick test_valid_uppercase;
+          Alcotest.test_case "digits" `Quick test_valid_digits;
+          Alcotest.test_case "special chars" `Quick test_valid_special;
+          Alcotest.test_case "space" `Quick test_invalid_space;
+          Alcotest.test_case "invalid special" `Quick test_invalid_special_chars;
+          Alcotest.test_case "null byte" `Quick test_invalid_null;
+        ] );
+      ( "instance_has_valid_chars",
+        [
+          Alcotest.test_case "simple valid" `Quick test_valid_name_simple;
+          Alcotest.test_case "complex valid" `Quick test_valid_name_complex;
+          Alcotest.test_case "empty string" `Quick test_valid_name_empty;
+          Alcotest.test_case "single char" `Quick test_valid_name_single_char;
+          Alcotest.test_case "with space" `Quick test_invalid_name_space;
+          Alcotest.test_case "special char" `Quick test_invalid_name_special;
+          Alcotest.test_case "unicode" `Quick test_invalid_name_unicode;
+        ] );
+      ( "strip_node_prefix",
+        [
+          Alcotest.test_case "present" `Quick test_strip_node_prefix_present;
+          Alcotest.test_case "absent" `Quick test_strip_node_prefix_absent;
+          Alcotest.test_case "empty" `Quick test_strip_node_prefix_empty;
+          Alcotest.test_case
+            "just prefix"
+            `Quick
+            test_strip_node_prefix_just_prefix;
+          Alcotest.test_case "no dash" `Quick test_strip_node_prefix_no_dash;
+          Alcotest.test_case "nested" `Quick test_strip_node_prefix_nested;
+        ] );
+      ( "invalid_instance_name_error_msg",
+        [
+          Alcotest.test_case "not empty" `Quick test_error_msg_not_empty;
+          Alcotest.test_case
+            "mentions invalid"
+            `Quick
+            test_error_msg_contains_invalid;
+        ] );
+      ( "PBT",
+        List.map
+          QCheck_alcotest.to_alcotest
+          [test_valid_chars_consistency; test_strip_prefix_no_crash] );
+    ]

--- a/test/test_import_wizard_pure.ml
+++ b/test/test_import_wizard_pure.ml
@@ -1,0 +1,276 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+open Octez_manager_lib
+open Octez_manager_ui
+module Navigation = Miaou.Core.Navigation
+
+(* ============================================================ *)
+(* Helper: create minimal import_wizard state                    *)
+(* ============================================================ *)
+
+let make_state ?(step = Import_wizard.SelectService) ?(external_services = [])
+    ?(selected_idx = 0) ?selected_service ?(strategy = Import.Takeover)
+    ?custom_name ?network_override ?error () : Import_wizard.state =
+  {
+    step;
+    external_services;
+    selected_idx;
+    selected_service;
+    strategy;
+    custom_name;
+    network_override;
+    error;
+  }
+
+let wrap_state s = Navigation.make s
+
+(* ============================================================ *)
+(* move_selection Tests (wrapping mod behavior)                  *)
+(* ============================================================ *)
+
+let make_ext_svc name : External_service.t =
+  let unknown () : _ External_service.field =
+    {value = None; confidence = External_service.Unknown; source = "test"}
+  in
+  let detected v : _ External_service.field =
+    {value = Some v; confidence = External_service.Detected; source = "test"}
+  in
+  {
+    config =
+      {
+        unit_name = name;
+        unit_file_path = None;
+        exec_start = "/usr/bin/octez-node run";
+        unit_state =
+          {active_state = "active"; sub_state = "running"; enabled = Some true};
+        user = None;
+        group = None;
+        working_dir = None;
+        environment_files = [];
+        role = detected External_service.Node;
+        binary_path = unknown ();
+        binary_version = unknown ();
+        data_dir = detected "/tmp";
+        rpc_addr = detected "127.0.0.1:8732";
+        net_addr = unknown ();
+        network = detected "mainnet";
+        history_mode = unknown ();
+        node_endpoint = unknown ();
+        base_dir = unknown ();
+        delegates =
+          {
+            value = Some [];
+            confidence = External_service.Unknown;
+            source = "test";
+          };
+        dal_endpoint = unknown ();
+        daily_logs_dir = None;
+        extra_args = [];
+        parse_warnings = [];
+      };
+    suggested_instance_name = name;
+  }
+
+let test_move_down () =
+  let svcs = [make_ext_svc "a"; make_ext_svc "b"; make_ext_svc "c"] in
+  let ps = wrap_state (make_state ~external_services:svcs ~selected_idx:0 ()) in
+  let ps' = Import_wizard.move_selection ps 1 in
+  Alcotest.(check int) "moved to 1" 1 ps'.Navigation.s.selected_idx
+
+let test_move_up () =
+  let svcs = [make_ext_svc "a"; make_ext_svc "b"; make_ext_svc "c"] in
+  let ps = wrap_state (make_state ~external_services:svcs ~selected_idx:1 ()) in
+  let ps' = Import_wizard.move_selection ps (-1) in
+  Alcotest.(check int) "moved to 0" 0 ps'.Navigation.s.selected_idx
+
+let test_move_wrap_bottom () =
+  let svcs = [make_ext_svc "a"; make_ext_svc "b"; make_ext_svc "c"] in
+  let ps = wrap_state (make_state ~external_services:svcs ~selected_idx:2 ()) in
+  let ps' = Import_wizard.move_selection ps 1 in
+  Alcotest.(check int) "wraps to 0" 0 ps'.Navigation.s.selected_idx
+
+let test_move_wrap_top () =
+  let svcs = [make_ext_svc "a"; make_ext_svc "b"; make_ext_svc "c"] in
+  let ps = wrap_state (make_state ~external_services:svcs ~selected_idx:0 ()) in
+  let ps' = Import_wizard.move_selection ps (-1) in
+  Alcotest.(check int) "wraps to 2" 2 ps'.Navigation.s.selected_idx
+
+let test_move_empty () =
+  let ps = wrap_state (make_state ~external_services:[] ~selected_idx:0 ()) in
+  let ps' = Import_wizard.move_selection ps 1 in
+  Alcotest.(check int) "stays at 0" 0 ps'.Navigation.s.selected_idx
+
+let test_move_single () =
+  let svcs = [make_ext_svc "only"] in
+  let ps = wrap_state (make_state ~external_services:svcs ~selected_idx:0 ()) in
+  let ps' = Import_wizard.move_selection ps 1 in
+  Alcotest.(check int) "stays at 0" 0 ps'.Navigation.s.selected_idx
+
+(* ============================================================ *)
+(* toggle_strategy Tests                                         *)
+(* ============================================================ *)
+
+let strategy_to_string = function
+  | Import.Takeover -> "Takeover"
+  | Import.Clone -> "Clone"
+
+let test_toggle_takeover_to_clone () =
+  let ps = wrap_state (make_state ~strategy:Import.Takeover ()) in
+  let ps' = Import_wizard.toggle_strategy ps in
+  Alcotest.(check string)
+    "becomes Clone"
+    "Clone"
+    (strategy_to_string ps'.Navigation.s.strategy)
+
+let test_toggle_clone_to_takeover () =
+  let ps = wrap_state (make_state ~strategy:Import.Clone ()) in
+  let ps' = Import_wizard.toggle_strategy ps in
+  Alcotest.(check string)
+    "becomes Takeover"
+    "Takeover"
+    (strategy_to_string ps'.Navigation.s.strategy)
+
+let test_toggle_round_trip () =
+  let ps = wrap_state (make_state ~strategy:Import.Takeover ()) in
+  let ps' = Import_wizard.toggle_strategy ps in
+  let ps'' = Import_wizard.toggle_strategy ps' in
+  Alcotest.(check string)
+    "back to Takeover"
+    "Takeover"
+    (strategy_to_string ps''.Navigation.s.strategy)
+
+(* ============================================================ *)
+(* header Tests                                                  *)
+(* ============================================================ *)
+
+let contains_substring haystack needle =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  if nlen > hlen then false
+  else
+    let rec aux i =
+      if i > hlen - nlen then false
+      else if String.sub haystack i nlen = needle then true
+      else aux (i + 1)
+    in
+    aux 0
+
+let test_header_select () =
+  let s = make_state ~step:Import_wizard.SelectService () in
+  let lines = Import_wizard.header s in
+  let joined = String.concat " " lines in
+  Alcotest.(check bool) "mentions Step 1" true (contains_substring joined "1/3")
+
+let test_header_configure () =
+  let s = make_state ~step:Import_wizard.ConfigureImport () in
+  let lines = Import_wizard.header s in
+  let joined = String.concat " " lines in
+  Alcotest.(check bool) "mentions Step 2" true (contains_substring joined "2/3")
+
+let test_header_review () =
+  let s = make_state ~step:Import_wizard.ReviewImport () in
+  let lines = Import_wizard.header s in
+  let joined = String.concat " " lines in
+  Alcotest.(check bool) "mentions Step 3" true (contains_substring joined "3/3")
+
+let test_header_importing () =
+  let s = make_state ~step:Import_wizard.Importing () in
+  let lines = Import_wizard.header s in
+  let joined = String.concat " " lines in
+  Alcotest.(check bool)
+    "mentions Importing"
+    true
+    (contains_substring joined "Importing")
+
+(* ============================================================ *)
+(* handled_keys Tests                                            *)
+(* ============================================================ *)
+
+let test_handled_keys_has_escape () =
+  let keys = Import_wizard.handled_keys () in
+  Alcotest.(check bool) "has Escape" true (List.mem Miaou.Core.Keys.Escape keys)
+
+let test_handled_keys_has_enter () =
+  let keys = Import_wizard.handled_keys () in
+  Alcotest.(check bool) "has Enter" true (List.mem Miaou.Core.Keys.Enter keys)
+
+let test_handled_keys_has_arrows () =
+  let keys = Import_wizard.handled_keys () in
+  Alcotest.(check bool) "has Up" true (List.mem Miaou.Core.Keys.Up keys) ;
+  Alcotest.(check bool) "has Down" true (List.mem Miaou.Core.Keys.Down keys)
+
+(* ============================================================ *)
+(* keymap Tests                                                  *)
+(* ============================================================ *)
+
+let test_keymap_not_empty () =
+  let s = make_state () in
+  let km = Import_wizard.keymap s in
+  Alcotest.(check bool) "not empty" true (List.length km >= 1)
+
+let test_keymap_has_esc () =
+  let s = make_state () in
+  let km = Import_wizard.keymap s in
+  let keys = List.map (fun kb -> kb.Miaou.Core.Tui_page.key) km in
+  Alcotest.(check bool) "has Esc" true (List.mem "Esc" keys)
+
+let test_keymap_has_enter () =
+  let s = make_state () in
+  let km = Import_wizard.keymap s in
+  let keys = List.map (fun kb -> kb.Miaou.Core.Tui_page.key) km in
+  Alcotest.(check bool) "has Enter" true (List.mem "Enter" keys)
+
+(* ============================================================ *)
+(* Test Runner                                                   *)
+(* ============================================================ *)
+
+let () =
+  Alcotest.run
+    "Import_wizard (pure)"
+    [
+      ( "move_selection",
+        [
+          Alcotest.test_case "down" `Quick test_move_down;
+          Alcotest.test_case "up" `Quick test_move_up;
+          Alcotest.test_case "wrap bottom" `Quick test_move_wrap_bottom;
+          Alcotest.test_case "wrap top" `Quick test_move_wrap_top;
+          Alcotest.test_case "empty" `Quick test_move_empty;
+          Alcotest.test_case "single" `Quick test_move_single;
+        ] );
+      ( "toggle_strategy",
+        [
+          Alcotest.test_case
+            "takeover to clone"
+            `Quick
+            test_toggle_takeover_to_clone;
+          Alcotest.test_case
+            "clone to takeover"
+            `Quick
+            test_toggle_clone_to_takeover;
+          Alcotest.test_case "round trip" `Quick test_toggle_round_trip;
+        ] );
+      ( "header",
+        [
+          Alcotest.test_case "select step" `Quick test_header_select;
+          Alcotest.test_case "configure step" `Quick test_header_configure;
+          Alcotest.test_case "review step" `Quick test_header_review;
+          Alcotest.test_case "importing step" `Quick test_header_importing;
+        ] );
+      ( "handled_keys",
+        [
+          Alcotest.test_case "has Escape" `Quick test_handled_keys_has_escape;
+          Alcotest.test_case "has Enter" `Quick test_handled_keys_has_enter;
+          Alcotest.test_case "has arrows" `Quick test_handled_keys_has_arrows;
+        ] );
+      ( "keymap",
+        [
+          Alcotest.test_case "not empty" `Quick test_keymap_not_empty;
+          Alcotest.test_case "has Esc" `Quick test_keymap_has_esc;
+          Alcotest.test_case "has Enter" `Quick test_keymap_has_enter;
+        ] );
+    ]

--- a/test/test_log_viewer_page_pure.ml
+++ b/test/test_log_viewer_page_pure.ml
@@ -1,0 +1,49 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+open Octez_manager_lib
+open Octez_manager_ui
+module FT = Log_viewer_page.For_tests
+
+(* ============================================================ *)
+(* source_label Tests                                            *)
+(* ============================================================ *)
+
+let test_journald_label () =
+  Alcotest.(check string)
+    "journald"
+    "journald"
+    (FT.source_label Log_viewer.Journald)
+
+let test_daily_logs_label () =
+  Alcotest.(check string)
+    "daily logs"
+    "daily logs"
+    (FT.source_label Log_viewer.DailyLogs)
+
+(* ============================================================ *)
+(* name Tests                                                    *)
+(* ============================================================ *)
+
+let test_name () =
+  Alcotest.(check string) "name" "log_viewer" Log_viewer_page.name
+
+(* ============================================================ *)
+(* Test Runner                                                   *)
+(* ============================================================ *)
+
+let () =
+  Alcotest.run
+    "Log_viewer_page (pure)"
+    [
+      ( "source_label",
+        [
+          Alcotest.test_case "journald" `Quick test_journald_label;
+          Alcotest.test_case "daily logs" `Quick test_daily_logs_label;
+        ] );
+      ("name", [Alcotest.test_case "module name" `Quick test_name]);
+    ]

--- a/test/test_snapshots_pure.ml
+++ b/test/test_snapshots_pure.ml
@@ -1,0 +1,182 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+open Octez_manager_ui
+module Lib_snapshots = Octez_manager_lib.Snapshots
+module Navigation = Miaou.Core.Navigation
+
+(* ============================================================ *)
+(* Helper: create minimal entries and state                      *)
+(* ============================================================ *)
+
+let make_entry ?(label = "test") ?download_url () : Lib_snapshots.entry =
+  {
+    network = "mainnet";
+    slug = label;
+    label;
+    download_url;
+    history_mode = None;
+    metadata = [];
+  }
+
+let make_state ?(network = "mainnet") ?(entries = []) ?(selected = 0) ?error ()
+    : Snapshots.state =
+  {network; entries; selected; error}
+
+let wrap_state s = Navigation.make s
+
+(* ============================================================ *)
+(* move_selection Tests                                          *)
+(* ============================================================ *)
+
+let test_move_down () =
+  let entries = [make_entry ~label:"a" (); make_entry ~label:"b" ()] in
+  let ps = wrap_state (make_state ~entries ~selected:0 ()) in
+  let ps' = Snapshots.move_selection ps 1 in
+  Alcotest.(check int) "moved to 1" 1 ps'.Navigation.s.selected
+
+let test_move_up () =
+  let entries = [make_entry ~label:"a" (); make_entry ~label:"b" ()] in
+  let ps = wrap_state (make_state ~entries ~selected:1 ()) in
+  let ps' = Snapshots.move_selection ps (-1) in
+  Alcotest.(check int) "moved to 0" 0 ps'.Navigation.s.selected
+
+let test_move_clamp_bottom () =
+  let entries = [make_entry ~label:"a" (); make_entry ~label:"b" ()] in
+  let ps = wrap_state (make_state ~entries ~selected:1 ()) in
+  let ps' = Snapshots.move_selection ps 1 in
+  Alcotest.(check int) "clamped at 1" 1 ps'.Navigation.s.selected
+
+let test_move_clamp_top () =
+  let entries = [make_entry ~label:"a" (); make_entry ~label:"b" ()] in
+  let ps = wrap_state (make_state ~entries ~selected:0 ()) in
+  let ps' = Snapshots.move_selection ps (-1) in
+  Alcotest.(check int) "clamped at 0" 0 ps'.Navigation.s.selected
+
+let test_move_empty () =
+  let ps = wrap_state (make_state ~entries:[] ~selected:0 ()) in
+  let ps' = Snapshots.move_selection ps 1 in
+  Alcotest.(check int) "stays at 0" 0 ps'.Navigation.s.selected
+
+let test_move_single () =
+  let entries = [make_entry ~label:"only" ()] in
+  let ps = wrap_state (make_state ~entries ~selected:0 ()) in
+  let ps' = Snapshots.move_selection ps 1 in
+  Alcotest.(check int) "stays at 0" 0 ps'.Navigation.s.selected
+
+let test_move_large_delta () =
+  let entries =
+    [
+      make_entry ~label:"a" ();
+      make_entry ~label:"b" ();
+      make_entry ~label:"c" ();
+    ]
+  in
+  let ps = wrap_state (make_state ~entries ~selected:0 ()) in
+  let ps' = Snapshots.move_selection ps 100 in
+  Alcotest.(check int) "clamped at max" 2 ps'.Navigation.s.selected
+
+(* ============================================================ *)
+(* header Tests                                                  *)
+(* ============================================================ *)
+
+let contains_substring haystack needle =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  if nlen > hlen then false
+  else
+    let rec aux i =
+      if i > hlen - nlen then false
+      else if String.sub haystack i nlen = needle then true
+      else aux (i + 1)
+    in
+    aux 0
+
+let test_header_contains_network () =
+  let s = make_state ~network:"mainnet" () in
+  let lines = Snapshots.header s in
+  let joined = String.concat " " lines in
+  Alcotest.(check bool)
+    "contains network"
+    true
+    (contains_substring joined "mainnet")
+
+let test_header_different_network () =
+  let s = make_state ~network:"weeklynet" () in
+  let lines = Snapshots.header s in
+  let joined = String.concat " " lines in
+  Alcotest.(check bool)
+    "contains weeklynet"
+    true
+    (contains_substring joined "weeklynet")
+
+let test_header_length () =
+  let s = make_state () in
+  let lines = Snapshots.header s in
+  Alcotest.(check bool) "has lines" true (List.length lines >= 1)
+
+(* ============================================================ *)
+(* handled_keys Tests                                            *)
+(* ============================================================ *)
+
+let test_handled_keys_has_escape () =
+  let keys = Snapshots.handled_keys () in
+  Alcotest.(check bool) "has Escape" true (List.mem Miaou.Core.Keys.Escape keys)
+
+(* ============================================================ *)
+(* keymap Tests                                                  *)
+(* ============================================================ *)
+
+let test_keymap_not_empty () =
+  let s = make_state () in
+  let km = Snapshots.keymap s in
+  Alcotest.(check bool) "not empty" true (List.length km >= 1)
+
+let test_keymap_has_esc () =
+  let s = make_state () in
+  let km = Snapshots.keymap s in
+  let keys = List.map (fun kb -> kb.Miaou.Core.Tui_page.key) km in
+  Alcotest.(check bool) "has Esc" true (List.mem "Esc" keys)
+
+(* ============================================================ *)
+(* Test Runner                                                   *)
+(* ============================================================ *)
+
+let () =
+  Alcotest.run
+    "Snapshots page (pure)"
+    [
+      ( "move_selection",
+        [
+          Alcotest.test_case "down" `Quick test_move_down;
+          Alcotest.test_case "up" `Quick test_move_up;
+          Alcotest.test_case "clamp bottom" `Quick test_move_clamp_bottom;
+          Alcotest.test_case "clamp top" `Quick test_move_clamp_top;
+          Alcotest.test_case "empty" `Quick test_move_empty;
+          Alcotest.test_case "single" `Quick test_move_single;
+          Alcotest.test_case "large delta" `Quick test_move_large_delta;
+        ] );
+      ( "header",
+        [
+          Alcotest.test_case
+            "contains network"
+            `Quick
+            test_header_contains_network;
+          Alcotest.test_case
+            "different network"
+            `Quick
+            test_header_different_network;
+          Alcotest.test_case "has lines" `Quick test_header_length;
+        ] );
+      ( "handled_keys",
+        [Alcotest.test_case "has Escape" `Quick test_handled_keys_has_escape] );
+      ( "keymap",
+        [
+          Alcotest.test_case "not empty" `Quick test_keymap_not_empty;
+          Alcotest.test_case "has Esc" `Quick test_keymap_has_esc;
+        ] );
+    ]


### PR DESCRIPTION
## Summary
- Add ~60 pure unit tests for `flows`, `snapshots`, `import_wizard`, and `log_viewer_page`
- Test coverage of pure page functions: validation, selection movement, toggle logic, headers, keymaps
- Add `For_tests` module to `log_viewer_page` (which has a restrictive `.mli`)
- Includes QCheck property-based tests for character validation

## Test plan
- [x] `dune build` passes
- [x] `dune runtest` passes
- [x] `dune fmt` passes
- [x] `./scripts/check-copyright.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)