### PR TITLE
feat(ui): wrap binaries page sections in Box_widget borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **CI optimization**: Integration tests within each shard now run in parallel (3 jobs per shard), reducing per-shard time by ~40-50%
 - **CI optimization**: Docker layer caching for integration tests reduces container build time by 40-60% (2-3 min per run)
 - Diagnostics page now uses bordered boxes (Box_widget) for cleaner visual section separation
+- Binaries page sections (Managed Versions, Registered Directories, Available for Download) now render with Box_widget Rounded borders in distinct colors instead of manual ASCII art
 - RPC browser now uses Grid_layout for side-by-side panel rendering
 - Instances page now uses Grid_layout for multi-column layout merging
 - Form navigation now supports Tab/Shift+Tab cycling between fields via Miaou Focus_ring

--- a/src/ui/pages/binaries/binaries_view.ml
+++ b/src/ui/pages/binaries/binaries_view.ml
@@ -11,6 +11,7 @@
     registered directories, available versions, and download progress. *)
 
 module Widgets = Miaou_widgets_display.Widgets
+module Box = Miaou_widgets_layout.Box_widget
 module Navigation = Miaou.Core.Navigation
 open Octez_manager_lib
 open Binaries_types
@@ -53,119 +54,120 @@ let set_help_hint s =
   | None -> Miaou.Core.Help_hint.clear ()
 
 (** Render the managed versions section. *)
-let render_managed_versions s add =
-  add
-    (Widgets.fg
-       14
-       (Widgets.bold
-          "\xe2\x94\x81\xe2\x94\x81\xe2\x94\x81 Managed Versions \
-           \xe2\x94\x81\xe2\x94\x81\xe2\x94\x81")) ;
-  add "" ;
-  if s.managed_versions = [] then
-    add (Widgets.dim "  No managed versions installed")
+let render_managed_versions s =
+  if s.managed_versions = [] then Widgets.dim "No managed versions installed"
   else
-    List.iteri
-      (fun _idx (version, size, count) ->
-        let is_selected =
-          match List.nth_opt s.items s.selected with
-          | Some (ManagedVersion (v, _, _)) when v = version -> true
-          | _ -> false
-        in
-        let prefix = if is_selected then "\xe2\x9e\xa4 " else "  " in
-        let size_str =
-          match size with
-          | Some s -> String_utils.format_size s
-          | None -> "unknown"
-        in
-        let usage =
-          if count = 0 then Widgets.dim "unused"
-          else if count = 1 then "1 instance"
-          else Printf.sprintf "%d instances" count
-        in
-        let expansion_indicator =
-          if count > 0 then
-            if List.mem version s.expanded_managed then " \xe2\x96\xbc"
-            else " \xe2\x96\xb6"
-          else ""
-        in
-        let line =
-          Printf.sprintf
-            "%sv%-15s  %10s  %s%s"
-            prefix
-            version
-            size_str
-            usage
-            expansion_indicator
-        in
-        add (if is_selected then Widgets.bold line else line) ;
-        if List.mem version s.expanded_managed then
-          let instances =
-            Service_registry.get_instances_using
-              (Binary_registry.Managed_version version)
+    let lines =
+      List.concat_map
+        (fun (version, size, count) ->
+          let is_selected =
+            match List.nth_opt s.items s.selected with
+            | Some (ManagedVersion (v, _, _)) when v = version -> true
+            | _ -> false
           in
-          List.iter
-            (fun inst ->
-              add (Widgets.dim (Printf.sprintf "      \xe2\x86\x92 %s" inst)))
-            instances)
-      s.managed_versions
+          let prefix = if is_selected then "\xe2\x9e\xa4 " else "  " in
+          let size_str =
+            match size with
+            | Some s -> String_utils.format_size s
+            | None -> "unknown"
+          in
+          let usage =
+            if count = 0 then Widgets.dim "unused"
+            else if count = 1 then "1 instance"
+            else Printf.sprintf "%d instances" count
+          in
+          let expansion_indicator =
+            if count > 0 then
+              if List.mem version s.expanded_managed then " \xe2\x96\xbc"
+              else " \xe2\x96\xb6"
+            else ""
+          in
+          let line =
+            Printf.sprintf
+              "%sv%-15s  %10s  %s%s"
+              prefix
+              version
+              size_str
+              usage
+              expansion_indicator
+          in
+          let main_line = if is_selected then Widgets.bold line else line in
+          if List.mem version s.expanded_managed then
+            let instances =
+              Service_registry.get_instances_using
+                (Binary_registry.Managed_version version)
+            in
+            let instance_lines =
+              List.map
+                (fun inst ->
+                  Widgets.dim (Printf.sprintf "      \xe2\x86\x92 %s" inst))
+                instances
+            in
+            main_line :: instance_lines
+          else [main_line])
+        s.managed_versions
+    in
+    String.concat "\n" lines
 
 (** Render the registered directories section. *)
-let render_registered_dirs s add =
-  add "" ;
-  add
-    (Widgets.fg
-       13
-       (Widgets.bold
-          "\xe2\x94\x81\xe2\x94\x81\xe2\x94\x81 Registered Directories \
-           \xe2\x94\x81\xe2\x94\x81\xe2\x94\x81")) ;
-  add
-    (Widgets.dim
-       "Register Octez binaries from development builds or custom locations") ;
-  add "" ;
-  if s.registered_dirs = [] then add (Widgets.dim "  No registered directories")
-  else
-    List.iter
-      (fun (ld, count) ->
-        let is_selected =
-          match List.nth_opt s.items s.selected with
-          | Some (RegisteredDir (ld2, _))
-            when ld.Binary_registry.alias = ld2.Binary_registry.alias ->
-              true
-          | _ -> false
-        in
-        let prefix = if is_selected then "\xe2\x9e\xa4 " else "  " in
-        let usage =
-          if count = 0 then Widgets.dim "unused"
-          else if count = 1 then "1 instance"
-          else Printf.sprintf "%d instances" count
-        in
-        let expansion_indicator =
-          if count > 0 then
-            if List.mem ld.Binary_registry.alias s.expanded_registered then
-              " \xe2\x96\xbc"
-            else " \xe2\x96\xb6"
-          else ""
-        in
-        let line =
-          Printf.sprintf
-            "%s%-20s  %s  %s%s"
-            prefix
-            ld.alias
-            (Widgets.dim ld.path)
-            usage
-            expansion_indicator
-        in
-        add (if is_selected then Widgets.bold line else line) ;
-        if List.mem ld.Binary_registry.alias s.expanded_registered then
-          let instances =
-            Service_registry.get_instances_using
-              (Binary_registry.Registered_alias ld.Binary_registry.alias)
+let render_registered_dirs s =
+  let header_lines =
+    [
+      Widgets.dim
+        "Register Octez binaries from development builds or custom locations";
+      "";
+    ]
+  in
+  let dir_lines =
+    if s.registered_dirs = [] then [Widgets.dim "No registered directories"]
+    else
+      List.concat_map
+        (fun (ld, count) ->
+          let is_selected =
+            match List.nth_opt s.items s.selected with
+            | Some (RegisteredDir (ld2, _))
+              when ld.Binary_registry.alias = ld2.Binary_registry.alias ->
+                true
+            | _ -> false
           in
-          List.iter
-            (fun inst ->
-              add (Widgets.dim (Printf.sprintf "      \xe2\x86\x92 %s" inst)))
-            instances)
-      s.registered_dirs ;
+          let prefix = if is_selected then "\xe2\x9e\xa4 " else "  " in
+          let usage =
+            if count = 0 then Widgets.dim "unused"
+            else if count = 1 then "1 instance"
+            else Printf.sprintf "%d instances" count
+          in
+          let expansion_indicator =
+            if count > 0 then
+              if List.mem ld.Binary_registry.alias s.expanded_registered then
+                " \xe2\x96\xbc"
+              else " \xe2\x96\xb6"
+            else ""
+          in
+          let line =
+            Printf.sprintf
+              "%s%-20s  %s  %s%s"
+              prefix
+              ld.alias
+              (Widgets.dim ld.path)
+              usage
+              expansion_indicator
+          in
+          let main_line = if is_selected then Widgets.bold line else line in
+          if List.mem ld.Binary_registry.alias s.expanded_registered then
+            let instances =
+              Service_registry.get_instances_using
+                (Binary_registry.Registered_alias ld.Binary_registry.alias)
+            in
+            let instance_lines =
+              List.map
+                (fun inst ->
+                  Widgets.dim (Printf.sprintf "      \xe2\x86\x92 %s" inst))
+                instances
+            in
+            main_line :: instance_lines
+          else [main_line])
+        s.registered_dirs
+  in
   (* Register directory button *)
   let link_action_selected =
     match List.nth_opt s.items s.selected with
@@ -176,98 +178,118 @@ let render_registered_dirs s add =
     let prefix = if link_action_selected then "\xe2\x9e\xa4 " else "  " in
     Printf.sprintf "%s%s" prefix (Widgets.fg 10 "[+ Register a directory...]")
   in
-  add (if link_action_selected then Widgets.bold link_button else link_button)
+  let button_line =
+    if link_action_selected then Widgets.bold link_button else link_button
+  in
+  String.concat "\n" (header_lines @ dir_lines @ [button_line])
 
 (** Render the available-for-download versions section. *)
-let render_available_versions s add =
-  add "" ;
-  add
-    (Widgets.fg
-       10
-       (Widgets.bold
-          "\xe2\x94\x81\xe2\x94\x81\xe2\x94\x81 Available for Download \
-           \xe2\x94\x81\xe2\x94\x81\xe2\x94\x81")) ;
-  add "" ;
+let render_available_versions s =
   if s.available_versions = [] then
-    add (Widgets.dim "  No versions available (or all installed)")
+    Widgets.dim "No versions available (or all installed)"
   else
-    List.iter
-      (fun item ->
-        match item with
-        | AvailableMajorGroup (major, versions) ->
-            let is_group_selected =
-              match List.nth_opt s.items s.selected with
-              | Some (AvailableMajorGroup (m, _)) when m = major -> true
-              | _ -> false
-            in
-            let is_expanded = List.mem major s.expanded_majors in
-            let expand_icon = if is_expanded then "\xe2\x88\x92" else "+" in
-            let prefix = if is_group_selected then "\xe2\x9e\xa4 " else "  " in
-            let version_count = List.length versions in
-            let group_line =
-              Printf.sprintf
-                "%s%s v%d  (%d version%s)"
-                prefix
-                expand_icon
-                major
-                version_count
-                (if version_count = 1 then "" else "s")
-            in
-            add
-              (if is_group_selected then Widgets.bold group_line else group_line) ;
-            if is_expanded then
-              List.iter
-                (fun (vi : Binary_downloader.version_info) ->
-                  let is_version_selected =
-                    match List.nth_opt s.items s.selected with
-                    | Some (AvailableVersion vi2)
-                      when vi.Binary_downloader.version
-                           = vi2.Binary_downloader.version ->
-                        true
-                    | _ -> false
-                  in
-                  let v_prefix =
-                    if is_version_selected then "  \xe2\x9e\xa4 " else "    "
-                  in
-                  let date_str =
-                    match vi.Binary_downloader.release_date with
-                    | Some d -> Printf.sprintf " - %s" d
-                    | None -> ""
-                  in
-                  let line =
-                    Printf.sprintf
-                      "  %sv%s%s"
-                      v_prefix
-                      vi.Binary_downloader.version
-                      date_str
-                  in
-                  add (if is_version_selected then Widgets.bold line else line))
-                versions
-        | _ -> ())
-      s.items
+    let lines =
+      List.concat_map
+        (fun item ->
+          match item with
+          | AvailableMajorGroup (major, versions) ->
+              let is_group_selected =
+                match List.nth_opt s.items s.selected with
+                | Some (AvailableMajorGroup (m, _)) when m = major -> true
+                | _ -> false
+              in
+              let is_expanded = List.mem major s.expanded_majors in
+              let expand_icon = if is_expanded then "\xe2\x88\x92" else "+" in
+              let prefix =
+                if is_group_selected then "\xe2\x9e\xa4 " else "  "
+              in
+              let version_count = List.length versions in
+              let group_line =
+                Printf.sprintf
+                  "%s%s v%d  (%d version%s)"
+                  prefix
+                  expand_icon
+                  major
+                  version_count
+                  (if version_count = 1 then "" else "s")
+              in
+              let main_line =
+                if is_group_selected then Widgets.bold group_line
+                else group_line
+              in
+              if is_expanded then
+                let version_lines =
+                  List.map
+                    (fun (vi : Binary_downloader.version_info) ->
+                      let is_version_selected =
+                        match List.nth_opt s.items s.selected with
+                        | Some (AvailableVersion vi2)
+                          when vi.Binary_downloader.version
+                               = vi2.Binary_downloader.version ->
+                            true
+                        | _ -> false
+                      in
+                      let v_prefix =
+                        if is_version_selected then "  \xe2\x9e\xa4 "
+                        else "    "
+                      in
+                      let date_str =
+                        match vi.Binary_downloader.release_date with
+                        | Some d -> Printf.sprintf " - %s" d
+                        | None -> ""
+                      in
+                      let line =
+                        Printf.sprintf
+                          "  %sv%s%s"
+                          v_prefix
+                          vi.Binary_downloader.version
+                          date_str
+                      in
+                      if is_version_selected then Widgets.bold line else line)
+                    versions
+                in
+                main_line :: version_lines
+              else [main_line]
+          | _ -> [])
+        s.items
+    in
+    String.concat "\n" lines
 
 (** Render download progress indicators. *)
-let render_progress add =
+let render_progress () =
   let multi_progress_lines = Context.render_multi_progress ~cols:80 in
-  if String.trim multi_progress_lines <> "" then (
-    add "" ;
-    add multi_progress_lines)
-  else (
-    add "" ;
+  if String.trim multi_progress_lines <> "" then multi_progress_lines
+  else
     let progress_line = Context.render_progress ~cols:80 in
-    if String.trim progress_line <> "" then add progress_line)
+    if String.trim progress_line <> "" then progress_line else ""
 
 (** Main view function for the binaries page. Assembles all sections. *)
-let view ps ~focus:_ ~size:_ =
+let view ps ~focus:_ ~size =
   let s = ps.Navigation.s in
-  let buf = Buffer.create 2048 in
-  let add line =
-    if Buffer.length buf > 0 then Buffer.add_char buf '\n' ;
-    Buffer.add_string buf line
-  in
+  let box_width = min 78 (size.LTerm_geom.cols - 2) in
   set_help_hint s ;
-  render_managed_versions s add ;
-  render_registered_dirs s add ;
-  render_available_versions s add ;
-  render_progress add ;
-  Buffer.contents buf
+  let sections =
+    [
+      Box.render
+        ~title:"Managed Versions"
+        ~style:Rounded
+        ~color:14
+        ~width:box_width
+        (render_managed_versions s);
+      Box.render
+        ~title:"Registered Directories"
+        ~style:Rounded
+        ~color:13
+        ~width:box_width
+        (render_registered_dirs s);
+      Box.render
+        ~title:"Available for Download"
+        ~style:Rounded
+        ~color:10
+        ~width:box_width
+        (render_available_versions s);
+    ]
+  in
+  let progress = render_progress () in
+  let sections = if progress = "" then sections else sections @ [progress] in
+  String.concat "\n" sections


### PR DESCRIPTION
## Summary

- Replace manual `━━━ Title ━━━` heavy-rule headers in the binaries page with Miaou `Box_widget` Rounded borders
- Each section (Managed Versions, Registered Directories, Available for Download) renders inside a titled, colored box
- Section renderers now return strings instead of using `add` callback pattern

## Stacked on

This PR is based on **#689** (`feat/miaou-0.3-adoption`).

## Test plan

- [ ] Verify binaries page renders with bordered sections
- [ ] Check box width adapts to terminal size
- [ ] Verify selection cursor and expansion indicators still work inside boxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)