### PR TITLE
refactor(ui): use Grid_layout for instances page column merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **CI optimization**: Docker layer caching for integration tests reduces container build time by 40-60% (2-3 min per run)
 - Diagnostics page now uses bordered boxes (Box_widget) for cleaner visual section separation
 - RPC browser now uses Grid_layout for side-by-side panel rendering
+- Instances page now uses Grid_layout for multi-column layout merging
 
 ### Fixed
 

--- a/src/ui/pages/instances/instances_render.ml
+++ b/src/ui/pages/instances/instances_render.ml
@@ -9,6 +9,7 @@
 
 module Widgets = Miaou_widgets_display.Widgets
 module Vsection = Miaou_widgets_layout.Vsection
+module Grid = Miaou_widgets_layout.Grid_layout
 module Metrics = Rpc_metrics
 open Octez_manager_lib
 open Instances_state
@@ -476,10 +477,12 @@ let dim_inactive_column line =
   (* Wrap entire line in dim formatting *)
   Printf.sprintf "\027[2m%s\027[22m" line
 
-(** Merge multiple column renders into combined lines with per-column scrolling *)
+(** Merge multiple column renders into combined lines with per-column scrolling.
+    Uses Grid_layout for consistent column layout. *)
 let merge_columns ~col_width ~visible_height ~column_scroll ~active_column
     ~columns_content =
   let empty_line = String.make col_width ' ' in
+  let num_columns = Array.length columns_content in
   (* Count non-empty columns for dimming decision *)
   let non_empty_cols =
     Array.fold_left
@@ -514,17 +517,33 @@ let merge_columns ~col_width ~visible_height ~column_scroll ~active_column
         else visible)
       columns_content
   in
-  (* Merge columns line by line *)
-  List.init visible_height (fun row_idx ->
-      let parts =
-        Array.to_list
-          (Array.map
-             (fun col ->
-               if row_idx < List.length col then List.nth col row_idx
-               else empty_line)
-             scrolled_columns)
-      in
-      String.concat column_separator parts)
+  (* Use Grid_layout to merge columns *)
+  let total_width =
+    (col_width * num_columns)
+    + (String.length column_separator * (num_columns - 1))
+  in
+  let cols_spec = List.init num_columns (fun _ -> Grid.Px col_width) in
+  let sep_width = String.length column_separator in
+  let grid_children =
+    Array.to_list
+      (Array.mapi
+         (fun col_idx col ->
+           Grid.cell ~row:0 ~col:col_idx (fun ~size:_ -> String.concat "\n" col))
+         scrolled_columns)
+  in
+  let grid =
+    Grid.create
+      ~rows:[Grid.Fr 1.]
+      ~cols:cols_spec
+      ~col_gap:sep_width
+      grid_children
+  in
+  let rendered =
+    Grid.render
+      grid
+      ~size:{LTerm_geom.rows = visible_height; cols = total_width}
+  in
+  String.split_on_char '\n' rendered
 
 (** Render external services section *)
 let render_external_service ~selected_idx ~current_idx ~folded


### PR DESCRIPTION
## Summary

- Replace manual line-by-line column merging with Miaou's `Grid_layout` widget in the instances page multi-column layout
- Add Grid module alias for `Miaou_widgets_layout.Grid_layout`
- Use `Grid.create` with dynamic column specs based on number of columns
- Preserves per-column scrolling and active column dimming logic
- Grid_layout handles column padding/alignment automatically

## Test plan

- [x] `dune build` passes
- [x] `dune runtest` passes
- [x] `dune fmt` passes
- [ ] Manual testing: verify instances page multi-column layout renders correctly

Closes #632