### PR TITLE
fix(ci): ensure full build before arch-index to prevent stale metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,8 @@ jobs:
           apt-get update -qq && apt-get install -y -qq libsqlite3-dev > /dev/null
           eval $(opam env)
           opam install sqlite3 -y
+          # Ensure all .cmt/.cmti files exist (the cached _build may be stale)
+          dune build @check
           dune exec -- tools/arch_index.exe
           dune exec tools/arch_query.exe -- metrics -o architecture-metrics.json
           dune exec tools/arch_query.exe -- stats


### PR DESCRIPTION
## Summary

- Adds `dune build @check` before `arch_index.exe` in CI to ensure all `.cmt`/`.cmti` files are regenerated from source, preventing stale build cache from producing inaccurate architecture metrics baselines.

## Problem

The dune build cache (restored via `restore-keys` fallback) may contain stale `.cmt`/`.cmti` files from prior runs with fewer modules. When the arch indexer scans these, it produces baselines with incorrect module/function counts (e.g., 123 modules instead of 135), causing other PRs to fail the metrics comparison step.

## Change

A single `dune build @check` step before the indexer ensures all type-checking artifacts match the current source tree.