### PR TITLE
fix(ci): add switch-valid guard to coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -52,9 +52,20 @@ jobs:
             opam switch create 5.3.0 ocaml.5.3.0 -y
             eval $(opam env)
           fi
+          # Verify the switch is functional — a cache hit can restore /root/.opam
+          # but the switch may be invalid, causing opam to recreate a bare switch
+          # without dune or project dependencies.
+          eval $(opam env)
+          if command -v dune > /dev/null 2>&1; then
+            echo "switch-valid=true" >> $GITHUB_OUTPUT
+          else
+            echo "WARNING: opam switch exists but dune is not installed."
+            echo "Will reinstall dependencies."
+            echo "switch-valid=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Pin miaou packages
-        if: steps.cache-opam.outputs.cache-hit != 'true'
+        if: steps.cache-opam.outputs.cache-hit != 'true' || steps.opam-init.outputs.switch-valid != 'true'
         run: |
           eval $(opam env)
           echo "Installing miaou packages..."
@@ -66,7 +77,7 @@ jobs:
           opam install miaou-core miaou-driver-term miaou-driver-matrix miaou-driver-web miaou-runner eio_posix --jobs=4
 
       - name: Install project dependencies
-        if: steps.cache-opam.outputs.cache-hit != 'true'
+        if: steps.cache-opam.outputs.cache-hit != 'true' || steps.opam-init.outputs.switch-valid != 'true'
         run: |
           eval $(opam env)
           git config --global --add safe.directory "$PWD"


### PR DESCRIPTION
## Summary

- Coverage workflow was failing with `dune: not found` when the opam cache restored a corrupted switch
- The main CI workflow already had a guard that detects invalid switches and forces dependency reinstallation — this applies the same fix to `coverage.yml`
- Adds `switch-valid` output check to the `opam-init` step and gates `Pin miaou packages` / `Install project dependencies` on it