### PR TITLE
docs: add web interface documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 
 - **Install and manage** Octez services as systemd units
 - **Terminal UI** with real-time monitoring and logs
+- **Web interface** for browser-based remote management
 - **RPC Browser** — Interactively explore and query RPC endpoints with syntax highlighting
 - **Snapshot import** from tzinit.org with automatic download
 - **Multiple instances** per service type
@@ -71,10 +72,14 @@ make build
 ### Launch the UI
 
 ```sh
+# Terminal UI
 octez-manager
+
+# Web interface (browser-based, for remote access)
+octez-manager web --port 8080
 ```
 
-The UI provides installation wizards, service monitoring, log viewing, and snapshot management.
+The UI provides installation wizards, service monitoring, log viewing, and snapshot management. The web interface offers the same features accessible from any browser.
 
 ### CLI Examples
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -32,6 +32,8 @@ export default defineConfig({
 						{ label: 'Node Setup', slug: 'guides/node-setup' },
 						{ label: 'DAL Node Setup', slug: 'guides/dal-node-setup' },
 						{ label: 'Baker Setup', slug: 'guides/baker-setup' },
+						{ label: 'Web Interface', slug: 'guides/web-interface' },
+						{ label: 'RPC Browser', slug: 'guides/rpc-browser' },
 					],
 				},
 				{

--- a/docs/src/content/docs/guides/tui-guide.md
+++ b/docs/src/content/docs/guides/tui-guide.md
@@ -9,6 +9,8 @@ This guide walks through common workflows using Shadownet as an example.
 
 > **Tip:** Press `?` at any time to see available actions for the current screen.
 
+> **Remote access:** For browser-based access, see [Web Interface](/guides/web-interface).
+
 ## Getting Started
 
 Launch the TUI:

--- a/docs/src/content/docs/guides/web-interface.md
+++ b/docs/src/content/docs/guides/web-interface.md
@@ -1,0 +1,183 @@
+---
+title: Web Interface
+description: Browser-based remote management for Octez Manager
+---
+
+The web interface provides browser-based access to Octez Manager, enabling remote management without SSH access. It offers the same functionality as the terminal UI through xterm.js terminal emulation.
+
+## Quick Start
+
+```bash
+# Start the web interface
+octez-manager web
+
+# With password protection
+octez-manager web --password mysecret
+
+# Custom port
+octez-manager web --port 8443
+```
+
+Then open `http://your-server:8080` in any browser.
+
+## Features
+
+The web interface provides full access to all Octez Manager functionality:
+
+- **Service management** — Install, start, stop, and configure nodes, bakers, accusers, and DAL nodes
+- **Real-time monitoring** — View service status, sync progress, and system metrics
+- **Log viewing** — Stream and search logs from any service
+- **Binary management** — Download and manage Octez versions
+- **RPC browser** — Explore and query node RPC endpoints
+
+## Authentication
+
+### No Authentication (Development)
+
+```bash
+octez-manager web
+```
+
+Anyone who can reach the server can control your services. Only use this on trusted networks or for local testing.
+
+### Password Protection (Recommended)
+
+```bash
+octez-manager web --password mysecret
+```
+
+Users must enter the password before gaining access. The password is transmitted over the WebSocket connection.
+
+> **Security:** For production use, place the web interface behind a reverse proxy with HTTPS (nginx, Caddy, etc.) to encrypt the connection.
+
+### Controller and Viewer Roles
+
+The web interface supports two access levels:
+
+| Role | Access | URL |
+|------|--------|-----|
+| **Controller** | Full control (read/write) | `http://server:8080/` |
+| **Viewer** | Read-only (observe only) | `http://server:8080/viewer` |
+
+To set separate passwords:
+
+```bash
+octez-manager web --password admin123 --viewer-password viewer123
+```
+
+- Controller password grants full access
+- Viewer password grants read-only access
+- Only one controller can be connected at a time
+- Multiple viewers can observe simultaneously
+
+### Environment Variables
+
+Passwords can be set via environment variables:
+
+```bash
+export MIAOU_WEB_PASSWORD=admin123
+export MIAOU_WEB_VIEWER_PASSWORD=viewer123
+octez-manager web
+```
+
+This is useful for systemd services or container deployments where command-line passwords might be visible in process listings.
+
+## Running as a Service
+
+To run the web interface as a systemd service:
+
+```ini
+# /etc/systemd/system/octez-manager-web.service
+[Unit]
+Description=Octez Manager Web Interface
+After=network.target
+
+[Service]
+Type=simple
+User=root
+Environment=MIAOU_WEB_PASSWORD=your-secure-password
+ExecStart=/usr/local/bin/octez-manager web --port 8080
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable octez-manager-web
+sudo systemctl start octez-manager-web
+```
+
+## Reverse Proxy with HTTPS
+
+For production deployments, use a reverse proxy to add HTTPS encryption.
+
+### Nginx Example
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name octez.example.com;
+
+    ssl_certificate /etc/letsencrypt/live/octez.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/octez.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+### Caddy Example
+
+```
+octez.example.com {
+    reverse_proxy 127.0.0.1:8080
+}
+```
+
+Caddy automatically handles HTTPS certificates.
+
+## Keyboard Shortcuts
+
+The web interface supports the same keyboard shortcuts as the TUI:
+
+| Key | Action |
+|-----|--------|
+| `↑`/`↓` | Navigate list |
+| `Enter` | Select / Open action menu |
+| `Tab` | Fold/unfold instance details |
+| `b` | Open Binaries page |
+| `d` | Open Diagnostics page |
+| `r` | Open RPC Browser |
+| `?` | Show help |
+| `Esc` | Go back / Close modal |
+
+> **Note:** `q` (quit) is disabled in the web interface to prevent accidental disconnection.
+
+## Troubleshooting
+
+### Connection Refused
+
+- Ensure the web server is running: `octez-manager web`
+- Check the port is correct (default: 8080)
+- Verify firewall rules allow the port
+
+### WebSocket Connection Failed
+
+- The web interface requires WebSocket support
+- Check that your reverse proxy is configured for WebSocket upgrades
+- Some corporate firewalls block WebSocket connections
+
+### Terminal Size Issues
+
+The terminal automatically fits to your browser window. If the display looks wrong:
+- Try resizing the browser window
+- Refresh the page
+- Check browser zoom level (100% works best)

--- a/docs/src/content/docs/reference/cli.md
+++ b/docs/src/content/docs/reference/cli.md
@@ -350,6 +350,47 @@ octez-manager [OPTIONS]
 
 > **Note**: When run without arguments, `octez-manager` launches the TUI. Use explicit subcommands for CLI operations.
 
+### `web`
+
+Start the web interface for browser-based remote management.
+
+```bash
+octez-manager web [OPTIONS]
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--port <PORT>`, `-p` | TCP port to listen on | 8080 |
+| `--password <PW>` | Controller password (full access) | none |
+| `--viewer-password <PW>` | Viewer password (read-only access) | same as --password |
+| `--page <NAME>` | Start on a specific page | instances |
+| `--ui-log` | Enable UI debug logs | false |
+| `--ui-logfile <FILE>` | Write UI logs to file | none |
+
+The web interface provides the same functionality as the TUI, accessible from any browser. It uses xterm.js for terminal emulation over WebSocket.
+
+**Authentication:**
+- Without passwords: Anyone can connect
+- With `--password`: Controller access requires authentication
+- With `--viewer-password`: Separate read-only access with different password
+
+Passwords can also be set via environment variables:
+- `MIAOU_WEB_PASSWORD` — Controller password
+- `MIAOU_WEB_VIEWER_PASSWORD` — Viewer password (falls back to controller password)
+
+**Examples:**
+
+```bash
+# Start on default port (8080), no authentication
+octez-manager web
+
+# Custom port with password protection
+octez-manager web --port 8443 --password mysecret
+
+# Separate passwords for controller and viewer
+octez-manager web --password admin123 --viewer-password viewer123
+```
+
 ### `list-available-networks`
 
 Show networks available from teztnets.com.


### PR DESCRIPTION
## Summary

- Add comprehensive Web Interface guide covering setup, authentication, and deployment
- Document `web` command in CLI reference with all options
- Update README to mention web interface feature
- Add cross-reference from TUI guide to web interface
- Add Web Interface and RPC Browser to docs sidebar navigation

## Changes

| File | Change |
|------|--------|
| `README.md` | Add web interface to features list and quick start |
| `docs/src/content/docs/guides/web-interface.md` | New guide for web interface |
| `docs/src/content/docs/reference/cli.md` | Add `web` command documentation |
| `docs/src/content/docs/guides/tui-guide.md` | Link to web interface guide |
| `docs/astro.config.mjs` | Add Web Interface and RPC Browser to sidebar |

## Test plan

- [x] Documentation builds (no broken links)
- [ ] Review content for accuracy