### PR TITLE
feat(core): add Signatory service type and validation

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -39,6 +39,7 @@
   settings
   service_backend
   installer_types
+  signatory_validation
   manager_interfaces
   capabilities
   rpc_addr

--- a/src/external_service.ml
+++ b/src/external_service.ml
@@ -7,13 +7,14 @@
 
 (** {1 Role Detection} *)
 
-type role = Node | Baker | Accuser | Dal_node | Unknown of string
+type role = Node | Baker | Accuser | Dal_node | Signatory | Unknown of string
 
 let role_to_string = function
   | Node -> "node"
   | Baker -> "baker"
   | Accuser -> "accuser"
   | Dal_node -> "dal-node"
+  | Signatory -> "signatory"
   | Unknown s -> s
 
 let role_of_string = function
@@ -21,6 +22,7 @@ let role_of_string = function
   | "baker" -> Baker
   | "accuser" -> Accuser
   | "dal-node" | "dal" -> Dal_node
+  | "signatory" -> Signatory
   | s -> Unknown s
 
 let role_of_binary_name ?subcommand binary_name =
@@ -40,6 +42,7 @@ let role_of_binary_name ?subcommand binary_name =
         || String.starts_with ~prefix:"tezos-accuser" name
       then Accuser
       else if String.starts_with ~prefix:"octez-dal-node" name then Dal_node
+      else if String.starts_with ~prefix:"signatory" name then Signatory
       else Unknown name
 
 (** {1 Confidence Tracking} *)

--- a/src/external_service.mli
+++ b/src/external_service.mli
@@ -14,7 +14,7 @@
 (** {1 Role Detection} *)
 
 (** Service role detected from binary name. *)
-type role = Node | Baker | Accuser | Dal_node | Unknown of string
+type role = Node | Baker | Accuser | Dal_node | Signatory | Unknown of string
 
 (** Convert a role to its string representation (e.g. [Node -> "node"]). *)
 val role_to_string : role -> string

--- a/src/external_service_detector.ml
+++ b/src/external_service_detector.ml
@@ -340,6 +340,10 @@ let detect_daily_logs_dir ~role ~data_dir ~base_dir =
   | External_service.Dal_node ->
       (* DAL node: <data_dir>/daily_logs/ *)
       check_dir (Filename.concat data_dir "daily_logs")
+  | External_service.Signatory ->
+      (* Signatory: <base_dir>/logs/signatory/ *)
+      let base = if base_dir <> "" then base_dir else data_dir in
+      check_dir (Filename.concat (Filename.concat base "logs") "signatory")
   | External_service.Unknown _ ->
       (* Unknown role: try generic daily_logs *)
       check_dir (Filename.concat data_dir "daily_logs")
@@ -480,6 +484,9 @@ let build_external_service ~unit_name ~exec_start ~properties =
           | External_service.Dal_node ->
               (* Baker/Accuser/DAL: probe their connected node's endpoint *)
               endpoint_field.value
+          | External_service.Signatory ->
+              (* Signatory: doesn't connect to node RPC *)
+              None
           | External_service.Unknown _ -> (
               (* Unknown: try rpc_addr first, then endpoint *)
               match rpc_addr_field.value with
@@ -663,6 +670,9 @@ let process_to_external_service (proc : Process_scanner.process_info) =
           | External_service.Dal_node ->
               (* Baker/Accuser/DAL: probe their connected node's endpoint *)
               node_endpoint.value
+          | External_service.Signatory ->
+              (* Signatory: doesn't connect to node RPC *)
+              None
           | External_service.Unknown _ -> (
               (* Unknown: try rpc_addr first, then endpoint *)
               match rpc_addr.value with

--- a/src/installer/import.ml
+++ b/src/installer/import.ml
@@ -105,6 +105,7 @@ let missing_required_fields external_svc =
     | Some External_service.Baker -> ["network"; "base_dir"; "node_endpoint"]
     | Some External_service.Accuser -> ["network"; "base_dir"; "node_endpoint"]
     | Some External_service.Dal_node -> ["network"; "data_dir"; "node_endpoint"]
+    | Some External_service.Signatory -> ["address"; "authorized_keys"]
     | Some (External_service.Unknown _) | None -> []
   in
   List.filter
@@ -149,9 +150,10 @@ let resolve_data_dir ~overrides ~external_svc =
         ~field_name:"data_dir"
   | Some External_service.Baker
   | Some External_service.Accuser
+  | Some External_service.Signatory
   | Some (External_service.Unknown _)
   | None ->
-      Ok "" (* Not required for baker/accuser *)
+      Ok "" (* Not required for baker/accuser/signatory *)
 
 let resolve_base_dir ~overrides ~external_svc =
   let config = external_svc.External_service.config in
@@ -163,9 +165,10 @@ let resolve_base_dir ~overrides ~external_svc =
         ~field_name:"base_dir"
   | Some External_service.Node
   | Some External_service.Dal_node
+  | Some External_service.Signatory
   | Some (External_service.Unknown _)
   | None ->
-      Ok "" (* Not required for node/dal *)
+      Ok "" (* Not required for node/dal/signatory *)
 
 let resolve_rpc_addr ~overrides ~external_svc =
   let config = external_svc.External_service.config in
@@ -1181,6 +1184,11 @@ let import_service ?(on_log = fun _ -> ())
               ~bin_dir
               ~strategy:options.strategy
               ~depends_on:depends_on_instance
+        | Some External_service.Signatory ->
+            Error
+              (`Msg
+                 "Signatory import is not yet implemented. Please use 'om \
+                  install-signatory' to create a new signatory instance.")
         | Some (External_service.Unknown role_str) ->
             Error (`Msg (Printf.sprintf "Unknown role: %s" role_str))
         | None -> Error (`Msg "Role not detected for external service")

--- a/src/installer_types.ml
+++ b/src/installer_types.ml
@@ -128,6 +128,30 @@ type snapshot_metadata = {
   no_check : bool;
 }
 
+(** Signatory backend configuration *)
+type signatory_backend = File of string  (** Path to keys directory *)
+
+(** Signatory watermark backend *)
+type watermark_backend =
+  | Memory
+  | File_watermark of string  (** Path to watermark file *)
+
+(** Signatory installation request *)
+type signatory_request = {
+  instance : string;
+  backend : signatory_backend;
+  authorized_keys : string list;  (** tz1/tz2/tz3/tz4 public key hashes *)
+  address : string;  (** HTTP server address, e.g., "127.0.0.1:6732" *)
+  metrics_address : string;  (** Metrics endpoint address *)
+  watermark : watermark_backend;
+  service_user : string;
+  app_bin_dir : string;
+  bin_source : Binary_registry.bin_source option;
+  logging_mode : Logging_mode.t;
+  auto_enable : bool;
+  preserve_data : bool;
+}
+
 type file_backup = {tmp_path : string; original_path : string}
 
 (** Strategy for importing external services *)

--- a/src/log_viewer.ml
+++ b/src/log_viewer.ml
@@ -52,14 +52,14 @@ let get_daily_log_file ~role ~instance =
                 ~default:svc.Service.data_dir
             in
             Some (Filename.concat base "daily_logs")
-        | "signer" ->
-            (* Signer: <base_dir>/logs/octez-signer/ *)
+        | "signatory" ->
+            (* Signatory: <base_dir>/logs/signatory/ *)
             let base =
               Option.value
-                (lookup "OCTEZ_SIGNER_BASE_DIR")
+                (lookup "SIGNATORY_BASE_DIR")
                 ~default:svc.Service.data_dir
             in
-            Some (Filename.concat (Filename.concat base "logs") "octez-signer")
+            Some (Filename.concat (Filename.concat base "logs") "signatory")
         | _ -> Some (Filename.concat svc.Service.data_dir "daily_logs"))
   in
   match logs_dir with

--- a/src/signatory_validation.ml
+++ b/src/signatory_validation.ml
@@ -1,0 +1,113 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Validation functions for Signatory configuration *)
+
+open Rresult
+
+(** Validate a Tezos public key hash (tz1/tz2/tz3/tz4 format).
+    
+    @param pkh Public key hash string
+    @return Ok () if valid, Error with message otherwise *)
+let validate_public_key_hash pkh =
+  let len = String.length pkh in
+  if len < 36 then
+    Error (`Msg (Printf.sprintf "Invalid public key hash '%s': too short" pkh))
+  else
+    let prefix = String.sub pkh 0 3 in
+    match prefix with
+    | "tz1" | "tz2" | "tz3" | "tz4" ->
+        (* Basic validation: correct prefix and reasonable length *)
+        if len >= 36 && len <= 40 then Ok ()
+        else
+          Error
+            (`Msg
+               (Printf.sprintf
+                  "Invalid public key hash '%s': expected 36-40 characters, \
+                   got %d"
+                  pkh
+                  len))
+    | _ ->
+        Error
+          (`Msg
+             (Printf.sprintf
+                "Invalid public key hash '%s': must start with tz1, tz2, tz3, \
+                 or tz4"
+                pkh))
+
+(** Validate a list of authorized keys.
+    
+    @param keys List of public key hashes
+    @return Ok () if all valid, Error with message for first invalid key *)
+let validate_authorized_keys keys =
+  if keys = [] then Error (`Msg "At least one authorized key is required")
+  else
+    List.fold_left
+      (fun acc key ->
+        match acc with Error _ -> acc | Ok () -> validate_public_key_hash key)
+      (Ok ())
+      keys
+
+(** Validate an HTTP address (host:port format).
+    
+    @param addr Address string
+    @param name Field name for error messages
+    @return Ok () if valid, Error with message otherwise *)
+let validate_http_address ~addr ~name =
+  match String.split_on_char ':' addr with
+  | [host; port_str] -> (
+      if host = "" then
+        Error (`Msg (Printf.sprintf "%s: host cannot be empty" name))
+      else
+        try
+          let port = int_of_string port_str in
+          if port < 1 || port > 65535 then
+            Error
+              (`Msg (Printf.sprintf "%s: port must be between 1 and 65535" name))
+          else Ok ()
+        with Failure _ ->
+          Error
+            (`Msg (Printf.sprintf "%s: invalid port number '%s'" name port_str))
+      )
+  | _ ->
+      Error
+        (`Msg
+           (Printf.sprintf
+              "%s: must be in format 'host:port', got '%s'"
+              name
+              addr))
+
+(** Validate Signatory backend configuration.
+    
+    @param backend Backend configuration
+    @return Ok () if valid, Error with message otherwise *)
+let validate_backend = function
+  | Installer_types.File path ->
+      if path = "" then Error (`Msg "Backend: file path cannot be empty")
+      else Ok ()
+
+(** Validate watermark backend configuration.
+    
+    @param watermark Watermark backend configuration
+    @return Ok () if valid, Error with message otherwise *)
+let validate_watermark = function
+  | Installer_types.Memory -> Ok ()
+  | Installer_types.File_watermark path ->
+      if path = "" then Error (`Msg "Watermark: file path cannot be empty")
+      else Ok ()
+
+(** Validate a complete Signatory request.
+    
+    @param req Signatory installation request
+    @return Ok () if all fields valid, Error with first validation failure *)
+let validate_request (req : Installer_types.signatory_request) =
+  let open Rresult.R.Infix in
+  validate_authorized_keys req.authorized_keys >>= fun () ->
+  validate_http_address ~addr:req.address ~name:"address" >>= fun () ->
+  validate_http_address ~addr:req.metrics_address ~name:"metrics_address"
+  >>= fun () ->
+  validate_backend req.backend >>= fun () -> validate_watermark req.watermark

--- a/src/signatory_validation.mli
+++ b/src/signatory_validation.mli
@@ -1,0 +1,49 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Validation functions for Signatory configuration *)
+
+(** Validate a Tezos public key hash (tz1/tz2/tz3/tz4 format).
+    
+    @param pkh Public key hash string
+    @return [Ok ()] if valid, [Error] with message otherwise *)
+val validate_public_key_hash : string -> (unit, [> `Msg of string]) result
+
+(** Validate a list of authorized keys.
+    
+    @param keys List of public key hashes
+    @return [Ok ()] if all valid, [Error] with message for first invalid key *)
+val validate_authorized_keys : string list -> (unit, [> `Msg of string]) result
+
+(** Validate an HTTP address (host:port format).
+    
+    @param addr Address string
+    @param name Field name for error messages
+    @return [Ok ()] if valid, [Error] with message otherwise *)
+val validate_http_address :
+  addr:string -> name:string -> (unit, [> `Msg of string]) result
+
+(** Validate Signatory backend configuration.
+    
+    @param backend Backend configuration
+    @return [Ok ()] if valid, [Error] with message otherwise *)
+val validate_backend :
+  Installer_types.signatory_backend -> (unit, [> `Msg of string]) result
+
+(** Validate watermark backend configuration.
+    
+    @param watermark Watermark backend configuration
+    @return [Ok ()] if valid, [Error] with message otherwise *)
+val validate_watermark :
+  Installer_types.watermark_backend -> (unit, [> `Msg of string]) result
+
+(** Validate a complete Signatory request.
+    
+    @param req Signatory installation request
+    @return [Ok ()] if all fields valid, [Error] with first validation failure *)
+val validate_request :
+  Installer_types.signatory_request -> (unit, [> `Msg of string]) result

--- a/src/ui/pages/instances/instances_actions.ml
+++ b/src/ui/pages/instances/instances_actions.ml
@@ -152,14 +152,14 @@ let _view_logs_old state =
                 ~default:svc.Service.data_dir
             in
             Filename.concat base "daily_logs"
-        | "signer" ->
-            (* Signer: <base_dir>/logs/octez-signer/ *)
+        | "signatory" ->
+            (* Signatory: <base_dir>/logs/signatory/ *)
             let base =
               Option.value
-                (lookup "OCTEZ_SIGNER_BASE_DIR")
+                (lookup "SIGNATORY_BASE_DIR")
                 ~default:svc.Service.data_dir
             in
-            Filename.concat (Filename.concat base "logs") "octez-signer"
+            Filename.concat (Filename.concat base "logs") "signatory"
         | _ -> Filename.concat svc.Service.data_dir "daily_logs"
       in
       let daily_logs () =

--- a/src/ui/pages/instances/instances_layout.ml
+++ b/src/ui/pages/instances/instances_layout.ml
@@ -19,7 +19,7 @@ let role_order = function
   | "baker" -> 1
   | "accuser" -> 2
   | "dal-node" -> 3
-  | "signer" -> 4
+  | "signatory" -> 4
   | _ -> 5
 
 (** Role section headers *)
@@ -28,7 +28,7 @@ let role_header = function
   | "baker" -> "── Bakers ──"
   | "accuser" -> "── Accusers ──"
   | "dal-node" -> "── DAL Nodes ──"
-  | "signer" -> "── Signers ──"
+  | "signatory" -> "── Signatories ──"
   | r -> Printf.sprintf "── %s ──" (String.capitalize_ascii r)
 
 (** Sort services by role, then by instance name *)
@@ -58,7 +58,7 @@ let calc_num_columns ~cols ~min_column_width ~column_separator =
 
 (** Group services by role, preserving order *)
 let group_by_role services =
-  let roles = ["node"; "baker"; "accuser"; "dal-node"; "signer"] in
+  let roles = ["node"; "baker"; "accuser"; "dal-node"; "signatory"] in
   List.filter_map
     (fun role ->
       let instances =

--- a/test/dune
+++ b/test/dune
@@ -931,3 +931,10 @@
  (modules test_cli_helpers)
  (instrumentation
   (backend bisect_ppx)))
+
+(test
+ (name test_signatory_validation)
+ (libraries alcotest octez_manager_lib)
+ (modules test_signatory_validation)
+ (instrumentation
+  (backend bisect_ppx)))

--- a/test/test_instances_render_pure.ml
+++ b/test/test_instances_render_pure.ml
@@ -28,7 +28,7 @@ let test_role_header_known_roles () =
   check string "baker" "── Bakers ──" (Layout.role_header "baker") ;
   check string "accuser" "── Accusers ──" (Layout.role_header "accuser") ;
   check string "dal-node" "── DAL Nodes ──" (Layout.role_header "dal-node") ;
-  check string "signer" "── Signers ──" (Layout.role_header "signer")
+  check string "signatory" "── Signatories ──" (Layout.role_header "signatory")
 
 let test_role_header_unknown_capitalizes () =
   let h = Layout.role_header "foobar" in

--- a/test/test_signatory_validation.ml
+++ b/test/test_signatory_validation.ml
@@ -1,0 +1,215 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+open Octez_manager_lib
+
+let test_valid_public_key_hashes () =
+  let valid_keys =
+    [
+      "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb";
+      "tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m";
+      "tz3VEZ4k6a4Wx42iyev6i2aVAptTRLEAivNN";
+      "tz4HQ91B7jVojQDZKvApqMfsfPnkqzfG3zPp";
+    ]
+  in
+  List.iter
+    (fun key ->
+      match Signatory_validation.validate_public_key_hash key with
+      | Ok () -> ()
+      | Error (`Msg msg) ->
+          Alcotest.failf "Expected %s to be valid but got error: %s" key msg)
+    valid_keys
+
+let test_invalid_public_key_hashes () =
+  let invalid_keys =
+    [
+      ("", "Empty string");
+      ("tz1", "Too short");
+      ("tz5VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb", "Invalid prefix");
+      ("tx1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb", "Wrong prefix");
+      ("tz1short", "Too short hash");
+    ]
+  in
+  List.iter
+    (fun (key, description) ->
+      match Signatory_validation.validate_public_key_hash key with
+      | Ok () -> Alcotest.failf "%s: Expected %s to be invalid" description key
+      | Error (`Msg _) -> ())
+    invalid_keys
+
+let test_valid_authorized_keys () =
+  let keys =
+    [
+      "tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb";
+      "tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m";
+    ]
+  in
+  match Signatory_validation.validate_authorized_keys keys with
+  | Ok () -> ()
+  | Error (`Msg msg) ->
+      Alcotest.failf "Expected valid authorized keys but got error: %s" msg
+
+let test_empty_authorized_keys () =
+  match Signatory_validation.validate_authorized_keys [] with
+  | Ok () -> Alcotest.fail "Expected error for empty authorized keys"
+  | Error (`Msg msg) ->
+      Alcotest.(check string)
+        "Error message"
+        "At least one authorized key is required"
+        msg
+
+let test_authorized_keys_with_invalid () =
+  let keys = ["tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"; "invalid_key"] in
+  match Signatory_validation.validate_authorized_keys keys with
+  | Ok () -> Alcotest.fail "Expected error for invalid key in list"
+  | Error (`Msg _) -> ()
+
+let test_valid_http_addresses () =
+  let addresses =
+    [
+      ("127.0.0.1:6732", "Localhost IPv4");
+      ("0.0.0.0:8080", "Any address");
+      ("192.168.1.100:9000", "Private network");
+      ("signatory.example.com:6732", "Domain name");
+    ]
+  in
+  List.iter
+    (fun (addr, description) ->
+      match
+        Signatory_validation.validate_http_address ~addr ~name:"test address"
+      with
+      | Ok () -> ()
+      | Error (`Msg msg) ->
+          Alcotest.failf
+            "%s: Expected %s to be valid but got error: %s"
+            description
+            addr
+            msg)
+    addresses
+
+let test_invalid_http_addresses () =
+  let addresses =
+    [
+      ("localhost", "Missing port");
+      (":6732", "Missing host");
+      ("127.0.0.1:0", "Port too low");
+      ("127.0.0.1:65536", "Port too high");
+      ("127.0.0.1:abc", "Invalid port");
+      ("127.0.0.1:6732:extra", "Too many colons");
+    ]
+  in
+  List.iter
+    (fun (addr, description) ->
+      match
+        Signatory_validation.validate_http_address ~addr ~name:"test address"
+      with
+      | Ok () -> Alcotest.failf "%s: Expected %s to be invalid" description addr
+      | Error (`Msg _) -> ())
+    addresses
+
+let test_valid_backends () =
+  let backends = [Installer_types.File "/path/to/keys"] in
+  List.iter
+    (fun backend ->
+      match Signatory_validation.validate_backend backend with
+      | Ok () -> ()
+      | Error (`Msg msg) ->
+          Alcotest.failf "Expected backend to be valid but got error: %s" msg)
+    backends
+
+let test_invalid_backends () =
+  let backends = [(Installer_types.File "", "Empty file path")] in
+  List.iter
+    (fun (backend, description) ->
+      match Signatory_validation.validate_backend backend with
+      | Ok () -> Alcotest.failf "%s: Expected backend to be invalid" description
+      | Error (`Msg _) -> ())
+    backends
+
+let test_valid_watermarks () =
+  let watermarks =
+    [
+      Installer_types.Memory;
+      Installer_types.File_watermark "/path/to/watermark.json";
+    ]
+  in
+  List.iter
+    (fun watermark ->
+      match Signatory_validation.validate_watermark watermark with
+      | Ok () -> ()
+      | Error (`Msg msg) ->
+          Alcotest.failf "Expected watermark to be valid but got error: %s" msg)
+    watermarks
+
+let test_invalid_watermarks () =
+  let watermarks = [(Installer_types.File_watermark "", "Empty file path")] in
+  List.iter
+    (fun (watermark, description) ->
+      match Signatory_validation.validate_watermark watermark with
+      | Ok () ->
+          Alcotest.failf "%s: Expected watermark to be invalid" description
+      | Error (`Msg _) -> ())
+    watermarks
+
+let test_valid_request () =
+  let req : Installer_types.signatory_request =
+    {
+      instance = "test-signatory";
+      backend = Installer_types.File "/keys";
+      authorized_keys = ["tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb"];
+      address = "127.0.0.1:6732";
+      metrics_address = "127.0.0.1:9090";
+      watermark = Installer_types.Memory;
+      service_user = "tezos";
+      app_bin_dir = "/usr/local/bin";
+      bin_source = None;
+      logging_mode = Logging_mode.Journald;
+      auto_enable = true;
+      preserve_data = false;
+    }
+  in
+  match Signatory_validation.validate_request req with
+  | Ok () -> ()
+  | Error (`Msg msg) ->
+      Alcotest.failf "Expected request to be valid but got error: %s" msg
+
+let () =
+  let open Alcotest in
+  run
+    "Signatory Validation"
+    [
+      ( "Public Key Hashes",
+        [
+          test_case "valid key hashes" `Quick test_valid_public_key_hashes;
+          test_case "invalid key hashes" `Quick test_invalid_public_key_hashes;
+        ] );
+      ( "Authorized Keys",
+        [
+          test_case "valid authorized keys" `Quick test_valid_authorized_keys;
+          test_case "empty authorized keys" `Quick test_empty_authorized_keys;
+          test_case
+            "authorized keys with invalid"
+            `Quick
+            test_authorized_keys_with_invalid;
+        ] );
+      ( "HTTP Addresses",
+        [
+          test_case "valid HTTP addresses" `Quick test_valid_http_addresses;
+          test_case "invalid HTTP addresses" `Quick test_invalid_http_addresses;
+        ] );
+      ( "Backends",
+        [
+          test_case "valid backends" `Quick test_valid_backends;
+          test_case "invalid backends" `Quick test_invalid_backends;
+        ] );
+      ( "Watermarks",
+        [
+          test_case "valid watermarks" `Quick test_valid_watermarks;
+          test_case "invalid watermarks" `Quick test_invalid_watermarks;
+        ] );
+      ("Requests", [test_case "valid request" `Quick test_valid_request]);
+    ]


### PR DESCRIPTION
## Summary

Implements core infrastructure for Signatory remote signer support as part of milestone #7. This PR adds the foundational types, validation, and service role integration needed for managing Signatory as a systemd service.

**Scope**: This PR implements **File backend only** to keep the initial implementation simple. HSM/KMS backends will be added in issue #715.

## Changes

### Core Types (`src/installer_types.ml`)
- Added `signatory_backend` type:
  - ✅ **File** - File-based key storage
  - 🔜 YubiHSM, Azure KMS, AWS KMS, GCP KMS, Vault (see #715)
- Added `watermark_backend` type:
  - ✅ **Memory** - In-memory watermarks
  - ✅ **File** - File-based watermark storage
  - 🔜 AWS DynamoDB, GCP Firestore (see #715)
- Added `signatory_request` type with all installation fields

### Service Role Integration
- Added `Signatory` variant to `External_service.role` type
- Updated `role_to_string`, `role_of_string`, `role_of_binary_name`
- Fixed exhaustive pattern matches across 10+ locations:
  - `src/external_service_detector.ml`
  - `src/installer/import.ml`
  - `src/log_viewer.ml`
  - `src/ui/pages/instances/instances_actions.ml`
  - `src/ui/pages/instances/instances_layout.ml`

### Validation Module (`src/signatory_validation.ml`)
- `validate_address`: validates host:port format, port range [1-65535]
- `validate_authorized_keys`: validates Tezos public key hash formats (tz1/tz2/tz3/tz4)
- `validate_backend`: validates File backend configuration
- `validate_watermark`: validates Memory and File watermark backends
- `validate_request`: comprehensive validation of signatory_request

### UI Updates
- Updated instances layout to display "Signatories" section
- Updated log viewer to handle signatory log directories

### Tests
- Added comprehensive unit tests (`test/test_signatory_validation.ml`)
- Tests cover address validation, public key hash validation, backend validation
- All tests passing ✅
- Updated existing test for new role display

## Related

Closes #700

Part of milestone #7 (Signatory Remote Signer Support)

## Testing

```bash
dune build
dune runtest
dune fmt
./scripts/check-copyright.sh
```

All checks passing.

## Future Work

The following will be added in separate PRs:
- **Issue #715**: HSM/KMS Backend Support (YubiHSM, Azure/AWS/GCP KMS, Vault, DynamoDB, Firestore)
- **Issue #701**: Installer module (systemd, config generation)
- **Issue #702**: CLI commands (`om install-signatory`)
- **Issue #703**: TUI installation wizard

Co-Authored-By: Claude <noreply@anthropic.com>