### PR TITLE
refactor: add missing .mli files for 17 large modules

### DIFF
--- a/src/cli/cmd_binaries.mli
+++ b/src/cli/cmd_binaries.mli
@@ -1,0 +1,11 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2025-2026 Nomadic Labs <contact@nomadic-labs.com>            *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Binary management commands. *)
+
+(** The binaries command group *)
+val binaries_cmd : unit Cmdliner.Cmd.t

--- a/src/cli/cmd_import.mli
+++ b/src/cli/cmd_import.mli
@@ -1,0 +1,11 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2025-2026 Nomadic Labs <contact@nomadic-labs.com>            *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Import command for importing existing Octez services from the filesystem. *)
+
+(** The import command *)
+val import_cmd : unit Cmdliner.Cmd.t

--- a/src/cli/cmd_rpc.ml
+++ b/src/cli/cmd_rpc.ml
@@ -100,7 +100,7 @@ let execute_get service path =
       flush stderr
 
 (** Get completions for a path prefix *)
-let get_completions service prefix =
+let _get_completions service prefix =
   (* Split prefix into path segments *)
   let segments =
     String.split_on_char '/' prefix |> List.filter (fun s -> s <> "")

--- a/src/cli/cmd_rpc.mli
+++ b/src/cli/cmd_rpc.mli
@@ -1,0 +1,20 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** RPC browsing and execution commands. *)
+
+open Octez_manager_lib
+
+(** The rpc command group *)
+val rpc_cmd : unit Cmdliner.Cmd.t
+
+(** Parse a URL into a synthetic service for RPC calls. *)
+val service_from_url : string -> Service.t
+
+(** Resolve an RPC service from instance name, URL, or public node name. *)
+val resolve_service :
+  string option -> string option -> string option -> (Service.t, string) result

--- a/src/help_parser.mli
+++ b/src/help_parser.mli
@@ -1,0 +1,155 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Shared helper for parsing CLI --help output.
+
+    Parses the output of octez-node, octez-baker, and cmdliner-based
+    --help text into structured option and command entries. *)
+
+(** Classification of the expected value for a CLI option argument. *)
+type value_kind =
+  | Addr_port  (** Address:port pair (e.g. [127.0.0.1:8732]). *)
+  | Port  (** Port number. *)
+  | Addr  (** IP address or hostname. *)
+  | File  (** File path. *)
+  | Dir  (** Directory path. *)
+  | Path  (** Generic filesystem path. *)
+  | Number  (** Integer. *)
+  | Float  (** Floating-point number. *)
+  | Text  (** Free-form text. *)
+
+(** Whether a CLI option is a boolean toggle or takes a typed value. *)
+type arg_kind = Toggle | Value of value_kind
+
+(** A parsed CLI option with flag names, optional placeholder, doc string,
+    and classified argument kind. *)
+type option_entry = {
+  names : string list;
+  arg : string option;
+  doc : string;
+  kind : arg_kind;
+}
+
+(** A parsed CLI subcommand with its name and documentation. *)
+type command_entry = {name : string; doc : string}
+
+(** {2 String Helpers} *)
+
+(** [contains ~needle haystack] returns [true] if [needle] occurs in
+    [haystack]. *)
+val contains : needle:string -> string -> bool
+
+(** Trim whitespace and return [Some s] if non-empty, [None] otherwise. *)
+val trim_nonempty : string -> string option
+
+(** Return the first long-form ([--]-prefixed) name, or the first name. *)
+val primary_name : string list -> string
+
+(** Filter to long-form names only; return all if none are long-form. *)
+val display_names : string list -> string list
+
+(** {2 Argument Classification} *)
+
+(** Heuristically classify an option's argument kind by scanning the
+    placeholder, doc string, and flag names for keywords. *)
+val classify_arg_kind :
+  names:string list -> arg:string option -> doc:string -> arg_kind
+
+(** {2 Spec/Doc Splitting} *)
+
+(** Split a help line into (spec, doc) using tab or double-space gap. *)
+val split_spec_doc_default : string -> string * string
+
+(** Like {!split_spec_doc_default} but falls back to [: ] for baker output. *)
+val split_spec_doc_baker : string -> string * string
+
+(** Strip trailing punctuation from a placeholder string. *)
+val clean_placeholder : string -> string
+
+(** Strip trailing punctuation from an option name string. *)
+val clean_name : string -> string
+
+(** {2 Spec Parsing} *)
+
+(** Parse an option specifier into flag names and optional placeholder. *)
+val parse_spec : string -> string list * string option
+
+(** Split bracket syntax like [--flag\[=VAL\]] into [Some ("--flag", "=VAL")]. *)
+val split_bracket_arg : string -> (string * string) option
+
+(** Parse a cmdliner-style option specifier (handles bracket and [=] syntax). *)
+val parse_spec_cmdliner : string -> string list * string option
+
+(** {2 Line Detection} *)
+
+(** [true] if the line looks like a node help option definition. *)
+val is_option_line_node : string -> bool
+
+(** [true] if the line looks like a baker help option definition. *)
+val is_option_line_baker : string -> bool
+
+(** [true] if the line looks like a cmdliner option definition. *)
+val is_option_line_cmdliner : string -> bool
+
+(** {2 Parsing Pipelines} *)
+
+(** Remove ANSI escape sequences from a string. *)
+val strip_ansi : string -> string
+
+(** Generic help parser parameterized by line detection, splitting,
+    and spec parsing strategies. *)
+val parse_help_with :
+  is_option_line:(string -> bool) ->
+  split_spec_doc:(string -> string * string) ->
+  parse_spec:(string -> string list * string option) ->
+  string ->
+  option_entry list
+
+(** Parse [octez-node --help] output into option entries. *)
+val parse_help_node : string -> option_entry list
+
+(** Parse [octez-baker --help] output into option entries. *)
+val parse_help_baker : string -> option_entry list
+
+(** {2 Section Extraction} *)
+
+(** [true] if the line is an all-caps section header (e.g. ["OPTIONS"]). *)
+val is_section_header : string -> bool
+
+(** Extract lines belonging to a named section from help output lines. *)
+val extract_section_lines : header:string -> string list -> string list
+
+(** Parse the OPTIONS and COMMON OPTIONS sections of cmdliner help output. *)
+val parse_cmdliner_options : string -> option_entry list
+
+(** [true] if the line looks like a subcommand usage line. *)
+val looks_like_command_line : string -> bool
+
+(** Parse the COMMANDS section of cmdliner help output. *)
+val parse_cmdliner_commands : string -> command_entry list
+
+(** {2 Baker Global Options} *)
+
+(** [true] if the line starts with ["Global options"]. *)
+val is_baker_global_section_header : string -> bool
+
+(** Extract lines belonging to the baker global options section. *)
+val extract_baker_global_section : string list -> string list
+
+(** Parse the baker global options section into option entries. *)
+val parse_baker_global_options : string -> option_entry list
+
+(** Parse baker global options and return a flat list of flag names. *)
+val extract_baker_global_option_names : string -> string list
+
+(** Classify an argument as [`Global] or [`Command] based on known global
+    option names. *)
+val classify_arg : global_options:string list -> string -> [> `Global | `Command]
+
+(** Partition extra CLI arguments into [(global_args, command_args)]. *)
+val split_extra_args :
+  global_options:string list -> string list -> string list * string list

--- a/src/ui/binary_help_explorer.ml
+++ b/src/ui/binary_help_explorer.ml
@@ -711,7 +711,7 @@ let excluded_baker_options =
     "--chain";
   ]
 
-type baker_mode = [`Local | `Remote]
+type _baker_mode = [`Local | `Remote]
 
 let load_baker_options ~binary ~mode =
   let cache_key =

--- a/src/ui/binary_help_explorer.mli
+++ b/src/ui/binary_help_explorer.mli
@@ -1,0 +1,165 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Modal explorer for octez binary --help options.
+
+    Parses --help output and displays options in a selectable grid,
+    allowing users to toggle and set values for extra CLI arguments. *)
+
+open Octez_manager_lib
+
+(** A selectable row in the options grid, holding one CLI option with its
+    current value and selection state. *)
+type row = {
+  opt : Help_parser.option_entry;
+  mutable value : string option;
+  mutable selected : bool;
+}
+
+(** {2 Modal Openers} *)
+
+(** Open the help explorer modal for [octez-node run] flags.
+    Parses the binary's --help output and filters out options already
+    managed by the install form (e.g. [--data-dir], [--rpc-addr]).
+    @param app_bin_dir directory containing the octez-node binary
+    @param initial_args previously selected extra arguments to pre-populate
+    @param on_apply callback invoked with the list of selected flag tokens *)
+val open_node_run_help :
+  app_bin_dir:string ->
+  initial_args:string ->
+  on_apply:(string list -> unit) ->
+  unit
+
+(** Open the help explorer modal for [octez-baker run] flags.
+    @param app_bin_dir directory containing the octez-baker binary
+    @param mode [`Local] for local-node mode, [`Remote] for remote-node mode
+    @param initial_args previously selected extra arguments to pre-populate
+    @param on_apply callback invoked with the list of selected flag tokens *)
+val open_baker_run_help :
+  app_bin_dir:string ->
+  mode:[`Local | `Remote] ->
+  initial_args:string ->
+  on_apply:(string list -> unit) ->
+  unit
+
+(** Open the help explorer modal for [octez-accuser run] flags.
+    @param app_bin_dir directory containing the octez-accuser binary
+    @param initial_args previously selected extra arguments to pre-populate
+    @param on_apply callback invoked with the list of selected flag tokens *)
+val open_accuser_run_help :
+  app_bin_dir:string ->
+  initial_args:string ->
+  on_apply:(string list -> unit) ->
+  unit
+
+(** Open the help explorer modal for [octez-dal-node run] flags.
+    @param app_bin_dir directory containing the octez-dal-node binary
+    @param initial_args previously selected extra arguments to pre-populate
+    @param on_apply callback invoked with the list of selected flag tokens *)
+val open_dal_run_help :
+  app_bin_dir:string ->
+  initial_args:string ->
+  on_apply:(string list -> unit) ->
+  unit
+
+(** {2 Utility Functions} *)
+
+(** Render an option value for display: [None] becomes [""], [Some v] becomes [v]. *)
+val render_value : string option -> string
+
+(** Truncate a string to [max_len] characters, appending an ellipsis if needed. *)
+val truncate : max_len:int -> string -> string
+
+(** Return the display label for an option entry (comma-separated flag names). *)
+val option_label : Help_parser.option_entry -> string
+
+(** Build a list of CLI tokens from all selected rows.
+    Each selected flag produces its name, plus its value if set. *)
+val format_tokens : row list -> string list
+
+(** Check whether a flag [name] matches an [excluded] prefix string.
+    Returns [true] if [name] equals or starts with the prefix. *)
+val name_matches_excluded : string -> string -> bool
+
+(** Check whether an option entry should be excluded based on a list
+    of excluded flag name prefixes. *)
+val is_excluded_option :
+  Help_parser.option_entry -> excluded:string list -> bool
+
+(** Flag prefixes excluded from the node help explorer
+    (flags already managed by the install form). *)
+val excluded_node_options : string list
+
+(** Flag prefixes excluded from the baker help explorer. *)
+val excluded_baker_options : string list
+
+(** Flag prefixes excluded from the accuser help explorer. *)
+val excluded_accuser_options : string list
+
+(** Flag prefixes excluded from the DAL node help explorer. *)
+val excluded_dal_options : string list
+
+(** Check whether an option entry matches a specific flag string. *)
+val option_matches_flag : Help_parser.option_entry -> string -> bool
+
+(** Initialize rows from a list of option entries, pre-selecting those
+    that appear in the [initial_args] string. *)
+val init_rows_from_args : Help_parser.option_entry list -> string -> row list
+
+(** Generate short and long markdown help-hint text for a row.
+    Returns [(short_hint, long_hint)] where either may be [None]. *)
+val option_hint_markdown : row -> string option * string option
+
+(** {2 Testing Interface} *)
+
+module For_tests : sig
+  (** Parse [octez-node --help] output into option entries. *)
+  val parse_help : string -> Help_parser.option_entry list
+
+  (** Parse [octez-baker --help] output into option entries. *)
+  val parse_baker_help : string -> Help_parser.option_entry list
+
+  (** Convert an {!Help_parser.arg_kind} to its string representation. *)
+  val arg_kind_to_string : Help_parser.arg_kind -> string
+
+  (** Parse an initial-args string into [(flag, value option)] pairs. *)
+  val parse_initial_args : string -> (string * string option) list
+
+  (** @see {!truncate} *)
+  val truncate : max_len:int -> string -> string
+
+  (** Wrap text to a given [width], returning a list of wrapped lines. *)
+  val wrap_text : width:int -> string -> string list
+
+  (** @see {!option_label} *)
+  val option_label : Help_parser.option_entry -> string
+
+  (** @see {!render_value} *)
+  val render_value : string option -> string
+
+  (** @see {!format_tokens} *)
+  val format_tokens : row list -> string list
+
+  (** @see {!name_matches_excluded} *)
+  val name_matches_excluded : string -> string -> bool
+
+  (** @see {!is_excluded_option} *)
+  val is_excluded_option :
+    Help_parser.option_entry -> excluded:string list -> bool
+
+  (** @see {!excluded_node_options} *)
+  val excluded_node_options : string list
+
+  (** @see {!excluded_baker_options} *)
+  val excluded_baker_options : string list
+
+  (** Create a row from an option entry with default (unselected, no value) state. *)
+  val make_row : Help_parser.option_entry -> row
+
+  (** Create a pre-selected row from an option entry with the given value. *)
+  val make_row_selected : Help_parser.option_entry -> string option -> row
+end

--- a/src/ui/flows.mli
+++ b/src/ui/flows.mli
@@ -1,0 +1,33 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** UI flow orchestration for quick-create wizards.
+
+    Provides modal-based flows for creating node, baker, accuser,
+    and DAL node instances via interactive prompts. *)
+
+open Octez_manager_lib
+
+(** Error message shown when an instance name contains invalid characters. *)
+val invalid_instance_name_error_msg : string
+
+(** Remove the ["node-"] prefix from an instance name, if present. *)
+val strip_node_prefix : string -> string
+
+(** Open the node creation wizard (instance name, network, history mode,
+    bootstrap method). *)
+val create_node_flow : on_success:(unit -> unit) -> unit
+
+(** Open the baker creation wizard, selecting from available node services. *)
+val create_baker_flow :
+  services:Service.t list -> on_success:(unit -> unit) -> unit
+
+(** Open the accuser creation wizard. *)
+val create_accuser_flow : on_success:(unit -> unit) -> unit
+
+(** Open the DAL node creation wizard. *)
+val create_dal_node_flow : on_success:(unit -> unit) -> unit

--- a/src/ui/pages/binaries/binaries_page.ml
+++ b/src/ui/pages/binaries/binaries_page.ml
@@ -186,14 +186,14 @@ let keymap _ =
     kb "?" "Help";
   ]
 
-let header =
+let _header =
   let open Miaou_widgets_display.Widgets in
   [
     title_highlight " Binaries Management ";
     dim "Manage Octez binary versions and registered directories";
   ]
 
-let footer = []
+let _footer = []
 
 module Page_Impl :
   Miaou.Core.Tui_page.PAGE_SIG with type state = state and type msg = msg =

--- a/src/ui/pages/binaries/binaries_page.mli
+++ b/src/ui/pages/binaries/binaries_page.mli
@@ -1,0 +1,91 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Binaries management page for downloading, registering, and pruning binaries. *)
+
+open Octez_manager_lib
+
+(** The type of item shown in the binaries list. *)
+type item_type =
+  | ManagedVersion of string * int64 option * int
+      (** A managed version: [(version, total_size, binary_count)]. *)
+  | RegisteredDir of Binary_registry.registered_dir * int
+      (** A user-registered directory with its binary count. *)
+  | RegisterAction  (** The "Register directory..." action row. *)
+  | AvailableVersion of Binary_downloader.version_info
+      (** A single downloadable version. *)
+  | AvailableMajorGroup of int * Binary_downloader.version_info list
+      (** A collapsible group of versions sharing the same major version. *)
+
+(** Page state holding managed, registered, and available versions. *)
+type state = {
+  managed_versions : (string * int64 option * int) list;
+      (** Installed managed versions. *)
+  registered_dirs : (Binary_registry.registered_dir * int) list;
+      (** User-registered directories. *)
+  available_versions : Binary_downloader.version_info list;
+      (** Remote versions available for download. *)
+  items : item_type list;  (** Flat list of displayable items. *)
+  selected : int;  (** Currently selected item index. *)
+  loading_remote : bool;  (** [true] while fetching remote version list. *)
+  expanded_majors : int list;  (** Major version groups currently expanded. *)
+  expanded_managed : string list;  (** Managed versions currently expanded. *)
+  expanded_registered : string list;
+      (** Registered directories currently expanded. *)
+}
+
+(** Message type (unused, placeholder for Miaou page signature). *)
+type msg = unit
+
+(** Page name for the page registry. *)
+val name : string
+
+(** Pre-built page value for registration. *)
+val page : Miaou.Core.Registry.page
+
+(** Register this page with the global page registry. *)
+val register : unit -> unit
+
+(** Page implementation exposing [state] and [msg] type equalities. *)
+module Page_Impl :
+  Miaou.Core.Tui_page.PAGE_SIG with type state = state and type msg = msg
+
+(** Testing interface exposing internal helpers. *)
+module For_tests : sig
+  (** Filter a version list to keep only the [n] latest major version families. *)
+  val filter_latest_n_major_versions :
+    int ->
+    Binary_downloader.version_info list ->
+    Binary_downloader.version_info list
+
+  (** Format a byte count as a human-readable size string (e.g. ["1.2 GB"]). *)
+  val format_size : int64 -> string
+
+  (** Build the flat item list from managed versions, registered directories,
+      available versions, and which major groups are expanded. *)
+  val build_items :
+    (string * int64 option * int) list ->
+    (Binary_registry.registered_dir * int) list ->
+    Binary_downloader.version_info list ->
+    int list ->
+    item_type list
+
+  (** Move the cursor up by one position. *)
+  val move_up : state -> state
+
+  (** Move the cursor down by one position. *)
+  val move_down : state -> state
+
+  (** Toggle expansion of a major version group. *)
+  val toggle_major_expansion : state -> int -> state
+
+  (** Toggle expansion of a managed version entry. *)
+  val toggle_managed_expansion : state -> string -> state
+
+  (** Toggle expansion of a registered directory entry. *)
+  val toggle_registered_expansion : state -> string -> state
+end

--- a/src/ui/pages/diagnostics/charts.mli
+++ b/src/ui/pages/diagnostics/charts.mli
@@ -1,0 +1,39 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Chart widgets for the diagnostics page.
+
+    Renders braille line charts, sparklines, and summary bars from
+    metrics snapshots. *)
+
+(** Strip trailing whitespace from chart output lines. *)
+val trim_chart_padding : string -> string
+
+(** Render a braille line chart of background queue depth over time. *)
+val render_bg_queue_chart :
+  Metrics.metrics_snapshot list -> width:int -> height:int -> string
+
+(** Render a braille line chart of service status counts over time. *)
+val render_service_status_chart :
+  Metrics.metrics_snapshot list -> width:int -> height:int -> string
+
+(** Render a braille line chart of RPC polling latency over time. *)
+val render_latency_chart :
+  Metrics.metrics_snapshot list -> width:int -> height:int -> string
+
+(** Render a braille line chart of key-to-render time over time. *)
+val render_key_to_render_chart :
+  Metrics.metrics_snapshot list -> width:int -> height:int -> string
+
+(** Render horizontal summary bars showing queue depth, latency,
+    and render performance. *)
+val render_summary_bars :
+  Metrics.metrics_snapshot list -> width:int -> height:int -> string
+
+(** Render an inline sparkline of background queue depth. *)
+val render_bg_queue_sparkline :
+  Miaou_widgets_display.Sparkline_widget.t -> string

--- a/src/ui/pages/diagnostics/diagnostics_page.ml
+++ b/src/ui/pages/diagnostics/diagnostics_page.ml
@@ -185,7 +185,7 @@ let header =
     Widgets.dim "Live system metrics and service status";
   ]
 
-let footer = []
+let _footer = []
 
 (* Section content renderers - each returns lines for that section *)
 let render_services_content services =

--- a/src/ui/pages/diagnostics/diagnostics_page.mli
+++ b/src/ui/pages/diagnostics/diagnostics_page.mli
@@ -1,0 +1,20 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2025-2026 Nomadic Labs <contact@nomadic-labs.com>            *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Diagnostics page showing system metrics, caches, and scheduler status. *)
+
+(** Page name for the page registry. *)
+val name : string
+
+(** Pre-built page value for registration. *)
+val page : Miaou.Core.Registry.page
+
+(** Register this page with the global page registry. *)
+val register : unit -> unit
+
+(** Page implementation satisfying the Miaou TUI page signature. *)
+module Page : Miaou.Core.Tui_page.PAGE_SIG

--- a/src/ui/pages/import_wizard.mli
+++ b/src/ui/pages/import_wizard.mli
@@ -1,0 +1,63 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Import wizard for importing existing Octez services. *)
+
+open Octez_manager_lib
+module Navigation = Miaou.Core.Navigation
+
+(** Steps in the import wizard flow. *)
+type step =
+  | SelectService  (** Step 1: choose an external service to import. *)
+  | ConfigureImport  (** Step 2: configure import strategy and options. *)
+  | ReviewImport  (** Step 3: review and confirm the import. *)
+  | Importing  (** Terminal state while the import job runs. *)
+
+(** Wizard state tracking the current step, selected service, and options. *)
+type state = {
+  step : step;  (** Current wizard step. *)
+  external_services : External_service.t list;
+      (** Detected external Octez services. *)
+  selected_idx : int;  (** Index of the highlighted service in step 1. *)
+  selected_service : External_service.t option;
+      (** The service chosen for import. *)
+  strategy : Import.import_strategy;
+      (** Import strategy ([Takeover] or [Clone]). *)
+  custom_name : string option;  (** Optional custom instance name override. *)
+  network_override : string option;  (** Optional network name override. *)
+  error : string option;  (** Error message from the last operation. *)
+}
+
+(** Navigation-wrapped state. *)
+type pstate = state Navigation.t
+
+(** Page name for the page registry. *)
+val name : string
+
+(** Pre-built page value for registration. *)
+val page : Miaou.Core.Registry.page
+
+(** Register this page with the global page registry. *)
+val register : unit -> unit
+
+(** Page implementation satisfying the Miaou TUI page signature. *)
+module Page : Miaou.Core.Tui_page.PAGE_SIG
+
+(** Move the service selection cursor by [delta] positions (wraps around). *)
+val move_selection : pstate -> int -> pstate
+
+(** Toggle the import strategy between [Takeover] and [Clone]. *)
+val toggle_strategy : pstate -> pstate
+
+(** Return the header lines for the current wizard step. *)
+val header : state -> string list
+
+(** Return the list of key events this page handles. *)
+val handled_keys : unit -> Miaou.Core.Keys.t list
+
+(** Return the keymap description for the help bar. *)
+val keymap : state -> state Miaou.Core.Tui_page.key_binding_desc list

--- a/src/ui/pages/install_baker_form_v3.mli
+++ b/src/ui/pages/install_baker_form_v3.mli
@@ -1,0 +1,57 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Baker installation form using field bundles. *)
+
+(** How the baker connects to a DAL node. *)
+type dal_selection =
+  | Dal_none  (** No DAL node configured. *)
+  | Dal_instance of string  (** Use a managed DAL node instance by name. *)
+  | Dal_endpoint of string
+      (** Use an external DAL node at the given endpoint. *)
+
+(** Form model holding all baker configuration fields. *)
+type model = {
+  core : Form_builder_common.core_service_config;
+      (** Shared service config (name, bin dir, user, etc.). *)
+  client : Form_builder_common.client_config;
+      (** Client-side config (base dir, node endpoint). *)
+  parent_node : string;
+      (** Parent node instance name (empty for external node). *)
+  node_data_dir : string;  (** Data directory of the parent node. *)
+  dal : dal_selection;  (** DAL node connection mode. *)
+  delegates : string list;  (** List of delegate public key hashes. *)
+  liquidity_baking_vote : string;
+      (** Liquidity baking toggle vote (["on"], ["off"], or ["pass"]). *)
+  edit_mode : bool;  (** [true] when editing an existing baker instance. *)
+  original_instance : string option;
+      (** Original instance name in edit mode. *)
+  stopped_dependents : string list;
+      (** Services that were stopped for the edit. *)
+}
+
+(** Page name for the page registry. *)
+val name : string
+
+(** Pre-built page value for registration. *)
+val page : Miaou.Core.Registry.page
+
+(** Register this page with the global page registry. *)
+val register : unit -> unit
+
+(** Page implementation satisfying the Miaou TUI page signature. *)
+module Page : Miaou.Core.Tui_page.PAGE_SIG
+
+(** Testing interface exposing internal helpers. *)
+module For_tests : sig
+  (** Return the default initial model with empty/default field values. *)
+  val initial_model : unit -> model
+
+  (** Determine whether the baker runs in [`Local] or [`Remote] node mode
+      based on the model and current service states. *)
+  val baker_node_mode : model -> Data.Service_state.t list -> [`Local | `Remote]
+end

--- a/src/ui/pages/install_node_form_v3.ml
+++ b/src/ui/pages/install_node_form_v3.ml
@@ -194,7 +194,7 @@ let schedule_snapshot_fetch slug =
 let snapshot_entries_from_cache slug =
   Cache.get_safe_keyed_cached snapshot_cache slug
 
-let ensure_snapshot_entries slug =
+let _ensure_snapshot_entries slug =
   match snapshot_entries_from_cache slug with
   | Some entries -> Ok entries
   | None -> (

--- a/src/ui/pages/install_node_form_v3.mli
+++ b/src/ui/pages/install_node_form_v3.mli
@@ -1,0 +1,52 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Node installation form using field bundles. *)
+
+open Octez_manager_lib
+
+(** A snapshot entry from the TzInit snapshot provider. *)
+type tzinit_snapshot = {
+  network_slug : string;  (** Network identifier slug (e.g. ["mainnet"]). *)
+  kind_slug : string;  (** Snapshot kind slug (e.g. ["rolling"]). *)
+  label : string;  (** Human-readable label for display. *)
+}
+
+(** User's snapshot selection for node installation. *)
+type snapshot_selection = [`None | `Url of string | `Tzinit of tzinit_snapshot]
+
+(** Page name for the page registry. *)
+val name : string
+
+(** Pre-built page value for registration. *)
+val page : Miaou.Core.Registry.page
+
+(** Register this page with the global page registry. *)
+val register : unit -> unit
+
+(** Page implementation satisfying the Miaou TUI page signature. *)
+module Page : Miaou.Core.Tui_page.PAGE_SIG
+
+(** Testing interface exposing internal helpers. *)
+module For_tests : sig
+  (** Clear the cached snapshot entries for all networks. *)
+  val clear_snapshot_cache : unit -> unit
+
+  (** Populate the snapshot cache for a specific [network]. *)
+  val set_snapshot_cache :
+    network:string -> entries:Snapshots.entry list -> unit
+
+  (** Check whether a snapshot entry matches the given [history_mode]
+      (e.g. ["rolling"], ["full"], ["archive"]). *)
+  val snapshot_entry_matches_history_mode :
+    Snapshots.entry -> history_mode:string -> bool
+
+  (** Detect whether the selected snapshot conflicts with the chosen
+      history mode for the given [network]. Returns [true] on conflict. *)
+  val history_snapshot_conflict :
+    history_mode:string -> snapshot:snapshot_selection -> network:string -> bool
+end

--- a/src/ui/pages/instance_details.ml
+++ b/src/ui/pages/instance_details.ml
@@ -83,7 +83,7 @@ let header s =
     | None -> "");
   ]
 
-let footer = []
+let _footer = []
 
 let view_details svc =
   let render_fields fields =

--- a/src/ui/pages/instance_details.mli
+++ b/src/ui/pages/instance_details.mli
@@ -1,0 +1,20 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2025-2026 Nomadic Labs <contact@nomadic-labs.com>            *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Instance details page showing configuration, status, and actions. *)
+
+(** Page name for the page registry. *)
+val name : string
+
+(** Pre-built page value for registration. *)
+val page : Miaou.Core.Registry.page
+
+(** Register this page with the global page registry. *)
+val register : unit -> unit
+
+(** Page implementation satisfying the Miaou TUI page signature. *)
+module Page : Miaou.Core.Tui_page.PAGE_SIG

--- a/src/ui/pages/rpc_browser/rpc_browser.mli
+++ b/src/ui/pages/rpc_browser/rpc_browser.mli
@@ -1,0 +1,20 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2025-2026 Nomadic Labs <contact@nomadic-labs.com>            *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** RPC browser page for exploring and executing node RPC endpoints. *)
+
+(** Page name for the page registry. *)
+val name : string
+
+(** Pre-built page value for registration. *)
+val page : Miaou.Core.Registry.page
+
+(** Register this page with the global page registry. *)
+val register : unit -> unit
+
+(** Page implementation satisfying the Miaou TUI page signature. *)
+module Page : Miaou.Core.Tui_page.PAGE_SIG

--- a/src/ui/pages/rpc_node_selection.mli
+++ b/src/ui/pages/rpc_node_selection.mli
@@ -1,0 +1,76 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** RPC node selection page for choosing local or public nodes. *)
+
+open Octez_manager_lib
+
+(** A selectable node entry. *)
+type node_item = {
+  label : string;  (** Display label for the node. *)
+  rpc_addr : string;
+      (** RPC endpoint address (e.g. ["https://mainnet.api.tez.ie"]). *)
+  is_public : bool;
+      (** [true] for public nodes, [false] for local instances. *)
+  network : string option;  (** Network name if known (e.g. [Some "mainnet"]). *)
+}
+
+(** An entry in the flat display list. *)
+type display_item =
+  | SectionHeader of string  (** Section heading (e.g. ["PUBLIC NODES"]). *)
+  | NetworkHeader of string  (** Network subheading (e.g. ["Mainnet"]). *)
+  | NodeItem of node_item  (** A selectable node entry. *)
+
+(** Page state holding the loaded nodes and cursor position. *)
+type state = {
+  public_nodes : node_item list;  (** Public nodes fetched from Taquito. *)
+  local_instances : node_item list;  (** Locally configured node instances. *)
+  cursor : int;  (** Currently highlighted item index. *)
+  loading : bool;  (** [true] while fetching public nodes. *)
+  error : string option;  (** Error message from the last fetch attempt. *)
+  display_items : display_item list;  (** Flat list of all display entries. *)
+}
+
+(** Page name for the page registry. *)
+val name : string
+
+(** Pre-built page value for registration. *)
+val page : Miaou.Core.Registry.page
+
+(** Register this page with the global page registry. *)
+val register : unit -> unit
+
+(** Page implementation satisfying the Miaou TUI page signature. *)
+module Page : Miaou.Core.Tui_page.PAGE_SIG
+
+(** Parse Taquito JSON response into a list of public node items. *)
+val parse_taquito_json : string -> node_item list
+
+(** Curated list of default public nodes used as fallback. *)
+val curated_defaults : node_item list
+
+(** Build a flat display list with section headers, network headers,
+    and node items from the given public and local node lists. *)
+val build_display_items :
+  public_nodes:node_item list ->
+  local_instances:node_item list ->
+  display_item list
+
+(** Return the total number of display items. *)
+val total_items : state -> int
+
+(** Return the item at the current cursor position.
+    Headers are distinguished from selectable nodes. *)
+val get_item_at_cursor :
+  state -> [`SectionHeader | `NetworkHeader | `Node of node_item | `None]
+
+(** Move the cursor by [delta] positions, skipping non-selectable headers. *)
+val move_cursor : int -> state -> state
+
+(** Create a synthetic {!Service.t} from a node item, suitable for
+    passing to the RPC browser page. *)
+val make_service_for_node : node_item -> Service.t

--- a/src/ui/public_nodes_cache.mli
+++ b/src/ui/public_nodes_cache.mli
@@ -1,0 +1,39 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Cache for public RPC nodes fetched from Taquito. *)
+
+open Octez_manager_lib
+
+(** A public RPC node's display label, RPC address, and optional network. *)
+type node_info = {label : string; rpc_addr : string; network : string option}
+
+(** Hardcoded fallback list of well-known public RPC nodes. *)
+val curated_defaults : node_info list
+
+(** Infer the Tezos network name from an RPC URL by matching known domains. *)
+val extract_network_from_url : string -> string option
+
+(** Parse a Taquito-format JSON string into a list of node info records. *)
+val parse_taquito_json : string -> node_info list
+
+(** Download the public node list from Taquito URLs, returning the first
+    successfully parsed non-empty result or [[]] on failure. *)
+val fetch_nodes : unit -> node_info list
+
+(** Replace the in-memory cached node list. *)
+val set_cache : node_info list -> unit
+
+(** Return cached public nodes, fetching and caching if empty.
+    Falls back to {!curated_defaults} if fetching yields nothing. *)
+val get_nodes : unit -> node_info list
+
+(** Convert a {!node_info} to a {!Service.t} suitable for RPC calls. *)
+val to_service : node_info -> Service.t
+
+(** Return all public nodes as a [Service.t list]. *)
+val get_services : unit -> Service.t list

--- a/src/ui/rpc_scheduler.mli
+++ b/src/ui/rpc_scheduler.mli
@@ -1,0 +1,83 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Background scheduler for polling RPC bootstrap status and head level.
+
+    Manages boot state (bootstrapping/ready) and head monitoring
+    for all active node instances. *)
+
+open Octez_manager_lib
+
+(** {2 Scheduler Control} *)
+
+(** Spawn the background polling domain and start the worker queue. *)
+val start : unit -> unit
+
+(** Poll all active node services and submit RPC requests for due instances. *)
+val tick : unit -> unit
+
+(** Stop all monitors and the worker queue. *)
+val shutdown : unit -> unit
+
+(** {2 Head Monitoring} *)
+
+(** Open a streaming [/monitor/heads/main] connection for a service. *)
+val start_head_monitor : Service.t -> unit
+
+(** Stop the head-monitor for the given instance name. *)
+val stop_head_monitor : string -> unit
+
+(** Stop all active head-monitor connections. *)
+val stop_all_monitors : unit -> unit
+
+(** {2 Worker Statistics} *)
+
+(** Return current stats (queue length, processed count) from the worker. *)
+val get_worker_stats : unit -> Worker_queue.stats
+
+(** {2 Testing Interface} *)
+
+module For_tests : sig
+  (** Clear all monitors, boot-state tables, and reset clock stubs. *)
+  val reset_state : unit -> unit
+
+  (** Temporarily replace the clock function for the duration of [f]. *)
+  val with_now : (unit -> float) -> (unit -> 'a) -> 'a
+
+  (** Temporarily replace the [poll_boot] function for the duration of [f]. *)
+  val with_poll_boot : (Service.t -> float -> unit) -> (unit -> 'a) -> 'a
+
+  (** Return the polling interval for an instance based on boot state. *)
+  val poll_interval : string -> float
+
+  (** [true] if the instance has never been polled or enough time has elapsed. *)
+  val is_due_for_poll : float -> Service.t -> bool
+
+  (** Polling interval when a node is not yet bootstrapped (6 seconds). *)
+  val boot_pending_interval : float
+
+  (** Polling interval when a node is bootstrapped (10 seconds). *)
+  val boot_ok_interval : float
+
+  (** Directly set the boot state for an instance. *)
+  val set_boot_state : string -> bool option -> unit
+
+  (** Directly set the last-poll timestamp for an instance. *)
+  val set_boot_at : string -> float -> unit
+
+  (** Prepend ["http://"] if the address does not start with ["http"]. *)
+  val normalize_endpoint : string -> string
+
+  (** Return [Some now] if the head level changed, otherwise preserve
+      the existing [last_block_time]. *)
+  val compute_last_block_time :
+    previous_head:int option ->
+    head_level:int option ->
+    now:float ->
+    existing_block_time:float option ->
+    float option
+end


### PR DESCRIPTION
## Summary

- Add `.mli` interface files for the 17 largest modules (>200 lines) that lacked them
- Reduces `missing_mli` metric from **30 → 13** (-57%)
- Prefix 6 dead values/types with `_` to suppress warnings now that `.mli` files hide them

## Modules covered

**TUI pages (8):** `install_node_form_v3`, `install_baker_form_v3`, `binaries_page`, `rpc_browser`, `diagnostics_page`, `rpc_node_selection`, `instance_details`, `import_wizard`

**Utilities (5):** `binary_help_explorer`, `rpc_scheduler`, `flows`, `public_nodes_cache`, `charts`

**CLI (3):** `cmd_binaries`, `cmd_rpc`, `cmd_import`

**Core (1):** `help_parser`

## Metrics impact

| Metric | Before | After |
|--------|--------|-------|
| `missing_mli` | 30 | 13 |
| All other metrics | unchanged | unchanged |

## Testing

- `dune build` passes cleanly
- All 600+ unit tests pass
- `dune fmt` clean
- Copyright headers verified