### PR TITLE
fix(removal): skip deletion of shared data directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Baker/accuser purge preserves node data**: Purging a baker or accuser instance no longer deletes the node's blockchain data directory. Previously, `om instance purge <baker>` would delete the node's data even though the node instance still existed, causing data loss. The fix detects when a data directory is shared by multiple services and skips deletion, preventing scenarios where purging one baker breaks other services using the same node. (fixes #727)
 - **Signatory key storage**: `secret.json` is now generated as valid JSON (empty array `[]`) instead of with `#` comment instructions that caused JSON parse errors. Instructions moved to separate `secret.json.README` file in the keys directory. Users with existing installations should remove `#` comment lines from their `secret.json` files to avoid "invalid character" errors that prevent Signatory from loading keys.
 - **RPC Browser responsiveness**: HTTP requests and endpoint listing now run in background worker pool, preventing UI freezes during slow network responses (fixes #673)
 

--- a/src/installer/removal.ml
+++ b/src/installer/removal.ml
@@ -9,6 +9,17 @@ open Rresult
 include Helpers
 include Config
 
+(** Check if a data directory is shared by multiple services.
+    Returns true if other services (besides [instance]) use the same data_dir. *)
+let is_shared_data_dir ~instance ~data_dir () =
+  match Service_registry.list () with
+  | Error _ -> false
+  | Ok all_services ->
+      List.exists
+        (fun (svc : Service.t) ->
+          svc.instance <> instance && svc.data_dir = data_dir)
+        all_services
+
 let remove_service ?(quiet = false) ~delete_data_dir ~instance () =
   let* svc_opt = Service_registry.find ~instance in
   match svc_opt with
@@ -52,7 +63,15 @@ let remove_service ?(quiet = false) ~delete_data_dir ~instance () =
       Systemd.remove_dropin ~role:svc.role ~instance ;
       let* () =
         match delete_data_dir with
-        | true -> File_ops.remove_tree svc.data_dir
+        | true ->
+            if is_shared_data_dir ~instance ~data_dir:svc.data_dir () then (
+              if not quiet then
+                Format.printf
+                  "⚠ Skipping data directory deletion (shared with other \
+                   services): %s@."
+                  svc.data_dir ;
+              Ok ())
+            else File_ops.remove_tree svc.data_dir
         | false -> Ok ()
       in
       Service_registry.remove ~instance

--- a/test/integration/cli-tester/tests/accuser/24-accuser-purge-preserves-node-data.sh
+++ b/test/integration/cli-tester/tests/accuser/24-accuser-purge-preserves-node-data.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Test: Purging accuser preserves node's blockchain data
+set -euo pipefail
+source /tests/lib.sh
+
+test_init "Purging accuser preserves node blockchain data"
+
+NODE_INSTANCE="test-accuser-purge-node"
+ACCUSER_INSTANCE="test-accuser-purge"
+RPC_PORT=$(alloc_port)
+NET_PORT=$(alloc_port)
+NODE_RPC="127.0.0.1:$RPC_PORT"
+NODE_NET="0.0.0.0:$NET_PORT"
+
+register_instance "$ACCUSER_INSTANCE"
+register_instance "$NODE_INSTANCE"
+
+# Install a node first
+echo "Installing node..."
+om install-node \
+	--instance "$NODE_INSTANCE" \
+	--network shadownet \
+	--rpc-addr "$NODE_RPC" \
+	--net-addr "$NODE_NET" \
+	--service-user tezos \
+	--no-enable 2>&1
+
+# Verify node data directory exists
+NODE_DATA_DIR="/var/lib/octez/$NODE_INSTANCE"
+if [ ! -d "$NODE_DATA_DIR" ]; then
+	echo "ERROR: Node data directory not created: $NODE_DATA_DIR"
+	exit 1
+fi
+echo "Node data directory exists: $NODE_DATA_DIR"
+
+# Install accuser pointing to the node
+echo "Installing accuser..."
+om install-accuser \
+	--instance "$ACCUSER_INSTANCE" \
+	--node-instance "$NODE_INSTANCE" \
+	--service-user tezos \
+	--no-enable 2>&1
+
+# Verify accuser is installed
+if ! instance_exists "$ACCUSER_INSTANCE"; then
+	echo "ERROR: Accuser instance not in registry"
+	exit 1
+fi
+echo "Accuser instance registered"
+
+# Now purge the accuser - this should NOT delete the node's data directory
+echo "Purging accuser..."
+om instance "$ACCUSER_INSTANCE" purge 2>&1
+
+# Verify accuser is removed
+if instance_exists "$ACCUSER_INSTANCE"; then
+	echo "ERROR: Accuser still in registry after purge"
+	exit 1
+fi
+echo "Accuser purged successfully"
+
+# CRITICAL CHECK: Node data directory should still exist
+if [ ! -d "$NODE_DATA_DIR" ]; then
+	echo "ERROR: Node data directory was deleted when purging accuser!"
+	echo "This is the bug we're fixing - accuser purge should not delete node's blockchain data"
+	exit 1
+fi
+echo "✓ Node data directory preserved after accuser purge"
+
+# Verify node instance still exists in registry
+if ! instance_exists "$NODE_INSTANCE"; then
+	echo "ERROR: Node instance removed from registry"
+	exit 1
+fi
+echo "✓ Node instance still in registry"
+
+echo "Test passed: Accuser purge preserves node blockchain data"

--- a/test/integration/cli-tester/tests/baker/43-baker-purge-preserves-node-data.sh
+++ b/test/integration/cli-tester/tests/baker/43-baker-purge-preserves-node-data.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Test: Purging baker preserves node's blockchain data
+set -euo pipefail
+source /tests/lib.sh
+
+test_init "Purging baker preserves node blockchain data"
+
+NODE_INSTANCE="test-purge-node"
+BAKER_INSTANCE="test-purge-baker"
+RPC_PORT=$(alloc_port)
+NET_PORT=$(alloc_port)
+NODE_RPC="127.0.0.1:$RPC_PORT"
+NODE_NET="0.0.0.0:$NET_PORT"
+
+register_instance "$BAKER_INSTANCE"
+register_instance "$NODE_INSTANCE"
+
+# Install a node first
+echo "Installing node..."
+om install-node \
+	--instance "$NODE_INSTANCE" \
+	--network shadownet \
+	--rpc-addr "$NODE_RPC" \
+	--net-addr "$NODE_NET" \
+	--service-user tezos \
+	--no-enable 2>&1
+
+# Verify node data directory exists
+NODE_DATA_DIR="/var/lib/octez/$NODE_INSTANCE"
+if [ ! -d "$NODE_DATA_DIR" ]; then
+	echo "ERROR: Node data directory not created: $NODE_DATA_DIR"
+	exit 1
+fi
+echo "Node data directory exists: $NODE_DATA_DIR"
+
+# Install baker pointing to the node
+echo "Installing baker..."
+om install-baker \
+	--instance "$BAKER_INSTANCE" \
+	--node-instance "$NODE_INSTANCE" \
+	--liquidity-baking-vote pass \
+	--service-user tezos \
+	--no-enable 2>&1
+
+# Verify baker is installed
+if ! instance_exists "$BAKER_INSTANCE"; then
+	echo "ERROR: Baker instance not in registry"
+	exit 1
+fi
+echo "Baker instance registered"
+
+# Now purge the baker - this should NOT delete the node's data directory
+echo "Purging baker..."
+om instance "$BAKER_INSTANCE" purge 2>&1
+
+# Verify baker is removed
+if instance_exists "$BAKER_INSTANCE"; then
+	echo "ERROR: Baker still in registry after purge"
+	exit 1
+fi
+echo "Baker purged successfully"
+
+# CRITICAL CHECK: Node data directory should still exist
+if [ ! -d "$NODE_DATA_DIR" ]; then
+	echo "ERROR: Node data directory was deleted when purging baker!"
+	echo "This is the bug we're fixing - baker purge should not delete node's blockchain data"
+	exit 1
+fi
+echo "✓ Node data directory preserved after baker purge"
+
+# Verify node instance still exists in registry
+if ! instance_exists "$NODE_INSTANCE"; then
+	echo "ERROR: Node instance removed from registry"
+	exit 1
+fi
+echo "✓ Node instance still in registry"
+
+echo "Test passed: Baker purge preserves node blockchain data"

--- a/test/integration/cli-tester/tests/baker/44-multiple-bakers-shared-data.sh
+++ b/test/integration/cli-tester/tests/baker/44-multiple-bakers-shared-data.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Test: Purging one baker preserves shared node data for other bakers
+set -euo pipefail
+source /tests/lib.sh
+
+test_init "Multiple bakers sharing node - purge one preserves data"
+
+NODE_INSTANCE="test-multi-baker-node"
+BAKER1_INSTANCE="test-baker1"
+BAKER2_INSTANCE="test-baker2"
+RPC_PORT=$(alloc_port)
+NET_PORT=$(alloc_port)
+NODE_RPC="127.0.0.1:$RPC_PORT"
+NODE_NET="0.0.0.0:$NET_PORT"
+
+register_instance "$BAKER1_INSTANCE"
+register_instance "$BAKER2_INSTANCE"
+register_instance "$NODE_INSTANCE"
+
+# Install a node first
+echo "Installing node..."
+om install-node \
+	--instance "$NODE_INSTANCE" \
+	--network shadownet \
+	--rpc-addr "$NODE_RPC" \
+	--net-addr "$NODE_NET" \
+	--service-user tezos \
+	--no-enable 2>&1
+
+# Verify node data directory exists
+NODE_DATA_DIR="/var/lib/octez/$NODE_INSTANCE"
+if [ ! -d "$NODE_DATA_DIR" ]; then
+	echo "ERROR: Node data directory not created: $NODE_DATA_DIR"
+	exit 1
+fi
+echo "Node data directory exists: $NODE_DATA_DIR"
+
+# Install first baker
+echo "Installing baker1..."
+om install-baker \
+	--instance "$BAKER1_INSTANCE" \
+	--node-instance "$NODE_INSTANCE" \
+	--liquidity-baking-vote pass \
+	--service-user tezos \
+	--no-enable 2>&1
+
+# Install second baker on the same node
+echo "Installing baker2..."
+om install-baker \
+	--instance "$BAKER2_INSTANCE" \
+	--node-instance "$NODE_INSTANCE" \
+	--liquidity-baking-vote pass \
+	--service-user tezos \
+	--no-enable 2>&1
+
+# Verify both bakers are installed
+if ! instance_exists "$BAKER1_INSTANCE"; then
+	echo "ERROR: Baker1 instance not in registry"
+	exit 1
+fi
+if ! instance_exists "$BAKER2_INSTANCE"; then
+	echo "ERROR: Baker2 instance not in registry"
+	exit 1
+fi
+echo "Both bakers registered"
+
+# Now purge baker1 - this should NOT delete the node's data directory
+# because baker2 still uses it
+echo "Purging baker1..."
+om instance "$BAKER1_INSTANCE" purge 2>&1
+
+# Verify baker1 is removed
+if instance_exists "$BAKER1_INSTANCE"; then
+	echo "ERROR: Baker1 still in registry after purge"
+	exit 1
+fi
+echo "Baker1 purged successfully"
+
+# CRITICAL CHECK: Node data directory should still exist (baker2 still uses it)
+if [ ! -d "$NODE_DATA_DIR" ]; then
+	echo "ERROR: Node data directory was deleted when purging baker1!"
+	echo "Baker2 still depends on this data - this is the bug we're fixing"
+	exit 1
+fi
+echo "✓ Node data directory preserved (baker2 still uses it)"
+
+# Verify node and baker2 still exist
+if ! instance_exists "$NODE_INSTANCE"; then
+	echo "ERROR: Node instance removed from registry"
+	exit 1
+fi
+if ! instance_exists "$BAKER2_INSTANCE"; then
+	echo "ERROR: Baker2 removed from registry"
+	exit 1
+fi
+echo "✓ Node and baker2 still in registry"
+
+# Now purge baker2 - this should STILL NOT delete the node's data
+# because the node instance still exists
+echo "Purging baker2..."
+om instance "$BAKER2_INSTANCE" purge 2>&1
+
+# CRITICAL CHECK: Node data directory should still exist (node instance still exists)
+if [ ! -d "$NODE_DATA_DIR" ]; then
+	echo "ERROR: Node data directory was deleted when purging baker2!"
+	echo "Node instance still exists - this is the bug we're fixing"
+	exit 1
+fi
+echo "✓ Node data directory preserved (node instance still exists)"
+
+# Verify node still exists
+if ! instance_exists "$NODE_INSTANCE"; then
+	echo "ERROR: Node instance removed from registry"
+	exit 1
+fi
+echo "✓ Node instance still in registry"
+
+echo "Test passed: Multiple bakers sharing node data directory works correctly"


### PR DESCRIPTION
## Summary

Fixes #727 - Prevent data loss when purging bakers/accusers that share a node's blockchain data directory.

## Problem

When purging a baker or accuser instance, the operation would unconditionally delete the service's `data_dir` field, which points to the node's blockchain data directory. This caused data loss even though the node instance (and potentially other bakers/accusers) still existed and needed that data.

### Impact Scenarios

**Scenario 1: Single baker + node**
```bash
om install-node --instance my-node
om install-baker --instance my-baker --node my-node
om instance purge my-baker  # ← DELETES node's blockchain data!
# Node instance still exists but data is gone
```

**Scenario 2: Multiple bakers on same node**
```bash
om install-node --instance my-node
om install-baker --instance baker1 --node my-node
om install-baker --instance baker2 --node my-node
om instance purge baker1  # ← DELETES shared blockchain, breaking baker2!
```

**Scenario 3: Baker + accuser + node**
```bash
om install-node --instance my-node
om install-baker --instance my-baker --node my-node
om install-accuser --instance my-accuser --node my-node
om instance purge my-baker  # ← DELETES blockchain, breaking accuser!
```

## Solution

Added `is_shared_data_dir()` helper that checks if other services use the same data directory. When purging a service, if the data directory is shared, we skip deletion and display a warning:

```
⚠ Skipping data directory deletion (shared with other services): /var/lib/octez/my-node
```

This prevents all three scenarios above from causing data loss.

## Changes

**Core fix:**
- `src/installer/removal.ml`: Added shared data directory detection logic

**Testing:**
- `test/integration/cli-tester/tests/baker/43-baker-purge-preserves-node-data.sh`: Test baker purge preserves node data
- `test/integration/cli-tester/tests/baker/44-multiple-bakers-shared-data.sh`: Test multiple bakers sharing node data
- `test/integration/cli-tester/tests/accuser/24-accuser-purge-preserves-node-data.sh`: Test accuser purge preserves node data

**Documentation:**
- `CHANGELOG.md`: Added entry under Fixed section

## Testing

All existing tests pass. Three new integration tests cover the bug scenarios:
1. Purging a baker preserves the node's blockchain data
2. Purging one of multiple bakers preserves shared data
3. Purging an accuser preserves the node's blockchain data

Co-Authored-By: Claude <noreply@anthropic.com>