### PR TITLE
fix(form_builder): remove premature model reset that caused visual flash on submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Pressing or holding Esc on modals no longer accidentally quits the application (Miaou Esc cooldown after modal close)
 - Application shutdown could hang for up to 10 minutes when background schedulers were sleeping; now exits within ~0.5s
 - Install-node and import-service jobs no longer time out after 120 seconds; long-running operations like snapshot downloads now run without a timeout (fixes #676)
+- Install/edit forms no longer flash with default values when submitting
 
 ### Removed
 

--- a/src/ui/form_builder.ml
+++ b/src/ui/form_builder.ml
@@ -549,9 +549,6 @@ struct
             match S.spec.on_submit model with
             | Ok () ->
                 Context.mark_instances_dirty () ;
-                (* Reset form to fresh initial values for next use *)
-                s.model_ref := S.spec.initial_model () ;
-                (* Navigate back to instances page via Context. *)
                 Context.navigate "instances" ;
                 s
             | Error (`Msg msg) ->
@@ -569,9 +566,6 @@ struct
         match S.spec.on_submit model with
         | Ok () ->
             Context.mark_instances_dirty () ;
-            (* Reset form to fresh initial values for next use *)
-            s.model_ref := S.spec.initial_model () ;
-            (* Navigate back to instances page via Context. *)
             Context.navigate "instances" ;
             s
         | Error (`Msg msg) ->


### PR DESCRIPTION
## Summary

- When pressing Enter to submit an install/edit form, the form fields would briefly flash back to their default values before navigating to the instances page
- The actual installation used the correct values -- the issue was purely cosmetic

## Root Cause

`proceed_with_submission` in `form_builder.ml` was doing two things in sequence:

1. **Reset the model**: `s.model_ref := S.spec.initial_model ()` (immediate)
2. **Request navigation**: `Context.navigate "instances"` (deferred -- consumed on next `refresh` tick)

Since `Context.navigate` sets a global `pending_navigation` ref that is only consumed on the next refresh cycle, the Miaou driver rendered one more frame of the form page with the already-reset default values before navigation completed.

## Fix

Removed the two `model_ref` reset lines. The reset was redundant because `init()` always creates a fresh model from `S.spec.initial_model()` each time the form page is navigated to.

## Changes

| File | Change |
|------|--------|
| `src/ui/form_builder.ml` | Removed `s.model_ref := S.spec.initial_model ()` from both branches of `proceed_with_submission` |
| `CHANGELOG.md` | Added fix entry |