### PR TITLE
fix(ui): keep RPC browser focus on existing pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- RPC Browser: toggling focus in side-by-side result mode now always targets an existing pager ID (avoids invalid focus state after pager removal)
 - Multi-column layout: pressing Up from the first instance now correctly navigates to "Browse RPCs" instead of jumping to "Install new instance"
 - Ghostnet network can no longer be selected despite deprecation (removed from all network selection code paths)
 - RPC Browser: Ghostnet URLs no longer appear in public nodes list (previously showed as "Unknown" network)

--- a/src/ui/pages/rpc_browser/rpc_browser_state.ml
+++ b/src/ui/pages/rpc_browser/rpc_browser_state.ml
@@ -211,7 +211,13 @@ let toggle_focus state =
   | Result ({focus; _} as r) ->
       let new_focus : result_focus =
         match (focus : result_focus) with
-        | FocusBrowser -> FocusPager 0
+        | FocusBrowser -> (
+            if List.exists (fun p -> p.id = r.last_pager_id) r.pagers then
+              FocusPager r.last_pager_id
+            else
+              match r.pagers with
+              | first :: _ -> FocusPager first.id
+              | [] -> FocusBrowser)
         | FocusPager _ -> FocusBrowser
       in
       {state with mode = Result {r with focus = new_focus}}

--- a/test/test_rpc_browser_state.ml
+++ b/test/test_rpc_browser_state.ml
@@ -170,6 +170,26 @@ let test_set_result () =
       Alcotest.(check string) "raw_body" "{}" slot.State.raw_body
   | None -> Alcotest.fail "expected focused pager"
 
+let test_toggle_focus_uses_existing_pager () =
+  let state = State.init ~instances:[] |> State.enter_result_mode in
+  let state =
+    match State.add_pager state with
+    | Some s -> s
+    | None -> Alcotest.fail "expected add_pager to succeed"
+  in
+  let state =
+    match State.remove_pager 0 state with
+    | Some s -> s
+    | None -> Alcotest.fail "expected remove_pager to succeed"
+  in
+  let state = State.focus_browser state |> State.toggle_focus in
+  match state.mode with
+  | State.Result {focus = State.FocusPager id; _} ->
+      Alcotest.(check int) "focus existing pager" 1 id
+  | State.Result {focus = State.FocusBrowser; _} ->
+      Alcotest.fail "expected pager focus"
+  | State.List _ -> Alcotest.fail "expected Result mode"
+
 (* ============================================================ *)
 (* Cursor Tests                                                  *)
 (* ============================================================ *)
@@ -327,6 +347,10 @@ let () =
         [
           Alcotest.test_case "execute get" `Quick test_execute_get;
           Alcotest.test_case "set result" `Quick test_set_result;
+          Alcotest.test_case
+            "toggle focus uses existing pager"
+            `Quick
+            test_toggle_focus_uses_existing_pager;
         ] );
       ( "cursor",
         [


### PR DESCRIPTION
## Summary

- fix RPC browser result-mode focus toggle to select an existing pager ID instead of hardcoding pager `0`
- use `last_pager_id` when it is still present, otherwise fall back to the first available pager
- add regression test covering the flaky sequence: remove pager `0`, focus browser, then toggle focus back to pager
- add changelog entry under `Fixed`

## Why

A property test occasionally hit a sequence where pager `0` had been removed, then `toggle_focus` tried to focus pager `0` again. That produced an invalid state (`FocusPager 0` with no pager 0 in `pagers`) and flaky CI failures.

## Notes

I ran commands with `eval $(opam env)` as requested. Full local execution is currently blocked by an existing environment mismatch (multiple unrelated UI module compile errors), so validation relies on CI for this branch.