### PR TITLE
fix(ui): prevent Esc key repeat from quitting app after modal close

### DIFF
--- a/.github/miaou-version
+++ b/.github/miaou-version
@@ -1,3 +1,3 @@
 # Bump this version to invalidate the miaou cache in CI
 # Format: YYYY-MM-DD or any string that changes when miaou needs updating
-2026-02-07-v1-matrix-footer-hints
+2026-02-07-v2-esc-cooldown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - System metrics (CPU, memory, disk) start populating without the previous startup delay
 - `make completions-check` no longer modifies the working directory when completions are out of date
 - Systemd service template warnings about unknown keys `StartLimitIntervalSec` and `StartLimitBurst` in [Service] section (moved to [Unit] section)
+- Pressing or holding Esc on modals no longer accidentally quits the application (Miaou Esc cooldown after modal close)
 
 ### Removed
 

--- a/src/ui/context.ml
+++ b/src/ui/context.ml
@@ -69,17 +69,6 @@ let consume_navigation () =
   pending_navigation := None ;
   value
 
-(* Flag to indicate that navigation.back should be skipped once.
-   Used when form exits to prevent back-navigation loop. *)
-let skip_back_once = ref false
-
-let set_skip_back_once () = skip_back_once := true
-
-let consume_skip_back_once () =
-  let value = !skip_back_once in
-  skip_back_once := false ;
-  value
-
 (* Global toast state *)
 let toasts_lock = Mutex.create ()
 

--- a/src/ui/context.mli
+++ b/src/ui/context.mli
@@ -42,11 +42,6 @@ val navigate : string -> unit
 
 val consume_navigation : unit -> string option
 
-(** Skip navigation back once - used when form exits to prevent back-navigation loop *)
-val set_skip_back_once : unit -> unit
-
-val consume_skip_back_once : unit -> bool
-
 (** Toast notifications *)
 val toast_info : string -> unit
 

--- a/src/ui/form_builder.ml
+++ b/src/ui/form_builder.ml
@@ -551,9 +551,7 @@ struct
                 Context.mark_instances_dirty () ;
                 (* Reset form to fresh initial values for next use *)
                 s.model_ref := S.spec.initial_model () ;
-                (* Navigate back to instances page via Context.
-                   Set skip_back_once to prevent loop when user presses Esc on instances. *)
-                Context.set_skip_back_once () ;
+                (* Navigate back to instances page via Context. *)
                 Context.navigate "instances" ;
                 s
             | Error (`Msg msg) ->
@@ -573,9 +571,7 @@ struct
             Context.mark_instances_dirty () ;
             (* Reset form to fresh initial values for next use *)
             s.model_ref := S.spec.initial_model () ;
-            (* Navigate back to instances page via Context.
-               Set skip_back_once to prevent loop when user presses Esc on instances. *)
-            Context.set_skip_back_once () ;
+            (* Navigate back to instances page via Context. *)
             Context.navigate "instances" ;
             s
         | Error (`Msg msg) ->
@@ -720,9 +716,7 @@ struct
           match Miaou.Core.Keys.of_string key with
           | Some Miaou.Core.Keys.Escape ->
               (* Go to instances page directly - Navigation.back would go to
-                 details page which may have stale/consumed context.
-                 Set skip_back_once to prevent loop when user presses Esc on instances. *)
-              Context.set_skip_back_once () ;
+                 details page which may have stale/consumed context. *)
               Context.navigate "instances" ;
               ps
           | Some Miaou.Core.Keys.Up ->
@@ -739,7 +733,6 @@ struct
   let service_cycle ps _ = refresh ps
 
   let back ps =
-    Context.set_skip_back_once () ;
     Context.navigate "instances" ;
     ps
 
@@ -778,7 +771,6 @@ struct
           | `Bubble -> (
               match key with
               | Miaou.Core.Keys.Escape ->
-                  Context.set_skip_back_once () ;
                   Context.navigate "instances" ;
                   (ps, Miaou_interfaces.Key_event.Handled)
               | Miaou.Core.Keys.Up ->


### PR DESCRIPTION
## Summary

- Bump Miaou to `2026-02-07-v2-esc-cooldown` which adds a 200ms Esc cooldown after modal close in the Matrix driver, preventing terminal key repeat from sending extra Esc events to the page and triggering app exit
- Remove dead `skip_back_once` code from `Context` — it was set in 5 places in `form_builder.ml` but `consume_skip_back_once()` was never called anywhere

## Root Cause

When a user presses or holds Esc to close a modal, the terminal sends multiple Esc key events via key repeat. The existing `drain_esc_keys` mechanism only catches bytes already buffered at drain time, not future key repeat events that arrive after the drain completes. The result: the first Esc closes the modal, the drain catches buffered Esc bytes, but a new Esc arrives from key repeat → no modal active → instances page receives Esc → `is_quit_key` returns true → app exits.

## Fix

The Miaou driver now sets a 200ms cooldown window after closing a modal with Esc. Any Esc events arriving within that window are silently suppressed. This covers the typical terminal key repeat interval (~30-100ms) with margin.

The Miaou fix was committed and tagged at `ce48e4f` (`2026-02-07-v2-esc-cooldown`).

## Files Changed

| File | Change |
|------|--------|
| `.github/miaou-version` | Bumped to `2026-02-07-v2-esc-cooldown` |
| `src/ui/context.ml` | Removed dead `skip_back_once` ref and functions (-11 lines) |
| `src/ui/context.mli` | Removed dead `set_skip_back_once` and `consume_skip_back_once` declarations (-5 lines) |
| `src/ui/form_builder.ml` | Removed 5 calls to `Context.set_skip_back_once()` (-10 lines) |
| `CHANGELOG.md` | Added fix entry |