### PR TITLE
fix(job_manager): make job timeout configurable to prevent snapshot download timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Systemd service template warnings about unknown keys `StartLimitIntervalSec` and `StartLimitBurst` in [Service] section (moved to [Unit] section)
 - Pressing or holding Esc on modals no longer accidentally quits the application (Miaou Esc cooldown after modal close)
 - Application shutdown could hang for up to 10 minutes when background schedulers were sleeping; now exits within ~0.5s
+- Install-node and import-service jobs no longer time out after 120 seconds; long-running operations like snapshot downloads now run without a timeout (fixes #676)
 
 ### Removed
 

--- a/src/ui/job_manager.ml
+++ b/src/ui/job_manager.ml
@@ -18,13 +18,15 @@ type job = {
   mutable finished_at : float option;
   mutable log : string list;
   mutable phase : string;
+  timeout : float option;
 }
 
 let jobs : job list ref = ref []
 
 let next_id = ref 1
 
-let submit ?(on_complete = fun _ -> ()) ~description action =
+let submit ?(on_complete = fun _ -> ()) ?(timeout = Some 120.0) ~description
+    action =
   let id = !next_id in
   incr next_id ;
   let job =
@@ -36,6 +38,7 @@ let submit ?(on_complete = fun _ -> ()) ~description action =
       finished_at = None;
       log = [];
       phase = "";
+      timeout;
     }
   in
   jobs := job :: !jobs ;
@@ -76,22 +79,24 @@ let get_running_job () = List.find_opt (fun j -> j.status = Running) !jobs
 
 let get_latest_job () = match !jobs with [] -> None | job :: _ -> Some job
 
-let stuck_timeout_secs = 120.0
-
 let check_stuck_jobs () =
   let now = Unix.gettimeofday () in
   List.iter
     (fun job ->
-      match job.status with
-      | Running when now -. job.started_at > stuck_timeout_secs ->
+      match (job.status, job.timeout) with
+      | Running, Some timeout when now -. job.started_at > timeout ->
           job.status <- Failed "Operation timed out" ;
           job.finished_at <- Some now ;
           Context.toast_error
             (Printf.sprintf
                "Job \"%s\" timed out after %.0fs"
                job.description
-               stuck_timeout_secs)
+               timeout)
       | _ -> ())
     !jobs
 
 let tick () = check_stuck_jobs ()
+
+module For_tests = struct
+  let inject_job job = jobs := job :: !jobs
+end

--- a/src/ui/pages/import_wizard.ml
+++ b/src/ui/pages/import_wizard.ml
@@ -167,6 +167,7 @@ and start_import ps =
           | Job_manager.Failed msg ->
               Context.toast_error (Printf.sprintf "Import failed: %s" msg)
           | Job_manager.Pending | Job_manager.Running -> ())
+        ~timeout:None
         ~description:"Import external service"
         import_task ;
       Navigation.update (fun s -> {s with step = Importing; error = None}) ps

--- a/src/ui/pages/install_node_form_v3.ml
+++ b/src/ui/pages/install_node_form_v3.ml
@@ -987,6 +987,7 @@ let spec =
           else Printf.sprintf "Install node %s" model.core.instance_name
         in
         Job_manager.submit
+          ~timeout:None
           ~description
           (fun ~append_log () ->
             (* In edit mode, stop the service and dependents before applying changes *)

--- a/test/unit_tests.ml
+++ b/test/unit_tests.ml
@@ -3063,6 +3063,56 @@ let job_manager_submit_and_list () =
   (* But we verified submission works. *)
   ()
 
+let job_manager_timeout_kills_expired_job () =
+  let open Octez_manager_ui in
+  Job_manager.clear_finished () ;
+  (* Create a job that "started" 200 seconds ago with a 120s timeout *)
+  let fake_job : Job_manager.job =
+    {
+      id = 9999;
+      description = "should-timeout";
+      status = Running;
+      started_at = Unix.gettimeofday () -. 200.0;
+      finished_at = None;
+      log = [];
+      phase = "";
+      timeout = Some 120.0;
+    }
+  in
+  Job_manager.For_tests.inject_job fake_job ;
+  Job_manager.tick () ;
+  (match fake_job.status with
+  | Failed msg ->
+      Alcotest.(check bool) "timed out message" true (String.length msg > 0)
+  | _ -> Alcotest.fail "expected job to be Failed after timeout") ;
+  Job_manager.clear_finished ()
+
+let job_manager_no_timeout_keeps_running () =
+  let open Octez_manager_ui in
+  Job_manager.clear_finished () ;
+  (* Create a job that "started" 1000 seconds ago with no timeout *)
+  let fake_job : Job_manager.job =
+    {
+      id = 9998;
+      description = "no-timeout-job";
+      status = Running;
+      started_at = Unix.gettimeofday () -. 1000.0;
+      finished_at = None;
+      log = [];
+      phase = "";
+      timeout = None;
+    }
+  in
+  Job_manager.For_tests.inject_job fake_job ;
+  Job_manager.tick () ;
+  (match fake_job.status with
+  | Running -> ()
+  | Failed _ -> Alcotest.fail "job with timeout=None should not be timed out"
+  | _ -> Alcotest.fail "unexpected status") ;
+  (* Cleanup: manually mark it done so clear_finished works *)
+  fake_job.status <- Succeeded ;
+  Job_manager.clear_finished ()
+
 let background_runner_enqueue_sync () =
   let module BR = Octez_manager_ui.Background_runner in
   let did_run = ref false in
@@ -5090,6 +5140,14 @@ let () =
       ( "job_manager",
         [
           Alcotest.test_case "submit" `Quick job_manager_submit_and_list;
+          Alcotest.test_case
+            "timeout kills expired job"
+            `Quick
+            job_manager_timeout_kills_expired_job;
+          Alcotest.test_case
+            "no timeout keeps running"
+            `Quick
+            job_manager_no_timeout_keeps_running;
           Alcotest.test_case
             "enqueue sync"
             `Quick


### PR DESCRIPTION
## Summary

- **Root cause**: The global 120-second `stuck_timeout_secs` in `Job_manager` was killing all background jobs after 2 minutes, including long-running snapshot downloads during node installation
- **Fix**: Added an optional `~timeout` parameter to `Job_manager.submit` (`Some 120.0` default for backward compat, `None` to disable timeout). Install-node and import-service jobs now use `~timeout:None`
- **Tests**: Two new unit tests verify that jobs with `Some timeout` are killed when expired, and jobs with `timeout = None` are never killed by `check_stuck_jobs`

Fixes #676

## Changes

| File | Change |
|------|--------|
| `src/ui/job_manager.ml` | Added `timeout : float option` to `job` record, `?(timeout = Some 120.0)` to `submit`, updated `check_stuck_jobs` to use per-job timeout, added `For_tests.inject_job` |
| `src/ui/pages/install_node_form_v3.ml` | Pass `~timeout:None` to `Job_manager.submit` |
| `src/ui/pages/import_wizard.ml` | Pass `~timeout:None` to `Job_manager.submit` |
| `test/unit_tests.ml` | Two new tests: `timeout kills expired job`, `no timeout keeps running` |
| `CHANGELOG.md` | Added fix entry |

## Callers analysis

| Caller | Timeout | Rationale |
|--------|---------|-----------|
| `install_node_form_v3.ml` | `None` | Snapshot downloads can take hours |
| `import_wizard.ml` | `None` | Service import can involve large data copies |
| `instances_helpers.ml` | `Some 120.0` (default) | Start/stop/restart - should complete quickly |
| `instances_lifecycle.ml` | `Some 120.0` (default) | Start/restart cascade - should complete quickly |
| `rpc_openapi.ml` | `Some 120.0` (default) | OpenAPI spec download - small file |
| `modal_helpers.ml` | `Some 120.0` (default) | Spinner modal for RPC browser |