### PR TITLE
fix(web): init Domain_pool and global keys in web mode

### DIFF
--- a/src/cli/cmd_web.ml
+++ b/src/cli/cmd_web.ml
@@ -73,6 +73,16 @@ let web_term =
            let result =
              Eio_posix.run @@ fun env ->
              Eio.Switch.run @@ fun sw ->
+             let pool =
+               Octez_manager_ui.Domain_pool.create
+                 ~sw
+                 ~domain_mgr:(Eio.Stdenv.domain_mgr env)
+                 ~num_domains:4
+             in
+             Octez_manager_ui.Domain_pool.set pool ;
+             Octez_manager_lib.Eio_process.init (Eio.Stdenv.process_mgr env) ;
+             Octez_manager_lib.Binary_downloader.set_parallel_submit
+               Octez_manager_ui.Domain_pool.submit ;
              Miaou_helpers.Fiber_runtime.init ~env ~sw ;
              Octez_manager_ui.Manager_app.register_and_init ~log ?logfile () ;
              (match warning with

--- a/src/ui/pages/manager_app.ml
+++ b/src/ui/pages/manager_app.ml
@@ -43,10 +43,41 @@ let find_page_or_default name default_name =
           Ok page
       | None -> Error (`Msg "Instances page missing from registry"))
 
+(** Open theme picker modal with live preview *)
+let open_theme_picker () =
+  let items = Theme_manager.list_available () in
+  (* Remember current theme to restore on cancel *)
+  let original_theme = Theme_manager.get_current () in
+  let load_theme name =
+    let theme, _warn = Theme_manager.load ~name () in
+    Theme_manager.set_current theme ;
+    Style_context.set_theme theme
+  in
+  Modal_helpers.open_theme_picker_modal
+    ~title:"Switch Theme (Ctrl+T)"
+    ~items
+    ~to_string:(fun s -> s)
+    ~load_theme
+    ~on_select:(fun name ->
+      (* Theme already applied via live preview, just save preference and notify *)
+      Theme_manager.save_preference name ;
+      Context.toast_info (Printf.sprintf "Switched to theme: %s" name))
+    ~on_cancel:(fun () ->
+      (* Restore the original theme on Esc *)
+      Theme_manager.set_current original_theme ;
+      Style_context.set_theme original_theme)
+    ()
+
+(** Register global key handler for Ctrl+T *)
+let register_global_keys () =
+  Context.register_global_key "C-t" (fun () -> open_theme_picker ()) ;
+  Context.register_global_key "K" (fun () -> Context.navigate Keys_page.name)
+
 let register_and_init ?(log = false) ?logfile () =
   Capabilities.register () ;
   register_pages () ;
   Runtime.initialize ~log ?logfile () ;
+  register_global_keys () ;
   Binary_downloader.cleanup_stale_temp_dirs () ;
   Background_runner.enqueue (fun () ->
       match Version_checker.check_for_updates () with
@@ -89,36 +120,6 @@ let shutdown () =
   Domain_pool.shutdown () ;
   Download.kill_active_download ()
 
-(** Open theme picker modal with live preview *)
-let open_theme_picker () =
-  let items = Theme_manager.list_available () in
-  (* Remember current theme to restore on cancel *)
-  let original_theme = Theme_manager.get_current () in
-  let load_theme name =
-    let theme, _warn = Theme_manager.load ~name () in
-    Theme_manager.set_current theme ;
-    Style_context.set_theme theme
-  in
-  Modal_helpers.open_theme_picker_modal
-    ~title:"Switch Theme (Ctrl+T)"
-    ~items
-    ~to_string:(fun s -> s)
-    ~load_theme
-    ~on_select:(fun name ->
-      (* Theme already applied via live preview, just save preference and notify *)
-      Theme_manager.save_preference name ;
-      Context.toast_info (Printf.sprintf "Switched to theme: %s" name))
-    ~on_cancel:(fun () ->
-      (* Restore the original theme on Esc *)
-      Theme_manager.set_current original_theme ;
-      Style_context.set_theme original_theme)
-    ()
-
-(** Register global key handler for Ctrl+T *)
-let register_global_keys () =
-  Context.register_global_key "C-t" (fun () -> open_theme_picker ()) ;
-  Context.register_global_key "K" (fun () -> Context.navigate Keys_page.name)
-
 let run ?page ?(log = false) ?logfile ?theme () =
   let initial_theme, warning = Theme_manager.load ?name:theme () in
   Theme_manager.set_current initial_theme ;
@@ -131,7 +132,6 @@ let run ?page ?(log = false) ?logfile ?theme () =
   Sys.set_signal Sys.sigint (Sys.Signal_handle handle_break) ;
   Sys.set_signal Sys.sigterm (Sys.Signal_handle handle_break) ;
   register_and_init ~log ?logfile () ;
-  register_global_keys () ;
   (match warning with Some msg -> Context.toast_warn msg | None -> ()) ;
   let start_name = Option.value ~default:Instances.name page in
   let rec loop history current_name =


### PR DESCRIPTION
## Summary
- Add `Domain_pool` creation, `Eio_process.init`, and `Binary_downloader.set_parallel_submit` to `cmd_web.ml` — mirrors the setup in `main.ml` that the web command was missing
- Move `register_global_keys` into `register_and_init` so both TUI and web runners register K/Ctrl+T page navigation
- Fixes `Unhandled(Get_monotonic_clock)` errors and broken page switching in web mode

## Test plan
- [ ] Run `octez-manager web --password 12345` and verify no `Domain_pool task failed` errors in stderr
- [ ] Open browser at `http://localhost:8080`, press K to confirm page navigation works
- [ ] Run `octez-manager ui` to confirm terminal mode is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)