### PR TITLE
fix(ci): use check_artifacts to skip docs-only runs for metrics baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,7 @@ jobs:
           branch: main
           name: architecture-metrics
           path: baseline-metrics
+          check_artifacts: true
           if_no_artifact_found: ignore
         continue-on-error: true
 


### PR DESCRIPTION
## Summary

- Adds `check_artifacts: true` to the `dawidd6/action-download-artifact` step in CI, fixing a bug where architecture metrics comparison was silently skipped on PRs.

## Problem

When a docs-only change is pushed to main, the `docs-check` job runs instead of `build-and-test`. Both jobs share the name `Build and Test` in the GitHub UI, but only `build-and-test` uploads the `architecture-metrics` artifact.

The `dawidd6/action-download-artifact` action finds the docs-only run as the "most recent successful workflow run on main" and reports no artifact. The compare step then prints "No baseline found" and exits 0, **silently skipping the metrics regression check**.

This means regressions (increased duplicates, missing docs, large functions, etc.) could slip through undetected on any PR that follows a docs-only merge to main.

## Fix

Adding `check_artifacts: true` makes the download action iterate backward through workflow runs until it finds one that actually contains the `architecture-metrics` artifact, bypassing docs-only runs that have no artifacts.