### PR TITLE
fix(opam): add explicit homepage and bug-reports fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Opam package now includes explicit homepage and bug-reports fields pointing to GitHub repository (fixes #729)
+
 ### Added
 
 - **Comprehensive Signatory documentation**: Added detailed setup guides covering all aspects of Signatory integration. New documentation includes [Signatory Setup Guide](/guides/signatory-setup/) with backend comparisons (file, YubiHSM, AWS/Azure/GCP KMS), security best practices (key management, network security, access control), troubleshooting procedures, performance tuning, and monitoring guidance. Added [Baker with Signatory Guide](/guides/baker-with-signatory/) with step-by-step baker setup using remote signers, including key generation, Signatory configuration, baker installation, connectivity verification, and production deployment checklist. CLI reference updated with complete `install-signatory` command documentation and examples for all backends. (closes #706)

--- a/dune-project
+++ b/dune-project
@@ -9,6 +9,8 @@
  (synopsis "Minimal Octez service installer")
  (description
   "Small CLI that installs octez-node and companion systemd services without the full Octez Setup UI.")
+ (homepage "https://github.com/trilitech/octez-manager")
+ (bug_reports "https://github.com/trilitech/octez-manager/issues")
  (depends
   (ocaml (>= 5.3))
   cmdliner


### PR DESCRIPTION
## Summary

- Adds explicit `homepage` and `bug_reports` fields to dune-project pointing to GitHub repository
- Updates CHANGELOG.md with fix entry

## Context

Issue #729 reported that the opam package lists old repository links. Investigation revealed that:

1. The opam file originally had GitLab URLs (`gitlab.com/mbourgoin/octez-manager`)
2. Someone manually edited the opam file to fix the URLs to point to GitHub
3. However, the dune-project (the source of truth) was never updated

Since dune-project has `(generate_opam_files true)`, the opam file is regenerated from dune-project. Without explicit `homepage` and `bug_reports` fields in dune-project, future regenerations would lose the correct URLs.

## Changes

- Added `(homepage "https://github.com/trilitech/octez-manager")` to dune-project
- Added `(bug_reports "https://github.com/trilitech/octez-manager/issues")` to dune-project  
- Added changelog entry under `[Unreleased] > Fixed`

Note: The opam file already has the correct URLs from a previous manual edit, so there's no diff in octez-manager.opam. This PR ensures dune-project (the source of truth) is correct so future opam regenerations preserve the correct URLs.

## Verification

- Build passes: `dune build @install`
- Tests pass: `dune runtest`
- Copyright headers correct: `./scripts/check-copyright.sh`
- Code formatted: `dune fmt`

Fixes #729