### PR TITLE
fix(signatory): use 'signatory@instance' service name instead of 'octez-signatory@instance'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Signatory service name**: Signatory services now use `signatory@instance` instead of `octez-signatory@instance` as the systemd service name. The "octez-" prefix was redundant since the signatory binary is not part of the Octez project. External service detector now recognizes both naming patterns for backward compatibility.
 - **TUI: Signatory install form improvements**: Backend selection now uses modal-based UI (File, YubiHSM, Azure KMS, AWS KMS, GCP KMS, Vault) instead of text input. Form validates signatory binary exists before allowing submission. Watermark field renamed to "Watermark Storage" for clarity. Defaults to latest managed Signatory version when available. Prevents duplicate authorized keys.
 - **TUI: Removed redundant "m" global menu**: The global "m" shortcut that opened a duplicate service installation menu has been removed. All service installation now goes through the "c" (Create Service) menu on the instances page, providing a single consistent installation path.
 - Instances page now groups services by role (Nodes, Bakers, Accusers, DAL nodes) with each group wrapped in a Box_widget container with distinct colors

--- a/src/external_service_detector.ml
+++ b/src/external_service_detector.ml
@@ -24,17 +24,22 @@ let clear_cache () = Mutex.protect cache_lock (fun () -> cache := [])
 (** {1 Filtering} *)
 
 (** Check if unit name matches octez-manager's naming convention.
-    Pattern: octez-<role>@<instance>.service *)
+    Patterns: 
+    - octez-<role>@<instance>.service (for node, baker, accuser, dal-node)
+    - signatory@<instance>.service (for signatory) *)
 let is_managed_unit_name unit_name =
-  (* Must start with "octez-" *)
-  if not (String.starts_with ~prefix:"octez-" unit_name) then false
-  else
+  (* Check for signatory@ pattern *)
+  if String.starts_with ~prefix:"signatory@" unit_name then
+    (* Must end with .service *)
+    String.ends_with ~suffix:".service" unit_name
+  else if String.starts_with ~prefix:"octez-" unit_name then
     (* Must contain exactly one @ symbol *)
     match String.split_on_char '@' unit_name with
     | [_role_part; instance_part] ->
         (* instance_part should end with .service *)
         String.ends_with ~suffix:".service" instance_part
     | _ -> false
+  else false
 
 let is_in_registry ~unit_name =
   (* Extract instance name from unit name *)
@@ -87,35 +92,41 @@ let list_all_service_units () =
     | Error _ -> []
   in
   let list_unit_files () =
-    let cmd =
-      Systemd.systemctl_cmd ()
-      @ [
-          "list-unit-files";
-          "--type=service";
-          "octez-*.service";
-          "--no-legend";
-          "--no-pager";
-        ]
+    (* Query both octez-* and signatory@ patterns *)
+    let query_pattern pattern =
+      let cmd =
+        Systemd.systemctl_cmd ()
+        @ [
+            "list-unit-files";
+            "--type=service";
+            pattern;
+            "--no-legend";
+            "--no-pager";
+          ]
+      in
+      match Cmd_runner.run_out cmd with
+      | Ok output ->
+          let lines = String.split_on_char '\n' output in
+          List.filter_map
+            (fun line ->
+              let trimmed = String.trim line in
+              if trimmed = "" then None
+              else
+                (* Line format: "unit.service   enabled/disabled/static" *)
+                (* Extract first field (unit name) *)
+                match String.split_on_char ' ' trimmed with
+                | unit_name :: _
+                  when String.ends_with ~suffix:".service" unit_name
+                       (* Skip template units (ending with @.service) *)
+                       && not (String.ends_with ~suffix:"@.service" unit_name)
+                  ->
+                    Some unit_name
+                | _ -> None)
+            lines
+      | Error _ -> []
     in
-    match Cmd_runner.run_out cmd with
-    | Ok output ->
-        let lines = String.split_on_char '\n' output in
-        List.filter_map
-          (fun line ->
-            let trimmed = String.trim line in
-            if trimmed = "" then None
-            else
-              (* Line format: "unit.service   enabled/disabled/static" *)
-              (* Extract first field (unit name) *)
-              match String.split_on_char ' ' trimmed with
-              | unit_name :: _
-                when String.ends_with ~suffix:".service" unit_name
-                     (* Skip template units (ending with @.service) *)
-                     && not (String.ends_with ~suffix:"@.service" unit_name) ->
-                  Some unit_name
-              | _ -> None)
-          lines
-    | Error _ -> []
+    (* Query both patterns and combine results *)
+    query_pattern "octez-*.service" @ query_pattern "signatory@*.service"
   in
   (* Get loaded units and unit files *)
   let loaded = list_loaded_units () in

--- a/src/systemd.ml
+++ b/src/systemd.ml
@@ -6,26 +6,43 @@
 (******************************************************************************)
 
 let system_unit_path role =
-  Printf.sprintf "/etc/systemd/system/octez-%s@.service" role
+  (* Signatory uses "signatory@.service", other services use "octez-<role>@.service" *)
+  match role with
+  | "signatory" -> "/etc/systemd/system/signatory@.service"
+  | _ -> Printf.sprintf "/etc/systemd/system/octez-%s@.service" role
 
 let user_unit_path role =
   let dir = Filename.concat (Paths.xdg_config_home ()) "systemd/user" in
-  Filename.concat dir (Printf.sprintf "octez-%s@.service" role)
+  (* Signatory uses "signatory@.service", other services use "octez-<role>@.service" *)
+  let service_name =
+    match role with
+    | "signatory" -> "signatory@.service"
+    | _ -> Printf.sprintf "octez-%s@.service" role
+  in
+  Filename.concat dir service_name
 
 let unit_path role =
   if Paths.is_root () then system_unit_path role else user_unit_path role
 
 let dropin_dir role inst =
+  (* Signatory uses "signatory@", other services use "octez-<role>@" *)
+  let service_prefix =
+    match role with "signatory" -> "signatory" | _ -> "octez-" ^ role
+  in
   if Paths.is_root () then
-    Printf.sprintf "/etc/systemd/system/octez-%s@%s.service.d" role inst
+    Printf.sprintf "/etc/systemd/system/%s@%s.service.d" service_prefix inst
   else
     let base = Filename.concat (Paths.xdg_config_home ()) "systemd/user" in
-    Filename.concat base (Printf.sprintf "octez-%s@%s.service.d" role inst)
+    Filename.concat base (Printf.sprintf "%s@%s.service.d" service_prefix inst)
 
 let dropin_path role inst =
   Filename.concat (dropin_dir role inst) "override.conf"
 
-let unit_name role inst = Printf.sprintf "octez-%s@%s" role inst
+let unit_name role inst =
+  (* Signatory uses "signatory@" prefix, other services use "octez-<role>@" *)
+  match role with
+  | "signatory" -> Printf.sprintf "signatory@%s" inst
+  | _ -> Printf.sprintf "octez-%s@%s" role inst
 
 let systemctl_cmd () =
   if Paths.is_root () then ["systemctl"] else ["systemctl"; "--user"]


### PR DESCRIPTION
## Summary

- Signatory services now use `signatory@instance` instead of `octez-signatory@instance` as the systemd service name
- The `octez-` prefix was redundant since the signatory binary is not part of the Octez project
- External service detector updated to recognize both naming patterns for backward compatibility

## Changes

- **src/systemd.ml**: Modified `unit_name`, `system_unit_path`, `user_unit_path`, and `dropin_dir` functions to use "signatory" prefix for signatory services instead of "octez-signatory"
- **src/external_service_detector.ml**: Updated `is_managed_unit_name` to recognize both `octez-*@` and `signatory@` patterns, updated `list_unit_files` to query both patterns
- **CHANGELOG.md**: Added entry documenting the service name change

## Testing

- Build passes: `dune build`
- All tests pass: `dune runtest`
- Code formatted: `dune fmt`