### PR TITLE
fix(ui): navigate to Browse RPCs when pressing Up from instances in multi-column mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Multi-column layout: pressing Up from the first instance now correctly navigates to "Browse RPCs" instead of jumping to "Install new instance"
 - Ghostnet network can no longer be selected despite deprecation (removed from all network selection code paths)
 - RPC Browser: Ghostnet URLs no longer appear in public nodes list (previously showed as "Unknown" network)
 - RPC Browser: Local instances now display network name (e.g., "Shadownet") instead of full URL (e.g., "https://teztnets.com/shadownet")

--- a/src/ui/pages/instances.ml
+++ b/src/ui/pages/instances.ml
@@ -126,6 +126,112 @@ include Instances_render
 (* Action handlers extracted to instances/instances_actions.ml *)
 open Instances_actions
 
+(** Single-column navigation: linear up/down with separator skipping. *)
+let move_selection_single_column s delta =
+  let raw = s.selected + delta in
+  let selected = clamp_selection s.services s.external_services raw in
+  (* Skip separator during navigation *)
+  let selected =
+    if selected = menu_item_count then selected + delta else selected
+  in
+  let selected = clamp_selection s.services s.external_services selected in
+  {s with selected}
+
+(** Multi-column: navigate within the menu area (indices 0..menu_item_count-1).
+    When pressing Down past the last menu item, jump to first service in
+    column 0. *)
+let move_selection_menu s delta =
+  let selected = max 0 (min menu_item_count (s.selected + delta)) in
+  if selected >= menu_item_count && delta > 0 then
+    let first_svc =
+      first_service_in_column ~num_columns:s.num_columns ~services:s.services 0
+    in
+    {s with selected = first_svc + services_start_idx; active_column = 0}
+  else {s with selected}
+
+(** Multi-column: navigate within the external services section
+    (below all column-distributed managed services). *)
+let move_selection_external s delta =
+  let first_external = services_start_idx + List.length s.services in
+  if s.selected = first_external && delta < 0 then
+    (* Moving up from first external service *)
+    if List.length s.services > 0 && s.num_columns > 1 then
+      let col_indices =
+        services_in_column ~num_columns:s.num_columns ~services:s.services 0
+      in
+      match List.rev col_indices with
+      | [] -> {s with selected = menu_item_count - 1; active_column = 0}
+      | last_idx :: _ ->
+          {s with selected = last_idx + services_start_idx; active_column = 0}
+    else if List.length s.services > 0 then
+      let last_managed = services_start_idx + List.length s.services - 1 in
+      {s with selected = last_managed}
+    else {s with selected = menu_item_count - 1}
+  else
+    let raw = s.selected + delta in
+    let selected = clamp_selection s.services s.external_services raw in
+    {s with selected}
+
+(** Multi-column: navigate within managed services, constrained to the
+    active column.  Moving up past the first service goes to the last menu
+    item; moving down past the last service goes to external services. *)
+let move_selection_managed s delta =
+  let current_idx = s.selected - services_start_idx in
+  let col_indices =
+    services_in_column
+      ~num_columns:s.num_columns
+      ~services:s.services
+      s.active_column
+  in
+  let current_pos =
+    List.find_mapi
+      (fun i idx -> if idx = current_idx then Some i else None)
+      col_indices
+    |> Option.value ~default:0
+  in
+  let new_pos = current_pos + delta in
+  if new_pos < 0 then (
+    s.column_scroll.(s.active_column) <- 0 ;
+    {s with selected = menu_item_count - 1})
+  else if new_pos >= List.length col_indices then
+    if List.length s.external_services > 0 then
+      let first_external = services_start_idx + List.length s.services in
+      {s with selected = first_external}
+    else s
+  else
+    let new_idx = List.nth col_indices new_pos in
+    let line_start, line_count =
+      service_line_position
+        ~num_columns:s.num_columns
+        ~services:s.services
+        ~folded:s.folded
+        new_idx
+        s.active_column
+    in
+    adjust_column_scroll
+      ~column_scroll:s.column_scroll
+      ~col:s.active_column
+      ~line_start
+      ~line_count
+      ~visible_height:!last_visible_height_ref ;
+    {s with selected = new_idx + services_start_idx}
+
+(** Move selection up or down by [delta] steps, handling menu items,
+    separator skipping, and multi-column navigation. *)
+let move_selection s delta =
+  if s.services = [] && s.external_services = [] then {s with selected = 0}
+  else if s.num_columns <= 1 then move_selection_single_column s delta
+  else if s.selected < services_start_idx then move_selection_menu s delta
+  else
+    let current_idx = s.selected - services_start_idx in
+    let in_external = current_idx >= List.length s.services in
+    if in_external then move_selection_external s delta
+    else move_selection_managed s delta
+
+module For_tests = struct
+  let move_selection = move_selection
+end
+
 module Page_Impl :
   Miaou.Core.Tui_page.PAGE_SIG with type state = state and type msg = msg =
 struct
@@ -540,129 +646,7 @@ Press **Enter** to open instance menu.|}
     lower = "esc" || lower = "escape" || lower = "c-c" || lower = "ctrl+c"
     || lower = "^c" || String.equal key "\003"
 
-  let move_selection s delta =
-    if s.services = [] && s.external_services = [] then
-      (* Only Install button (0) when no services at all - ignore navigation *)
-      {s with selected = 0}
-    else if s.num_columns <= 1 then
-      (* Single column mode: simple linear navigation *)
-      let raw = s.selected + delta in
-      let selected = clamp_selection s.services s.external_services raw in
-      (* Skip separator during navigation *)
-      let selected =
-        if selected = menu_item_count then selected + delta else selected
-      in
-      let selected = clamp_selection s.services s.external_services selected in
-      {s with selected}
-    else if
-      (* Multi-column mode: navigate within current column *)
-      s.selected < services_start_idx
-    then
-      (* In menu area, simple navigation *)
-      let selected = max 0 (min menu_item_count (s.selected + delta)) in
-      (* Jump from menu to first service in first column (column 0) *)
-      if selected >= menu_item_count && delta > 0 then
-        let first_svc =
-          first_service_in_column
-            ~num_columns:s.num_columns
-            ~services:s.services
-            0
-        in
-        {s with selected = first_svc + services_start_idx; active_column = 0}
-      else {s with selected}
-    else
-      (* In services area: stay within column *)
-      let current_idx = s.selected - services_start_idx in
-      (* Check if we're in external services area *)
-      let external_start_idx = List.length s.services in
-      let in_external = current_idx >= external_start_idx in
-      if in_external then
-        (* External services: linear navigation below all columns *)
-        (* Check if moving up from first external service *)
-        let first_external = services_start_idx + List.length s.services in
-        if s.selected = first_external && delta < 0 then
-          (* Move to last service in first column (column 0), or menu if none *)
-          if List.length s.services > 0 && s.num_columns > 1 then
-            (* Multi-column: jump to last service in first column *)
-            let col_indices =
-              services_in_column
-                ~num_columns:s.num_columns
-                ~services:s.services
-                0
-            in
-            match List.rev col_indices with
-            | [] ->
-                (* First column is empty, go to menu *)
-                {s with selected = 0; active_column = 0}
-            | last_idx :: _ ->
-                {
-                  s with
-                  selected = last_idx + services_start_idx;
-                  active_column = 0;
-                }
-          else if List.length s.services > 0 then
-            (* Single-column: jump to last managed service *)
-            let last_managed =
-              services_start_idx + List.length s.services - 1
-            in
-            {s with selected = last_managed}
-          else
-            (* No managed services, jump to menu *)
-            {s with selected = 0}
-        else
-          (* Normal external service navigation *)
-          let raw = s.selected + delta in
-          let selected = clamp_selection s.services s.external_services raw in
-          {s with selected}
-      else
-        (* Managed services: column-based navigation *)
-        let col_indices =
-          services_in_column
-            ~num_columns:s.num_columns
-            ~services:s.services
-            s.active_column
-        in
-        let current_pos =
-          List.find_mapi
-            (fun i idx -> if idx = current_idx then Some i else None)
-            col_indices
-          |> Option.value ~default:0
-        in
-        let new_pos = current_pos + delta in
-        if new_pos < 0 then (
-          (* Moving up from first service goes to Install button *)
-          (* Scroll to top of column *)
-          s.column_scroll.(s.active_column) <- 0 ;
-          {s with selected = 0})
-        else if new_pos >= List.length col_indices then
-          if
-            (* At bottom of managed services column *)
-            List.length s.external_services > 0
-          then
-            (* Jump to first external service *)
-            let first_external = services_start_idx + List.length s.services in
-            {s with selected = first_external}
-          else
-            (* No external services, stay put *)
-            s
-        else
-          let new_idx = List.nth col_indices new_pos in
-          (* Adjust scroll to keep selection visible *)
-          let line_start, line_count =
-            service_line_position
-              ~num_columns:s.num_columns
-              ~services:s.services
-              ~folded:s.folded
-              new_idx
-              s.active_column
-          in
-          adjust_column_scroll
-            ~column_scroll:s.column_scroll
-            ~col:s.active_column
-            ~line_start
-            ~line_count
-            ~visible_height:!last_visible_height_ref ;
-          {s with selected = new_idx + services_start_idx}
+  let move_selection s delta = move_selection s delta
 
   let force_refresh_cmd s = force_refresh s
 

--- a/src/ui/pages/instances.mli
+++ b/src/ui/pages/instances.mli
@@ -12,3 +12,11 @@ val name : string
 val register : unit -> unit
 
 module Page : Miaou.Core.Tui_page.PAGE_SIG
+
+(** Functions exposed for testing. *)
+module For_tests : sig
+  (** Move selection up or down by [delta] steps.
+      Handles menu items, separator skipping, single-column linear navigation,
+      and multi-column column-constrained navigation. *)
+  val move_selection : Instances_state.state -> int -> Instances_state.state
+end

--- a/test/dune
+++ b/test/dune
@@ -191,6 +191,17 @@
   (backend bisect_ppx)))
 
 (test
+ (name test_instances_navigation_pure)
+ (libraries
+  alcotest
+  octez_manager_lib
+  octez-manager.ui
+  mock_service_helpers_lib)
+ (modules test_instances_navigation_pure)
+ (instrumentation
+  (backend bisect_ppx)))
+
+(test
  (name test_node_env)
  (libraries alcotest octez_manager_lib unix)
  (modules test_node_env)

--- a/test/test_instances_navigation_pure.ml
+++ b/test/test_instances_navigation_pure.ml
@@ -1,0 +1,241 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Pure unit tests for instances page navigation (move_selection).
+
+    Tests the multi-column and single-column navigation logic,
+    verifying that moving up from managed services goes to the
+    correct menu item (Browse RPCs, not Install). *)
+
+open Alcotest
+open Octez_manager_ui
+open Mock_service_helpers_lib
+open Mock_service_helpers
+module StringSet = Instances_state.StringSet
+
+let menu_item_count = Instances_state.menu_item_count
+
+let services_start_idx = Instances_state.services_start_idx
+
+(** Helper to create a state with the given services and column count *)
+let make_state ?(selected = 0) ?(num_columns = 1) ?(active_column = 0)
+    ?(external_services = []) services =
+  let column_scroll = Array.make (max 1 num_columns) 0 in
+  {
+    Instances_state.services;
+    external_services;
+    selected;
+    folded = StringSet.empty;
+    external_folded = StringSet.empty;
+    last_updated = 0.0;
+    num_columns;
+    active_column;
+    column_scroll;
+  }
+
+let move = Instances.For_tests.move_selection
+
+(* ============================================================ *)
+(* Single-column navigation tests                               *)
+(* ============================================================ *)
+
+let test_single_column_up_from_first_service () =
+  (* In single column, moving up from the first service (index 4)
+     should skip the separator (index 3) and land on Browse RPCs (index 2) *)
+  let services = [running_service ~instance:"node-1" ()] in
+  let s = make_state ~selected:services_start_idx ~num_columns:1 services in
+  let s' = move s (-1) in
+  check int "lands on Browse RPCs" (menu_item_count - 1) s'.selected
+
+let test_single_column_down_from_browse_rpcs () =
+  (* Moving down from Browse RPCs (index 2) should skip separator and
+     land on first service (index 4) *)
+  let services = [running_service ~instance:"node-1" ()] in
+  let s = make_state ~selected:(menu_item_count - 1) ~num_columns:1 services in
+  let s' = move s 1 in
+  check int "lands on first service" services_start_idx s'.selected
+
+let test_single_column_navigate_through_menu () =
+  let services = [running_service ~instance:"node-1" ()] in
+  let s = make_state ~selected:0 ~num_columns:1 services in
+  (* Down from Install -> Manage binaries *)
+  let s' = move s 1 in
+  check int "Install -> Manage binaries" 1 s'.selected ;
+  (* Down from Manage binaries -> Browse RPCs *)
+  let s' = move s' 1 in
+  check int "Manage binaries -> Browse RPCs" 2 s'.selected ;
+  (* Down from Browse RPCs -> first service (skip separator) *)
+  let s' = move s' 1 in
+  check int "Browse RPCs -> first service" services_start_idx s'.selected
+
+(* ============================================================ *)
+(* Multi-column navigation tests                                *)
+(* ============================================================ *)
+
+let test_multi_column_up_from_first_service_to_browse_rpcs () =
+  (* BUG FIX: In multi-column mode, moving up from the first service
+     in a column should go to Browse RPCs (last menu item),
+     not Install new instance (first menu item) *)
+  let services = multi_role_services () in
+  let s =
+    make_state
+      ~selected:services_start_idx
+      ~num_columns:2
+      ~active_column:0
+      services
+  in
+  let s' = move s (-1) in
+  check
+    int
+    "lands on Browse RPCs (last menu item)"
+    (menu_item_count - 1)
+    s'.selected
+
+let test_multi_column_up_from_second_column_to_browse_rpcs () =
+  (* Same fix applies when navigating up from column 1 *)
+  let services = multi_role_services () in
+  (* Find the first service index in column 1 *)
+  let col1_services =
+    Instances_layout.services_in_column ~num_columns:2 ~services 1
+  in
+  match col1_services with
+  | [] -> (* Column 1 is empty, skip test *) ()
+  | first_idx :: _ ->
+      let s =
+        make_state
+          ~selected:(first_idx + services_start_idx)
+          ~num_columns:2
+          ~active_column:1
+          services
+      in
+      let s' = move s (-1) in
+      check
+        int
+        "from column 1, lands on Browse RPCs"
+        (menu_item_count - 1)
+        s'.selected
+
+let test_multi_column_down_from_menu_to_service () =
+  (* Down from last menu item should go to first service in column 0 *)
+  let services = multi_role_services () in
+  let s =
+    make_state
+      ~selected:(menu_item_count - 1)
+      ~num_columns:2
+      ~active_column:0
+      services
+  in
+  let s' = move s 1 in
+  (* Should land on a service (index >= services_start_idx) *)
+  check bool "lands on a service" true (s'.selected >= services_start_idx) ;
+  check int "active_column is 0" 0 s'.active_column
+
+let test_multi_column_menu_navigation () =
+  (* Within the menu area, up/down should work linearly *)
+  let services = multi_role_services () in
+  let s = make_state ~selected:0 ~num_columns:2 services in
+  (* Down through menu *)
+  let s' = move s 1 in
+  check int "0 -> 1" 1 s'.selected ;
+  let s' = move s' 1 in
+  check int "1 -> 2" 2 s'.selected ;
+  (* Up through menu *)
+  let s' = move s' (-1) in
+  check int "2 -> 1" 1 s'.selected ;
+  let s' = move s' (-1) in
+  check int "1 -> 0" 0 s'.selected
+
+let test_multi_column_up_does_not_overshoot_menu () =
+  (* Moving up from menu item 0 should stay at 0 *)
+  let services = multi_role_services () in
+  let s = make_state ~selected:0 ~num_columns:2 services in
+  let s' = move s (-1) in
+  check int "stays at 0" 0 s'.selected
+
+let test_multi_column_roundtrip () =
+  (* Down from Browse RPCs to first service, then back up should return
+     to Browse RPCs *)
+  let services = multi_role_services () in
+  let s =
+    make_state
+      ~selected:(menu_item_count - 1)
+      ~num_columns:2
+      ~active_column:0
+      services
+  in
+  (* Down to first service *)
+  let s' = move s 1 in
+  check bool "now on a service" true (s'.selected >= services_start_idx) ;
+  (* Back up to menu *)
+  let s' = move s' (-1) in
+  check int "roundtrip returns to Browse RPCs" (menu_item_count - 1) s'.selected
+
+(* ============================================================ *)
+(* Empty state tests                                            *)
+(* ============================================================ *)
+
+let test_empty_state_stays_at_install () =
+  let s = make_state ~selected:0 ~num_columns:1 [] in
+  let s' = move s 1 in
+  check int "stays at Install" 0 s'.selected ;
+  let s' = move s (-1) in
+  check int "stays at Install (up)" 0 s'.selected
+
+let test_empty_state_multi_column () =
+  let s = make_state ~selected:0 ~num_columns:2 [] in
+  let s' = move s 1 in
+  check int "stays at Install" 0 s'.selected
+
+(* ============================================================ *)
+(* Test Suite                                                   *)
+(* ============================================================ *)
+
+let () =
+  Alcotest.run
+    "Instances Navigation"
+    [
+      ( "single-column",
+        [
+          ( "up from first service -> Browse RPCs",
+            `Quick,
+            test_single_column_up_from_first_service );
+          ( "down from Browse RPCs -> first service",
+            `Quick,
+            test_single_column_down_from_browse_rpcs );
+          ( "navigate through menu items",
+            `Quick,
+            test_single_column_navigate_through_menu );
+        ] );
+      ( "multi-column",
+        [
+          ( "up from first service -> Browse RPCs (bug fix)",
+            `Quick,
+            test_multi_column_up_from_first_service_to_browse_rpcs );
+          ( "up from column 1 -> Browse RPCs",
+            `Quick,
+            test_multi_column_up_from_second_column_to_browse_rpcs );
+          ( "down from menu -> first service",
+            `Quick,
+            test_multi_column_down_from_menu_to_service );
+          ( "menu navigation is linear",
+            `Quick,
+            test_multi_column_menu_navigation );
+          ( "up does not overshoot menu",
+            `Quick,
+            test_multi_column_up_does_not_overshoot_menu );
+          ( "roundtrip Browse RPCs <-> service",
+            `Quick,
+            test_multi_column_roundtrip );
+        ] );
+      ( "empty-state",
+        [
+          ("stays at Install", `Quick, test_empty_state_stays_at_install);
+          ( "multi-column stays at Install",
+            `Quick,
+            test_empty_state_multi_column );
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- **Fixed** multi-column navigation bug where pressing Up from the first service in any column jumped to "Install new instance" instead of "Browse RPCs" (the last menu item), making it inconsistent with single-column mode
- **Extracted** `move_selection` from `Page_Impl` to module top level with `For_tests` exposure for testability
- **Added** 11 pure unit tests covering single-column, multi-column, and empty-state navigation

## Root Cause

Three places in `move_selection` hardcoded `selected = 0` when navigating upward from services to the menu area in multi-column mode. In single-column mode, the separator-skipping logic naturally landed on index 2 ("Browse RPCs"), but the multi-column branches bypassed that and went straight to index 0 ("Install new instance").

## Fix

Changed all three occurrences to `menu_item_count - 1` (index 2, "Browse RPCs").