### PR TITLE
fix(install-node-form): clean up snapshot kind display (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - **DAL import RPC addr omitted to prevent config rewrite**: When importing a DAL node service, `--rpc-addr` and `--net-addr` flags are now only passed to `octez-dal-node` when they were explicitly present in the original service's `ExecStart`. Omitting these flags prevents `octez-dal-node` from rewriting `config.json` on every startup, preserving original configuration. (closes #793)
+- **Snapshot kind display in node install form**: The snapshot selector no longer shows redundant `(kind)` suffixes when a snapshot has a non-empty label. Snapshots with empty labels fall back to the kind slug, preventing blank display. (closes #113)
 - **Version reported by `--version`**: `octez-manager --version` now reports the version from the dune build system rather than a hardcoded string. In development builds (not installed via opam), it reports `dev`.
 
 - **Rewards non-mainnet TzKT routing**: Fixed incorrect TzKT API base URL used when generating or paying rewards for non-mainnet bakers. Network names that are full URLs (e.g. from Teztnets picker) are now normalized to slugs before constructing the TzKT endpoint. The continual scheduler and payout executor now correctly resolve the baker's base directory from environment variables (`OCTEZ_CLIENT_BASE_DIR`, `OCTEZ_BAKER_BASE_DIR`).

--- a/src/ui/pages/install_node_form_v3.ml
+++ b/src/ui/pages/install_node_form_v3.ml
@@ -477,6 +477,12 @@ let history_snapshot_conflict ~history_mode ~snapshot ~network =
 
 (** {1 Custom Fields} *)
 
+let format_selected_snapshot snap =
+  let display_kind =
+    if String.trim snap.label <> "" then snap.label else snap.kind_slug
+  in
+  Printf.sprintf "tzinit · %s" display_kind
+
 let snapshot_field =
   Form_builder.custom
     ~label:"Snapshot Import"
@@ -484,8 +490,7 @@ let snapshot_field =
       match m.snapshot with
       | `None -> "None"
       | `Url url -> if url = "" then "Custom URL..." else url
-      | `Tzinit snap ->
-          Printf.sprintf "tzinit · %s (%s)" snap.label snap.kind_slug)
+      | `Tzinit snap -> format_selected_snapshot snap)
     ~edit:(fun model_ref ->
       let snapshots_opt =
         match slug_of_network !model_ref.node.network with
@@ -535,7 +540,11 @@ let snapshot_field =
         | `None -> "None (manual sync)"
         | `Custom -> "Custom URL..."
         | `Tzinit e ->
-            Printf.sprintf "%s (%s)" e.Snapshots.label e.Snapshots.slug
+            let display_label =
+              if String.trim e.Snapshots.label <> "" then e.Snapshots.label
+              else e.Snapshots.slug
+            in
+            display_label
       in
 
       let on_select choice =
@@ -1148,6 +1157,8 @@ module For_tests = struct
   let history_snapshot_conflict = history_snapshot_conflict
 
   let generate_instance_name = generate_instance_name
+
+  let format_selected_snapshot = format_selected_snapshot
 end
 
 let page : Miaou.Core.Registry.page = (module Page)

--- a/src/ui/pages/install_node_form_v3.mli
+++ b/src/ui/pages/install_node_form_v3.mli
@@ -53,4 +53,9 @@ module For_tests : sig
   (** Generate instance name from network and history mode.
       Format: node-{network} for rolling, node-{network}-{history_mode} for full/archive *)
   val generate_instance_name : network:string -> history_mode:string -> string
+
+  (** Format the display string for a selected tzinit snapshot.
+      Shows "tzinit · {label}" using the human-readable label (or the
+      kind slug as fallback), without duplicating the slug in parentheses. *)
+  val format_selected_snapshot : tzinit_snapshot -> string
 end

--- a/test/test_install_node_form.ml
+++ b/test/test_install_node_form.ml
@@ -769,7 +769,46 @@ let validation_tests =
     ("detects duplicate instances", `Quick, test_duplicate_instance_detection);
   ]
 
+(* ============================================================ *)
+(* Regression tests for issue #113: snapshot kind duplication  *)
+(* ============================================================ *)
+
+(** Verify that the snapshot display string does not include the kind slug
+    twice (e.g. "Rolling (rolling)").  The expected format is
+    "tzinit · Rolling" when the label is set, or "tzinit · rolling" when
+    the label falls back to the slug. *)
+let test_snapshot_display_no_duplicate () =
+  let snap =
+    Install_node_form.For_tests.format_selected_snapshot
+      Install_node_form.
+        {network_slug = "mainnet"; kind_slug = "rolling"; label = "Rolling"}
+  in
+  check string "label used, not slug" "tzinit \xc2\xb7 Rolling" snap ;
+  check
+    bool
+    "no (rolling) suffix"
+    false
+    (TH.contains_substring snap "(rolling)")
+
+let test_snapshot_display_fallback_to_slug () =
+  let snap =
+    Install_node_form.For_tests.format_selected_snapshot
+      Install_node_form.
+        {network_slug = "mainnet"; kind_slug = "full"; label = ""}
+  in
+  check string "slug used as fallback" "tzinit \xc2\xb7 full" snap
+
+let snapshot_display_tests =
+  [
+    ("no duplicate kind", `Quick, test_snapshot_display_no_duplicate);
+    ("fallback to slug", `Quick, test_snapshot_display_fallback_to_slug);
+  ]
+
 let () =
   Alcotest.run
     "Install Node Form (TUI)"
-    [("node_form", form_tests); ("validation", validation_tests)]
+    [
+      ("node_form", form_tests);
+      ("validation", validation_tests);
+      ("snapshot_display", snapshot_display_tests);
+    ]


### PR DESCRIPTION
## Summary
- The snapshot selector in the node install form no longer shows redundant `(kind)` suffixes when a snapshot already has a human-readable label
- Snapshots with empty labels fall back to the kind slug, preventing blank display
- Extracted `format_selected_snapshot` helper for testability

## Changes
- `src/ui/pages/install_node_form_v3.ml`: extract `format_selected_snapshot` helper, use label-first logic in both `~get` display and `~edit` list display
- `src/ui/pages/install_node_form_v3.mli`: expose `format_selected_snapshot` in `For_tests`
- `test/test_install_node_form.ml`: add regression tests for the display fix
- `CHANGELOG.md`: entry under Fixed

## AGENTS.md Compliance
- No I/O in view functions: N/A (pure display string logic)
- Flex_layout used: N/A (no layout changes)
- Typed comparators: ✓
- ppx_forbid clean: ✓
- Copyright headers: ✓
- arch_query metrics: no regression ✓

## Tests
- Added `test_snapshot_display_no_duplicate`: verifies label is used without duplicate slug suffix
- Added `test_snapshot_display_fallback_to_slug`: verifies empty label falls back to kind slug

## Changelog
- Entry added to CHANGELOG.md: ✓

Closes #113