### PR TITLE
refactor(test): deduplicate test helpers (contains_substring, string_contains, make_service)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **God module split**: Split `common.ml` (916 lines, ~50 functions) into 5 focused submodules in `lib/common/`: `Paths` (filesystem paths, XDG dirs), `Cmd_runner` (shell execution), `File_ops` (file/directory operations), `Download` (HTTP downloads, checksums), `String_utils` (formatting, editor, string helpers). All 436 call sites across 79 files migrated from `Common.*` to direct submodule calls
 - **God module split**: Split `instances_actions.ml` (1414 lines, 38 functions) into 4 focused submodules: `Instances_helpers` (shared action helpers), `Instances_lifecycle` (start/restart with cascade, edit), `Instances_external` (external/unmanaged service actions), `Instances_update` (version update, cascade update, rollback). Core module reduced to 348 lines
 - **God module split**: Split `binaries_page.ml` (879 lines, 38 functions) into 4 focused submodules in `ui/pages/binaries/`: `Binaries_types` (shared types), `Binaries_data` (data loading, item building), `Binaries_actions` (side-effecting action handlers), `Binaries_view` (rendering). Core module reduced to 282 lines
+- **Test helper dedup**: Extracted 9 duplicate substring-search helpers (`contains_substring`, `string_contains`) into shared `test_string_helpers_lib` and replaced 4 duplicate `make_service` helpers in RPC browser tests with `Mock_service_helpers.mock_service`. Fixes an empty-needle bug in `test_cli_progress.ml`
 
 ### Fixed
 

--- a/src/ui/pages/binaries/binaries_view.mli
+++ b/src/ui/pages/binaries/binaries_view.mli
@@ -1,7 +1,7 @@
 (******************************************************************************)
 (*                                                                            *)
 (* SPDX-License-Identifier: MIT                                               *)
-(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(* Copyright (c) 2025-2026 Nomadic Labs <contact@nomadic-labs.com>            *)
 (*                                                                            *)
 (******************************************************************************)
 

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,10 @@
 (test
  (name unit_tests)
- (libraries alcotest octez_manager_lib octez-manager.ui)
+ (libraries
+  alcotest
+  octez_manager_lib
+  octez-manager.ui
+  test_string_helpers_lib)
  (modules unit_tests)
  (instrumentation
   (backend bisect_ppx)))
@@ -14,7 +18,7 @@
 
 (test
  (name test_cli_progress)
- (libraries alcotest octez_manager_cli)
+ (libraries alcotest octez_manager_cli test_string_helpers_lib)
  (modules test_cli_progress)
  (instrumentation
   (backend bisect_ppx)))
@@ -32,6 +36,11 @@
 ; Shared TUI test helpers library
 
 (library
+ (name test_string_helpers_lib)
+ (wrapped false)
+ (modules test_string_helpers))
+
+(library
  (name tui_test_helpers_lib)
  (libraries
   alcotest
@@ -39,7 +48,8 @@
   octez-manager.ui
   miaou-core.lib
   miaou-core.lib_miaou_internal
-  lambda-term)
+  lambda-term
+  test_string_helpers_lib)
  (modules tui_test_helpers)
  (instrumentation
   (backend bisect_ppx)))
@@ -405,7 +415,8 @@
   alcotest
   octez_manager_lib
   octez-manager.ui
-  mock_service_helpers_lib)
+  mock_service_helpers_lib
+  test_string_helpers_lib)
  (modules test_instances_render_pure)
  (instrumentation
   (backend bisect_ppx)))
@@ -538,14 +549,22 @@
 
 (test
  (name test_rpc_browser_state)
- (libraries alcotest octez_manager_lib octez-manager.ui)
+ (libraries
+  alcotest
+  octez_manager_lib
+  octez-manager.ui
+  mock_service_helpers_lib)
  (modules test_rpc_browser_state)
  (instrumentation
   (backend bisect_ppx)))
 
 (test
  (name test_rpc_browser_render_list)
- (libraries alcotest octez_manager_lib octez-manager.ui)
+ (libraries
+  alcotest
+  octez_manager_lib
+  octez-manager.ui
+  mock_service_helpers_lib)
  (modules test_rpc_browser_render_list)
  (instrumentation
   (backend bisect_ppx)))
@@ -564,7 +583,11 @@
 
 (test
  (name test_rpc_browser_actions)
- (libraries alcotest octez_manager_lib octez-manager.ui)
+ (libraries
+  alcotest
+  octez_manager_lib
+  octez-manager.ui
+  mock_service_helpers_lib)
  (modules test_rpc_browser_actions)
  (instrumentation
   (backend bisect_ppx)))
@@ -803,7 +826,8 @@
   qcheck-core
   qcheck-alcotest
   octez_manager_lib
-  octez-manager.ui)
+  octez-manager.ui
+  mock_service_helpers_lib)
  (modules test_rpc_browser_state_props)
  (instrumentation
   (backend bisect_ppx)))
@@ -831,21 +855,32 @@
   qcheck-core
   qcheck-alcotest
   octez_manager_lib
-  octez-manager.ui)
+  octez-manager.ui
+  test_string_helpers_lib)
  (modules test_flows_pure)
  (instrumentation
   (backend bisect_ppx)))
 
 (test
  (name test_snapshots_pure)
- (libraries alcotest octez_manager_lib octez-manager.ui miaou-core.lib)
+ (libraries
+  alcotest
+  octez_manager_lib
+  octez-manager.ui
+  miaou-core.lib
+  test_string_helpers_lib)
  (modules test_snapshots_pure)
  (instrumentation
   (backend bisect_ppx)))
 
 (test
  (name test_import_wizard_pure)
- (libraries alcotest octez_manager_lib octez-manager.ui miaou-core.lib)
+ (libraries
+  alcotest
+  octez_manager_lib
+  octez-manager.ui
+  miaou-core.lib
+  test_string_helpers_lib)
  (modules test_import_wizard_pure)
  (instrumentation
   (backend bisect_ppx)))
@@ -859,7 +894,7 @@
 
 (test
  (name test_log_export_pure)
- (libraries alcotest octez_manager_lib unix)
+ (libraries alcotest octez_manager_lib unix test_string_helpers_lib)
  (modules test_log_export_pure)
  (instrumentation
   (backend bisect_ppx)))

--- a/test/test_cli_progress.ml
+++ b/test/test_cli_progress.ml
@@ -33,18 +33,7 @@ let with_env_vars vars f =
         saved)
     f
 
-let string_contains ~needle haystack =
-  try
-    let _ = String.index haystack (String.get needle 0) in
-    let len = String.length needle in
-    let hlen = String.length haystack in
-    let rec check i =
-      if i + len > hlen then false
-      else if String.sub haystack i len = needle then true
-      else check (i + 1)
-    in
-    check 0
-  with Not_found -> false
+let string_contains = Test_string_helpers.string_contains
 
 (* ========================================================================= *)
 (* Progress Bar Rendering Tests *)

--- a/test/test_flows_pure.ml
+++ b/test/test_flows_pure.ml
@@ -111,17 +111,7 @@ let test_strip_node_prefix_nested () =
 (* invalid_instance_name_error_msg Tests                         *)
 (* ============================================================ *)
 
-let contains_substring haystack needle =
-  let nlen = String.length needle in
-  let hlen = String.length haystack in
-  if nlen > hlen then false
-  else
-    let rec aux i =
-      if i > hlen - nlen then false
-      else if String.sub haystack i nlen = needle then true
-      else aux (i + 1)
-    in
-    aux 0
+let contains_substring = Test_string_helpers.contains_substring
 
 let test_error_msg_not_empty () =
   Alcotest.(check bool)

--- a/test/test_import_wizard_pure.ml
+++ b/test/test_import_wizard_pure.ml
@@ -27,7 +27,7 @@ let make_state ?(step = Import_wizard.SelectService) ?(external_services = [])
     error;
   }
 
-let wrap_state s = Navigation.make s
+let wrap_state = Navigation.make
 
 (* ============================================================ *)
 (* move_selection Tests (wrapping mod behavior)                  *)
@@ -148,17 +148,7 @@ let test_toggle_round_trip () =
 (* header Tests                                                  *)
 (* ============================================================ *)
 
-let contains_substring haystack needle =
-  let nlen = String.length needle in
-  let hlen = String.length haystack in
-  if nlen > hlen then false
-  else
-    let rec aux i =
-      if i > hlen - nlen then false
-      else if String.sub haystack i nlen = needle then true
-      else aux (i + 1)
-    in
-    aux 0
+let contains_substring = Test_string_helpers.contains_substring
 
 let test_header_select () =
   let s = make_state ~step:Import_wizard.SelectService () in

--- a/test/test_instances_render_pure.ml
+++ b/test/test_instances_render_pure.ml
@@ -17,17 +17,7 @@ module Actions = Octez_manager_ui.Instances_actions
 module Layout = Octez_manager_ui.Instances_layout
 module State = Octez_manager_ui.Instances_state
 
-let string_contains ~needle haystack =
-  let nlen = String.length needle in
-  let hlen = String.length haystack in
-  if nlen > hlen then false
-  else
-    let found = ref false in
-    for i = 0 to hlen - nlen do
-      if not !found then
-        if String.sub haystack i nlen = needle then found := true
-    done ;
-    !found
+let string_contains = Test_string_helpers.string_contains
 
 (* ================================================================== *)
 (* role_header tests                                                   *)

--- a/test/test_log_export_pure.ml
+++ b/test/test_log_export_pure.ml
@@ -40,16 +40,7 @@ let make_svc ?(instance = "my-node") ?(role = "node") ?(network = "mainnet")
     dependents;
   }
 
-let contains_substring s sub =
-  let len_s = String.length s in
-  let len_sub = String.length sub in
-  if len_sub > len_s then false
-  else
-    let found = ref false in
-    for i = 0 to len_s - len_sub do
-      if String.sub s i len_sub = sub then found := true
-    done ;
-    !found
+let contains_substring = Test_string_helpers.contains_substring
 
 (* ── get_instance_details ──────────────────────────────────── *)
 

--- a/test/test_rpc_browser_actions.ml
+++ b/test/test_rpc_browser_actions.ml
@@ -5,24 +5,15 @@
 (*                                                                            *)
 (******************************************************************************)
 
-open Octez_manager_lib
 open Octez_manager_ui
 module State = Rpc_browser_state
 module Actions = Rpc_browser_actions
 
 (* Helper to create test services *)
 let make_service ?(rpc_addr = "127.0.0.1:8732") name =
-  Service.make
+  Mock_service_helpers_lib.Mock_service_helpers.mock_service
     ~instance:name
-    ~role:"node"
-    ~network:"mainnet"
-    ~history_mode:History_mode.Full
-    ~data_dir:"/tmp/test"
     ~rpc_addr
-    ~net_addr:"[::]:9732"
-    ~service_user:"tezos"
-    ~app_bin_dir:"/usr/bin"
-    ~logging_mode:Logging_mode.Journald
     ()
 
 (* ============================================================ *)

--- a/test/test_rpc_browser_render_list.ml
+++ b/test/test_rpc_browser_render_list.ml
@@ -5,24 +5,15 @@
 (*                                                                            *)
 (******************************************************************************)
 
-open Octez_manager_lib
 open Octez_manager_ui
 module State = Rpc_browser_state
 module Render = Rpc_browser_render_list
 
 (* Helper to create test services *)
 let make_service ?(rpc_addr = "127.0.0.1:8732") name =
-  Service.make
+  Mock_service_helpers_lib.Mock_service_helpers.mock_service
     ~instance:name
-    ~role:"node"
-    ~network:"mainnet"
-    ~history_mode:History_mode.Full
-    ~data_dir:"/tmp/test"
     ~rpc_addr
-    ~net_addr:"[::]:9732"
-    ~service_user:"tezos"
-    ~app_bin_dir:"/usr/bin"
-    ~logging_mode:Logging_mode.Journald
     ()
 
 (* ============================================================ *)

--- a/test/test_rpc_browser_state.ml
+++ b/test/test_rpc_browser_state.ml
@@ -5,23 +5,14 @@
 (*                                                                            *)
 (******************************************************************************)
 
-open Octez_manager_lib
 open Octez_manager_ui
 module State = Rpc_browser_state
 
 (* Helper to create test services *)
 let make_service ?(rpc_addr = "127.0.0.1:8732") name =
-  Service.make
+  Mock_service_helpers_lib.Mock_service_helpers.mock_service
     ~instance:name
-    ~role:"node"
-    ~network:"mainnet"
-    ~history_mode:History_mode.Full
-    ~data_dir:"/tmp/test"
     ~rpc_addr
-    ~net_addr:"[::]:9732"
-    ~service_user:"tezos"
-    ~app_bin_dir:"/usr/bin"
-    ~logging_mode:Logging_mode.Journald
     ()
 
 (* ============================================================ *)

--- a/test/test_rpc_browser_state_props.ml
+++ b/test/test_rpc_browser_state_props.ml
@@ -10,7 +10,6 @@
     Generates random sequences of operations and verifies
     invariants hold after every step. *)
 
-open Octez_manager_lib
 module State = Octez_manager_ui.Rpc_browser_state
 
 (* ================================================================== *)
@@ -18,18 +17,7 @@ module State = Octez_manager_ui.Rpc_browser_state
 (* ================================================================== *)
 
 let make_service name =
-  Service.make
-    ~instance:name
-    ~role:"node"
-    ~network:"mainnet"
-    ~history_mode:History_mode.Full
-    ~data_dir:"/tmp/test"
-    ~rpc_addr:"127.0.0.1:8732"
-    ~net_addr:"[::]:9732"
-    ~service_user:"tezos"
-    ~app_bin_dir:"/usr/bin"
-    ~logging_mode:Logging_mode.Journald
-    ()
+  Mock_service_helpers_lib.Mock_service_helpers.mock_service ~instance:name ()
 
 let instances = [make_service "node-a"; make_service "node-b"]
 

--- a/test/test_snapshots_pure.ml
+++ b/test/test_snapshots_pure.ml
@@ -27,7 +27,7 @@ let make_state ?(network = "mainnet") ?(entries = []) ?(selected = 0) ?error ()
     : Snapshots.state =
   {network; entries; selected; error}
 
-let wrap_state s = Navigation.make s
+let wrap_state = Navigation.make
 
 (* ============================================================ *)
 (* move_selection Tests                                          *)
@@ -84,17 +84,7 @@ let test_move_large_delta () =
 (* header Tests                                                  *)
 (* ============================================================ *)
 
-let contains_substring haystack needle =
-  let nlen = String.length needle in
-  let hlen = String.length haystack in
-  if nlen > hlen then false
-  else
-    let rec aux i =
-      if i > hlen - nlen then false
-      else if String.sub haystack i nlen = needle then true
-      else aux (i + 1)
-    in
-    aux 0
+let contains_substring = Test_string_helpers.contains_substring
 
 let test_header_contains_network () =
   let s = make_state ~network:"mainnet" () in

--- a/test/test_string_helpers.ml
+++ b/test/test_string_helpers.ml
@@ -1,0 +1,30 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Shared string-search helpers for tests.
+
+    Provides [contains_substring] and [string_contains] so that
+    every test file does not have to redefine its own copy. *)
+
+(** [contains_substring haystack needle] returns [true] when [needle] appears
+    anywhere inside [haystack]. *)
+let contains_substring haystack needle =
+  let nlen = String.length needle in
+  let hlen = String.length haystack in
+  if nlen = 0 then true
+  else if nlen > hlen then false
+  else
+    let rec loop i =
+      if i + nlen > hlen then false
+      else if String.sub haystack i nlen = needle then true
+      else loop (i + 1)
+    in
+    loop 0
+
+(** [string_contains ~needle haystack] is the same as
+    {!contains_substring} with a labelled [needle] argument. *)
+let string_contains ~needle haystack = contains_substring haystack needle

--- a/test/tui_flow_tests.ml
+++ b/test/tui_flow_tests.ml
@@ -54,18 +54,7 @@ let with_test_env f =
   Fun.protect ~finally:(fun () -> cleanup tmp_dir) (fun () -> f ())
 
 (** Helper to check if string contains substring *)
-let contains_substring haystack needle =
-  let nlen = String.length needle in
-  let hlen = String.length haystack in
-  if nlen = 0 then true
-  else if nlen > hlen then false
-  else
-    let rec loop i =
-      if i + nlen > hlen then false
-      else if String.sub haystack i nlen = needle then true
-      else loop (i + 1)
-    in
-    loop 0
+let contains_substring = Test_string_helpers.contains_substring
 
 (** Strip ANSI escape codes for easier text matching *)
 let strip_ansi s =

--- a/test/tui_test_helpers.ml
+++ b/test/tui_test_helpers.ml
@@ -183,19 +183,7 @@ let navigate_up ?(wait = true) n =
 (* Screen Content Helpers *)
 (* ============================================================ *)
 
-(** Check if string contains substring *)
-let contains_substring haystack needle =
-  let nlen = String.length needle in
-  let hlen = String.length haystack in
-  if nlen = 0 then true
-  else if nlen > hlen then false
-  else
-    let rec loop i =
-      if i + nlen > hlen then false
-      else if String.sub haystack i nlen = needle then true
-      else loop (i + 1)
-    in
-    loop 0
+include Test_string_helpers
 
 (** Strip ANSI escape codes from string *)
 let strip_ansi s =

--- a/test/unit_tests.ml
+++ b/test/unit_tests.ml
@@ -25,15 +25,7 @@ let list_list_string = Alcotest.(list (list string))
 
 let sort_pairs l = List.sort (fun (a, _) (b, _) -> compare a b) l
 
-let string_contains ~needle haystack =
-  let nlen = String.length needle in
-  let hlen = String.length haystack in
-  let rec loop idx =
-    if idx + nlen > hlen then false
-    else if String.sub haystack idx nlen = needle then true
-    else loop (idx + 1)
-  in
-  if nlen = 0 then true else loop 0
+let string_contains = Test_string_helpers.string_contains
 
 let string_index_opt ~needle haystack =
   let nlen = String.length needle in


### PR DESCRIPTION
## Summary

- Extract `contains_substring` and `string_contains` into a shared `test_string_helpers_lib`, replacing 8 independent copies across test files. One copy in `test_cli_progress.ml` had a latent empty-needle crash bug (`String.get` on empty string), now fixed.
- Consolidate 4 identical `make_service` helpers in RPC browser tests to use the existing `mock_service_helpers_lib`.
- Eta-reduce 2 trivial `wrap_state` aliases.

**Net: -64 lines, 0 duplicate test helpers remaining.**

## Details

### String helper dedup

| Helper | Copies removed | Files |
|--------|---------------|-------|
| `contains_substring` | 5 | `tui_flow_tests`, `test_snapshots_pure`, `test_log_export_pure`, `test_import_wizard_pure`, `test_flows_pure` |
| `string_contains` | 3 | `unit_tests`, `test_instances_render_pure`, `test_cli_progress` |

All replaced with a single canonical implementation in `test/test_string_helpers.ml`, exposed as `test_string_helpers_lib` (zero external dependencies).

`tui_test_helpers.ml` re-exports both via `include Test_string_helpers` so existing callers through that module continue to work.

### Bug fix

`test_cli_progress.ml` had a `string_contains` that called `String.get needle 0` without checking for empty needle — would crash on `string_contains ~needle:"" s`. Now uses the canonical implementation which handles empty needles correctly.

### make_service dedup

4 RPC browser test files each had a 13-line `make_service` function constructing `Service.t` records. All now delegate to `Mock_service_helpers.mock_service` from the existing `mock_service_helpers_lib`.

## Stacking

This PR is stacked on #662 (`refactor/split-god-modules`).