### PR TITLE
ci: run coverage only on main branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,14 +186,12 @@ jobs:
     name: Integration Tests (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     needs: [changes, build-and-test]
-    # Run fast (non-instrumented) integration tests when:
-    # 1. PR has 'skip-coverage' label (opt-in for faster iteration), OR
-    # 2. Pushing a release tag (fast tests for releases)
-    # Otherwise, coverage workflow runs instrumented tests (slower but collects coverage)
+    # Run fast (non-instrumented) integration tests on:
+    # 1. Pull requests (fast iteration - coverage runs only on main branch)
+    # 2. Release tags (fast validation before release)
     if: |
       needs.changes.outputs.needs-integration == 'true' && 
-      (contains(github.event.pull_request.labels.*.name, 'skip-coverage') ||
-       startsWith(github.ref, 'refs/tags/'))
+      (github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/'))
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,11 +1,9 @@
 name: Coverage Report
 
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches: [main]
+  workflow_dispatch:  # Allow manual trigger for debugging
 
 concurrency:
   group: coverage-${{ github.ref }}
@@ -13,7 +11,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   build-and-test-coverage:
@@ -150,14 +147,9 @@ jobs:
     name: Integration Tests Coverage (Shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     needs: [build-and-test-coverage]
-    # Run instrumented integration tests (with coverage) when:
-    # 1. Pushing to main (always maintain coverage baseline), OR
-    # 2. PR without 'skip-coverage' label (default behavior)
-    # If PR has 'skip-coverage' label, fast tests run instead (see ci.yml)
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && 
-       !contains(github.event.pull_request.labels.*.name, 'skip-coverage'))
+    # Only run on main branch pushes to maintain coverage baseline
+    # For PRs, fast non-instrumented tests run in ci.yml instead
+    if: github.event_name == 'push'
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -404,152 +396,6 @@ jobs:
           valColorRange: ${{ env.COVERAGE_PCT }}
           minColorRange: 0
           maxColorRange: 100
-
-      - name: Download baseline coverage from main branch (for PRs)
-        if: github.event_name == 'pull_request'
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          workflow: coverage.yml
-          branch: main
-          name: coverage-baseline
-          path: baseline-coverage
-          if_no_artifact_found: ignore
-        continue-on-error: true
-
-      - name: Extract baseline coverage (for PRs)
-        if: github.event_name == 'pull_request'
-        run: |
-          if [ -f baseline-coverage/coverage-full.json ]; then
-            BASE_COVERAGE=$(jq -r '.__meta.overall // .overall // 0' baseline-coverage/coverage-full.json 2>/dev/null || echo "0")
-            echo "BASE_COVERAGE=$BASE_COVERAGE" >> $GITHUB_ENV
-            echo "Base coverage from main: $BASE_COVERAGE%"
-          else
-            echo "No baseline coverage found, using 0"
-            echo "BASE_COVERAGE=0" >> $GITHUB_ENV
-            mkdir -p baseline-coverage
-            echo "{}" > baseline-coverage/coverage-data.json
-          fi
-        continue-on-error: true
-
-      - name: Comment PR with coverage
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const coverage = process.env.COVERAGE_PCT || '0';
-            const baseCoverage = process.env.BASE_COVERAGE || '0';
-            const diff = (parseFloat(coverage) - parseFloat(baseCoverage)).toFixed(2);
-            
-            let emoji = '📊';
-            let diffText = '';
-            let diffColor = '';
-            
-            if (diff > 0) {
-              emoji = '📈';
-              diffText = `(+${diff}%)`;
-              diffColor = '🟢';
-            } else if (diff < 0) {
-              emoji = '📉';
-              diffText = `(${diff}%)`;
-              diffColor = '🔴';
-            } else {
-              diffText = '(no change)';
-              diffColor = '⚪';
-            }
-            
-            let summary = '';
-            try {
-              summary = fs.readFileSync('coverage-summary.md', 'utf8');
-            } catch (e) {
-              summary = 'Coverage report not available';
-            }
-            
-            // Calculate per-file diffs
-            let fileDiffs = '';
-            try {
-              const currentData = JSON.parse(fs.readFileSync('coverage-data.json', 'utf8'));
-              const baselineData = JSON.parse(fs.readFileSync('baseline-coverage/coverage-data.json', 'utf8'));
-              
-              const changes = [];
-              for (const [file, currentPct] of Object.entries(currentData)) {
-                if (file.startsWith('__')) continue; // Skip metadata
-                if (file.startsWith('test/')) continue; // Skip test files
-                const basePct = baselineData[file] || 0;
-                const fileDiff = (parseFloat(currentPct) - parseFloat(basePct)).toFixed(2);
-                if (Math.abs(fileDiff) >= 0.01) {
-                  changes.push({ file, current: currentPct, base: basePct, diff: fileDiff });
-                }
-              }
-              
-              if (changes.length > 0) {
-                // Sort by absolute diff (largest changes first)
-                changes.sort((a, b) => Math.abs(parseFloat(b.diff)) - Math.abs(parseFloat(a.diff)));
-                
-                fileDiffs = '\n\n<details>\n<summary>📊 Coverage Changes by File</summary>\n\n';
-                fileDiffs += '```diff\n';
-                
-                const topChanges = changes.slice(0, 20); // Show top 20 changes
-                for (const {file, current, base, diff} of topChanges) {
-                  const symbol = parseFloat(diff) > 0 ? '+' : '';
-                  const prefix = parseFloat(diff) > 0 ? '+ ' : '- ';
-                  fileDiffs += `${prefix}${file.padEnd(60)} ${base}% → ${current}% (${symbol}${diff}%)\n`;
-                }
-                
-                if (changes.length > 20) {
-                  fileDiffs += `\n... and ${changes.length - 20} more files changed\n`;
-                }
-                
-                fileDiffs += '```\n</details>';
-              }
-            } catch (e) {
-              console.log('Could not calculate per-file diffs:', e.message);
-            }
-            
-            const comment = `## ${emoji} Coverage Report
-            
-            **Overall Coverage:** ${coverage}% ${diffColor} ${diffText}
-            ${fileDiffs}
-            
-            ${summary}
-            
-            <details>
-            <summary>ℹ️ Coverage Details</summary>
-            
-            - **Unit Tests:** ✅ Instrumented with bisect_ppx
-            - **Integration Tests:** ✅ Instrumented with bisect_ppx
-            - **Report Type:** Combined coverage from both test suites
-            - **Base Coverage:** ${baseCoverage}% (from main branch)
-            
-            </details>
-            `;
-            
-            // Find existing comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-            });
-            
-            const botComment = comments.find(comment => 
-              comment.user.type === 'Bot' && comment.body.includes('Coverage Report')
-            );
-            
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: comment
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number,
-                body: comment
-              });
-            }
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Updated Miaou TUI library to 0.2.6 with new `Key_event.result` API (`on_key`, `on_modal_key`, `key_hints`)
 - Renamed "linked directories" to "registered directories" (CLI commands: `binaries link` → `binaries register`, `binaries unlink` → `binaries unregister`)
+- **CI optimization**: Coverage collection now runs only on main branch pushes, not on PRs. This reduces PR feedback time from ~45 minutes to ~10-12 minutes while maintaining coverage baseline tracking on main.
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,15 +191,20 @@ Integration tests are located in `test/integration/cli-tester/tests/` organized 
 3. **Update documentation** if needed
 4. **Create a pull request** with a clear description
 
-### CI Labels
+### CI Behavior
 
-The following labels can be added to PRs to control CI behavior:
+**Fast Tests on PRs:**
+- PRs always run fast, non-instrumented integration tests (~10-12 min total)
+- This ensures quick feedback during development
 
-| Label | Effect | Use Case |
-|-------|--------|----------|
-| `skip-coverage` | Runs fast integration tests (2-3 min/shard) instead of instrumented tests (8-9 min/shard). No coverage report will be generated. | Use when iterating quickly and coverage data isn't needed. Remove before final merge to ensure coverage is collected. |
+**Coverage on Main Branch:**
+- Coverage collection runs only when changes are pushed to `main`
+- This maintains the coverage baseline without slowing down PR iterations
+- Coverage badge and reports are updated after merge
 
-**Note:** Coverage tests always run on the main branch to maintain the coverage baseline, regardless of labels used in PRs.
+**Manual Coverage (if needed):**
+- Use the "Actions" tab → "Coverage Report" → "Run workflow" to manually trigger coverage collection
+- Useful for debugging coverage issues before merging
 
 ### Pull Request Template
 


### PR DESCRIPTION
## Summary

This PR optimizes CI by running coverage collection only on main branch pushes, not on every PR iteration. This significantly improves developer feedback time while maintaining coverage baseline tracking.

## Motivation

Currently, coverage collection runs on every PR push unless the `skip-coverage` label is manually added:
- **Current PR time:** ~45 minutes (instrumented builds + 5 shard integration tests)
- **Target PR time:** ~10-12 minutes (fast non-instrumented tests)
- **Time savings:** ~35 minutes per PR iteration (70% reduction)

Coverage is still important, but developers need fast feedback during iteration. Running coverage only on main branch ensures:
- ✅ Fast PR feedback loop
- ✅ Coverage baseline maintained on main
- ✅ Coverage badge updated regularly
- ✅ No loss in coverage tracking accuracy

## Changes

### Coverage Workflow (`.github/workflows/coverage.yml`)
- **Trigger:** Now runs only on `push` to `main` + `workflow_dispatch` (manual trigger)
- **Removed:** PR-related conditionals, label checks, PR commenting step
- **Simplified:** Integration coverage job condition
- **Permissions:** Removed `pull-requests: write` (no longer needed)

### CI Workflow (`.github/workflows/ci.yml`)
- **Integration tests:** Now run on **all PRs** (not just with `skip-coverage` label)
- **Removed:** `skip-coverage` label condition
- **Updated:** Comments to reflect new behavior

### Documentation
- **CONTRIBUTING.md:** Updated to explain new CI behavior, removed `skip-coverage` label docs
- **CHANGELOG.md:** Added entry for CI optimization

## Testing

This PR itself will demonstrate the new behavior:
1. ✅ Fast integration tests will run on this PR (~10-12 min)
2. ❌ Coverage will NOT run on this PR
3. ✅ After merge, coverage will run on main branch

## Impact

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| PR feedback time | ~45 min | ~10-12 min | **70% faster** |
| Coverage on main | ✅ Yes | ✅ Yes | No change |
| Coverage badge | ✅ Updated | ✅ Updated | No change |
| Manual coverage | ❌ No | ✅ Yes (workflow_dispatch) | New capability |

## Trade-offs

**What we lose:**
- ❌ Per-PR coverage reports (no longer posted as comments)
- ❌ Coverage diff before merge (can't see impact until after merge)

**What we gain:**
- ✅ Much faster PR iteration
- ✅ Reduced CI resource usage
- ✅ Simplified workflow logic
- ✅ Manual coverage trigger option

## Rollback Plan

If issues arise after merge:
1. Revert this commit: `git revert <commit-hash> && git push`
2. Or add `pull_request` trigger back to `coverage.yml`
3. Coverage baseline on main is unaffected

## Related

This is Phase 1 of CI optimization from the analysis. Future optimizations:
- Phase 2: Fix TUI test hanging issues
- Phase 3: Docker layer caching
- Phase 4: Improved build caching

---

**Note:** The `skip-coverage` label is no longer needed and can be removed from PRs. It's now a no-op.