### PR TITLE
fix(ci): set safe.directory unconditionally in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           fetch-depth: 0  # Need full history for coverage comparison
 
+      - name: Mark workspace as safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Cache opam packages
         id: cache-opam
         uses: actions/cache@v4
@@ -81,7 +84,6 @@ jobs:
         if: steps.cache-opam.outputs.cache-hit != 'true' || steps.opam-init.outputs.switch-valid != 'true'
         run: |
           eval $(opam env)
-          git config --global --add safe.directory "$PWD"
           opam install . --deps-only --with-test --jobs=4
 
       - name: Build instrumented static binary


### PR DESCRIPTION
## Summary

- add a dedicated `git safe.directory` step immediately after checkout in `coverage.yml`
- remove the previous conditional `safe.directory` config from the dependency install step
- fix `git checkout -- static_flags.sexp` failures on cache-hit runs in the coverage job

## Why

`safe.directory` was only configured when the opam cache missed. On cache hits, the step was skipped and later git commands failed with:

`fatal: detected dubious ownership in repository`

This makes coverage on `main` intermittently red even when tests are fine.