### PR TITLE
feat(tui): add signatory info page with CLI instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **TUI: Signatory info page**: New "Signatory" option in the "Install new instance" menu displays available Signatory versions from GitHub releases and shows CLI commands for downloading and managing Signatory binaries.
 - **Signatory binary download**: Unified binary management commands now support both Octez and Signatory binaries. Use `om binaries download octez VERSION` or `om binaries download signatory VERSION` to download from official sources. `om binaries list-remote` shows available versions for both types (Octez >= 23.0, Signatory >= 1.3.0). `om binaries remove octez VERSION` or `om binaries remove signatory VERSION` removes installations. Signatory binaries install to `~/.local/share/octez-manager/signatory-binaries/` with checksum verification and atomic installation. (Part of milestone #7, issue #709)
 - **Mutable pattern detection**: Architecture index now tracks usage of `ref`, `:=`, `!`, `Atomic`, and mutable record fields. New `arch_query mutables` command shows summary of mutable patterns across the codebase. CI blocks PRs that increase `mutable_fields` or `functions_with_mutables` metrics.
 - **Network topology page**: Canvas-rendered visualization of service dependency relationships, accessible via 't' key from instances page. Shows nodes as bordered boxes with status indicators, connected by dependency lines. Adapts layout for narrow terminals (vertical stack) and wide terminals (side-by-side roots).

--- a/src/ui/pages/instances/instances_actions.ml
+++ b/src/ui/pages/instances/instances_actions.ml
@@ -291,17 +291,19 @@ let create_menu_modal state =
   let open Modal_helpers in
   open_choice_modal
     ~title:"Create Service"
-    ~items:[`Node; `DalNode; `Baker; `Accuser]
+    ~items:[`Node; `DalNode; `Baker; `Accuser; `Signatory]
     ~to_string:(function
       | `Node -> "Node"
       | `DalNode -> "DAL Node"
       | `Baker -> "Baker"
-      | `Accuser -> "Accuser")
+      | `Accuser -> "Accuser"
+      | `Signatory -> "Signatory")
     ~on_select:(function
       | `Node -> Context.navigate Install_node_form_v3.name
       | `Baker -> Context.navigate Install_baker_form_v3.name
       | `Accuser -> Context.navigate Install_accuser_form_v3.name
-      | `DalNode -> Context.navigate Install_dal_node_form_v3.name)
+      | `DalNode -> Context.navigate Install_dal_node_form_v3.name
+      | `Signatory -> Context.navigate Signatory_info.name)
     () ;
   state
 

--- a/src/ui/pages/manager_app.ml
+++ b/src/ui/pages/manager_app.ml
@@ -19,6 +19,7 @@ let register_pages () =
   Install_dal_node_form_v3.register () ;
   Import_wizard.register () ;
   Binaries.register () ;
+  Signatory_info.register () ;
   Diagnostics.register () ;
   Log_viewer_page.register () ;
   Rpc_node_selection.register () ;

--- a/src/ui/pages/signatory_info.ml
+++ b/src/ui/pages/signatory_info.ml
@@ -1,0 +1,179 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Signatory information page - shows CLI commands and available versions *)
+
+open Octez_manager_lib
+
+let name = "signatory_info"
+
+type state = {versions : Signatory_downloader.version_info list option}
+
+type msg = unit
+
+type pstate = state Miaou.Core.Navigation.t
+
+let init () =
+  (* Try to fetch versions, but don't block if it fails *)
+  let versions =
+    match Signatory_downloader.fetch_versions ~include_prerelease:false () with
+    | Ok vs -> Some vs
+    | Error _ -> None
+  in
+  Miaou.Core.Navigation.make {versions}
+
+let update ps _ = ps
+
+let view ps ~focus:_ ~size:_ =
+  let s = ps.Miaou.Core.Navigation.s in
+  let open Miaou_widgets_display.Widgets in
+  let header =
+    [
+      title_highlight " Signatory Installation ";
+      "";
+      "Signatory is a remote-signing service for Tezos bakers.";
+      "";
+    ]
+  in
+  let versions_section =
+    match s.versions with
+    | Some versions ->
+        let version_lines =
+          [bold "Available Signatory Versions:"; ""]
+          @ (versions
+            |> List.filteri (fun i _ -> i < 5)
+            (* Show top 5 *)
+            |> List.map (fun (v : Signatory_downloader.version_info) ->
+                let date_str =
+                  match v.release_date with
+                  | Some d -> Printf.sprintf " (%s)" d
+                  | None -> ""
+                in
+                Printf.sprintf
+                  "  %s v%s%s"
+                  (if v.is_prerelease then yellow "●" else green "●")
+                  v.version
+                  date_str))
+        in
+        version_lines
+    | None ->
+        [
+          bold "Available Signatory Versions:";
+          "";
+          red "Failed to fetch versions from GitHub";
+        ]
+  in
+  let cli_section =
+    [
+      "";
+      "";
+      bold "To install Signatory, use the CLI:";
+      "";
+      dim "  # List available versions";
+      "  octez-manager binaries list-signatory";
+      "";
+      dim "  # Download a specific version";
+      "  octez-manager binaries download-signatory --version 1.3.1";
+      "";
+      dim "  # List installed versions";
+      "  octez-manager binaries list-managed-signatory";
+      "";
+      dim "  # Remove a version";
+      "  octez-manager binaries remove-signatory --version 1.3.1";
+      "";
+      "";
+      dim "Press Esc to go back";
+    ]
+  in
+  String.concat "\n" (header @ versions_section @ cli_section)
+
+let handle_key ps key ~size:_ =
+  match Miaou.Core.Keys.of_string key with
+  | Some Miaou.Core.Keys.Escape -> Miaou.Core.Navigation.back ps
+  | _ -> ps
+
+let handle_modal_key ps key ~size:_ =
+  Miaou.Core.Modal_manager.handle_key key ;
+  ps
+
+let has_modal _ = Miaou.Core.Modal_manager.has_active ()
+
+let move _ _ = assert false
+
+let service_select _ _ = assert false
+
+let service_cycle _ _ = assert false
+
+let back ps = Miaou.Core.Navigation.back ps
+
+let handled_keys () = Miaou.Core.Keys.[Escape]
+
+let keymap _ =
+  let noop ps = ps in
+  let kb key help =
+    {Miaou.Core.Tui_page.key; action = noop; help; display_only = true}
+  in
+  [kb "Esc" "Back"; kb "?" "Help"]
+
+module Page_Impl :
+  Miaou.Core.Tui_page.PAGE_SIG with type state = state and type msg = msg =
+struct
+  type nonrec state = state
+
+  type nonrec msg = msg
+
+  type nonrec pstate = pstate
+
+  type key_binding = state Miaou.Core.Tui_page.key_binding_desc
+
+  let init = init
+
+  let update = update
+
+  let refresh ps = ps
+
+  let view = view
+
+  let handle_key = handle_key
+
+  let handle_modal_key = handle_modal_key
+
+  let has_modal = has_modal
+
+  let move = move
+
+  let service_select = service_select
+
+  let service_cycle = service_cycle
+
+  let back = back
+
+  let handled_keys = handled_keys
+
+  let keymap = keymap
+
+  let on_key ps key ~size =
+    let ps' = handle_key ps (Miaou.Core.Keys.to_string key) ~size in
+    (ps', Miaou_interfaces.Key_event.Handled)
+
+  let on_modal_key ps key ~size =
+    let ps' = handle_modal_key ps (Miaou.Core.Keys.to_string key) ~size in
+    (ps', Miaou_interfaces.Key_event.Handled)
+
+  let key_hints _ps =
+    Miaou.Core.Tui_page.
+      [{key = "Esc"; help = "Back"}; {key = "?"; help = "Help"}]
+end
+
+let page : Miaou.Core.Registry.page =
+  (module struct
+    include Page_Impl
+  end)
+
+let register () =
+  if not (Miaou.Core.Registry.exists name) then
+    Miaou.Core.Registry.register name page


### PR DESCRIPTION
## Summary

Adds TUI support for Signatory by providing an information page that:
- Displays available Signatory versions fetched from GitHub releases
- Shows CLI commands for downloading and managing Signatory binaries
- Is accessible via the new "Signatory" option in the "Install new instance" menu

This is a temporary solution until full signatory installation is implemented in the TUI. For now, users can see what versions are available and use the CLI commands to manage signatory binaries.

## Changes

- **New Page**: `src/ui/pages/signatory_info.ml` - Information page for Signatory
- **Install Menu**: Added "Signatory" option to the install menu in `instances_actions.ml`
- **Registration**: Registered the new page in `manager_app.ml`
- **CHANGELOG**: Updated with new TUI feature

## Testing

- [x] Build succeeds
- [x] Tests pass
- [x] Code formatted with `dune fmt`
- [x] Copyright headers verified

## Related

- Builds on top of PR #716 which added CLI support for Signatory binary downloads
- Part of Signatory support milestone