### PR TITLE
fix: serialize install/purge to prevent service user race

### DIFF
--- a/test/integration/cli-tester/tests/lib.sh
+++ b/test/integration/cli-tester/tests/lib.sh
@@ -57,6 +57,12 @@ ensure_tezos_user() {
 	fi
 }
 
+# Lock file used to serialize install and purge operations.
+# Purge can delete the tezos service user; install needs it for chown.
+# Without serialization, a parallel purge can delete the user between
+# install's ensure_service_account and its chown call.
+_OM_USER_LOCK="/tmp/om-service-user.lock"
+
 # Instance helpers
 instance_exists() {
 	local instance="$1"
@@ -81,6 +87,7 @@ inject_identity() {
 	local pregenerated="/etc/octez/pregenerated/identity.json"
 
 	if [ -f "$pregenerated" ]; then
+		ensure_tezos_user
 		cp "$pregenerated" "$data_dir/identity.json"
 		chown tezos:tezos "$data_dir/identity.json"
 		chmod 600 "$data_dir/identity.json"
@@ -170,8 +177,34 @@ wait_for_service_stopped() {
 }
 
 # octez-manager helpers
+#
+# Wraps octez-manager with a file lock for install and purge/remove
+# operations. This prevents a race where a parallel purge deletes the
+# tezos service user while an install needs it for chown.
 om() {
-	octez-manager "$@"
+	local _needs_lock=0
+	case "${1:-}" in
+	install-*) _needs_lock=1 ;;
+	instance)
+		local _arg
+		for _arg in "$@"; do
+			case "$_arg" in purge | remove) _needs_lock=1 && break ;; esac
+		done
+		;;
+	esac
+
+	if [ "$_needs_lock" -eq 1 ]; then
+		(
+			flock -w 60 200
+			case "${1:-}" in install-*) ensure_tezos_user ;; esac
+			octez-manager "$@"
+			_om_rc=$?
+			ensure_tezos_user
+			exit "$_om_rc"
+		) 200>"$_OM_USER_LOCK"
+	else
+		octez-manager "$@"
+	fi
 }
 
 om_install_node() {
@@ -204,12 +237,10 @@ cleanup_instance() {
 
 	# Stop service if running, ignore errors
 	om instance "$instance" stop 2>/dev/null || true
-	# Remove and purge
+	# Remove and purge (om() holds the user lock and recreates
+	# the tezos user after each purge/remove automatically)
 	om instance "$instance" remove 2>/dev/null || true
 	om instance "$instance" purge 2>/dev/null || true
-
-	# Purge may delete the service user; recreate for parallel tests
-	ensure_tezos_user
 }
 
 # RPC helpers
@@ -292,6 +323,7 @@ create_external_service() {
 
 	mkdir -p "$unit_dir"
 	mkdir -p "$data_dir"
+	ensure_tezos_user
 	chown -R tezos:tezos "$data_dir"
 
 	case "$role" in
@@ -383,7 +415,7 @@ start_unmanaged_process() {
 	local args="$@"
 	local octez_bin_path="/usr/local/bin"
 
-	su -s /bin/sh tezos -c "$octez_bin_path/$binary $args" &
+	runuser -s /bin/sh -c "$octez_bin_path/$binary $args" tezos &
 	echo $!
 }
 

--- a/test/integration/cli-tester/tests/node/10-purge-with-data.sh
+++ b/test/integration/cli-tester/tests/node/10-purge-with-data.sh
@@ -54,8 +54,4 @@ if [ -d "$ENV_DIR" ]; then
 fi
 echo "Env directory removed"
 
-# Recreate the tezos system user if purge deleted it.
-# Other parallel tests depend on this user existing.
-ensure_tezos_user
-
 echo "Purge test passed"

--- a/test/integration/cli-tester/tests/node/11-remove-vs-purge.sh
+++ b/test/integration/cli-tester/tests/node/11-remove-vs-purge.sh
@@ -63,8 +63,4 @@ if [ -d "$DATA_DIR" ]; then
 fi
 echo "Data deleted after purge"
 
-# Recreate the tezos system user if purge deleted it.
-# Other parallel tests depend on this user existing.
-ensure_tezos_user
-
 echo "Remove vs purge test passed"

--- a/test/integration/cli-tester/tests/node/14-multiple-instances.sh
+++ b/test/integration/cli-tester/tests/node/14-multiple-instances.sh
@@ -70,7 +70,6 @@ echo "Different RPC ports configured"
 # Remove first, verify second still exists
 echo "Removing first instance..."
 om instance "$INSTANCE1" purge
-ensure_tezos_user
 
 if instance_exists "$INSTANCE1"; then
 	echo "ERROR: First instance not removed"


### PR DESCRIPTION
## Summary
- Fixes intermittent shard 3 CI failure in `06-install-custom-rpc-net` caused by `chown: invalid user: 'tezos:tezos'`
- Root cause: parallel test `10-purge-with-data` can delete the `tezos` service user while another test's `om install-node` needs it for `chown`
- Wraps `om()` in `lib.sh` with `flock` serialization for `install-*` and `purge`/`remove` operations
- Ensures `tezos` user is atomically recreated after purge and verified before install
- Also adds `ensure_tezos_user` guards before direct `chown` calls in `inject_identity` and `create_external_service`
- Fixes `su` → `runuser` in `start_unmanaged_process` (consistent with #739)

## Test plan
- [ ] All integration test shards pass (especially shard 3)
- [ ] Run shard 3 multiple times to verify no more flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)