### PR TITLE
fix(test): add signatory binary and parallel to coverage Dockerfile

### DIFF
--- a/test/integration/cli-tester/Dockerfile.coverage
+++ b/test/integration/cli-tester/Dockerfile.coverage
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     netbase \
     procps \
     bc \
+    parallel \
     libgmp10 \
     libc6 \
     && rm -rf /var/lib/apt/lists/*
@@ -38,6 +39,16 @@ RUN for binary in octez-node octez-client octez-baker octez-accuser octez-dal-no
         curl -sfL "${OCTEZ_BASE_URL}/${binary}" -o /usr/local/bin/${binary} && \
         chmod +x /usr/local/bin/${binary}; \
     done
+
+# Download Signatory binary for signatory integration tests
+ARG SIGNATORY_VERSION=1.3.1
+ARG SIGNATORY_URL=https://github.com/ecadlabs/signatory/releases/download/v${SIGNATORY_VERSION}/signatory_${SIGNATORY_VERSION}_linux_amd64.tar.gz
+RUN echo "Downloading signatory ${SIGNATORY_VERSION}..." && \
+    curl -sfL "${SIGNATORY_URL}" -o /tmp/signatory.tar.gz && \
+    tar -xzf /tmp/signatory.tar.gz -C /tmp && \
+    mv /tmp/signatory /usr/local/bin/signatory && \
+    chmod +x /usr/local/bin/signatory && \
+    rm -f /tmp/signatory.tar.gz
 
 # Download Zcash/Sapling parameters required for node operation
 ARG ZCASH_PARAMS_URL=https://download.z.cash/downloads


### PR DESCRIPTION
## Summary

- `Dockerfile.coverage` was missing the `signatory` binary download that `Dockerfile` has, causing 5 signatory integration tests to fail in the Coverage Report CI workflow with `octez-manager: Binary not found: /usr/local/bin/signatory`
- Also adds the `parallel` package (also present in `Dockerfile` but missing from `Dockerfile.coverage`) to enable parallel test execution in the coverage workflow

## Failing tests fixed

All failures were in the `signatory/` test suite:
- Shard 1: `01-install` (signatory), `03-key-management`
- Shard 2: `02-baker-dependency`
- Shard 4: `05-multiple-instances`
- Shard 5: `06-restart-cascade`

Root cause: The two Dockerfiles diverged — `Dockerfile` has signatory download (added in lines 41-48), but `Dockerfile.coverage` never received the same addition.

## Test plan

- [ ] Coverage Report CI workflow on main should now pass all 5 signatory tests
- [ ] No source code changes — only test infrastructure (Dockerfile.coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)