### PR TITLE
fix(binaries): re-render on download progress updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Download progress bar now updates in real time instead of requiring a keypress to refresh (fixes #798)
+
 ### Added
 
 - **Directory picker: type a path directly**: When a form field opens a directory picker, a new "Type a path directly..." option lets users enter an arbitrary path without navigating the filesystem tree. Useful for paths on remote mounts or outside home directories. (closes #800)

--- a/src/ui/context.ml
+++ b/src/ui/context.ml
@@ -100,6 +100,13 @@ let mark_keys_dirty () = Atomic.set keys_dirty true
 
 let consume_keys_dirty () = Atomic.exchange keys_dirty false
 
+(* Download progress dirty flag — set from background domains during binary downloads *)
+let download_dirty = Atomic.make false
+
+let mark_download_dirty () = Atomic.set download_dirty true
+
+let consume_download_dirty () = Atomic.exchange download_dirty false
+
 type pending_tab =
   | Tab_instances
   | Tab_wallets
@@ -385,7 +392,8 @@ let multi_progress_start ~version ~binaries =
   in
   multi_progress :=
     Some
-      {version; binaries = widgets; finished_at = None; checksum_message = None}
+      {version; binaries = widgets; finished_at = None; checksum_message = None} ;
+  mark_download_dirty ()
 
 (* Update progress for a specific binary *)
 let multi_progress_update ~binary ~downloaded ~total =
@@ -417,7 +425,8 @@ let multi_progress_update ~binary ~downloaded ~total =
             mp.binaries
         in
         {mp with binaries})
-      !multi_progress
+      !multi_progress ;
+  mark_download_dirty ()
 
 (* Mark a binary as complete *)
 let multi_progress_complete ~binary ~size =
@@ -439,19 +448,22 @@ let multi_progress_complete ~binary ~size =
             mp.binaries
         in
         {mp with binaries})
-      !multi_progress
+      !multi_progress ;
+  mark_download_dirty ()
 
 (* Set checksum message *)
 let multi_progress_checksum msg =
   multi_progress :=
-    Option.map (fun mp -> {mp with checksum_message = Some msg}) !multi_progress
+    Option.map (fun mp -> {mp with checksum_message = Some msg}) !multi_progress ;
+  mark_download_dirty ()
 
 (* Finish multi-progress *)
 let multi_progress_finish () =
   multi_progress :=
     Option.map
       (fun mp -> {mp with finished_at = Some (Unix.gettimeofday ())})
-      !multi_progress
+      !multi_progress ;
+  mark_download_dirty ()
 
 (* Render multi-progress display *)
 let render_multi_progress ~cols:_ =

--- a/src/ui/context.mli
+++ b/src/ui/context.mli
@@ -71,6 +71,13 @@ val mark_keys_dirty : unit -> unit
 (** Consume and clear the keys dirty flag. Returns [true] if it was set. *)
 val consume_keys_dirty : unit -> bool
 
+(** Mark download progress as needing a re-render (thread-safe via [Atomic]).
+    Called from background download domains whenever progress changes. *)
+val mark_download_dirty : unit -> unit
+
+(** Consume and clear the download dirty flag. Returns [true] if it was set. *)
+val consume_download_dirty : unit -> bool
+
 (** Pending tab switch requested by global key handlers. *)
 type pending_tab =
   | Tab_instances

--- a/src/ui/pages/binaries/binaries_page.ml
+++ b/src/ui/pages/binaries/binaries_page.ml
@@ -62,6 +62,7 @@ let init () =
       expanded_octez_majors;
       expanded_managed_octez_items;
       expanded_registered;
+      download_tick = 0;
     }
 
 let update ps _ = ps
@@ -103,13 +104,18 @@ let refresh_data s =
     expanded_octez_majors = s.expanded_octez_majors;
     expanded_managed_octez_items = s.expanded_managed_octez_items;
     expanded_registered = s.expanded_registered;
+    download_tick = s.download_tick;
   }
 
 let refresh ps = Navigation.update refresh_data ps
 
 let auto_refresh ps =
   (* Auto-refresh if data has been marked dirty (e.g., after remove/download) *)
-  if Context.consume_instances_dirty () then refresh ps else ps
+  if Context.consume_instances_dirty () then refresh ps
+  else if Context.consume_download_dirty () then
+    (* Increment tick to force re-render without refetching data *)
+    Navigation.update (fun s -> {s with download_tick = s.download_tick + 1}) ps
+  else ps
 
 let toggle_major_expansion s major =
   let expanded_octez_majors =

--- a/src/ui/pages/binaries/binaries_page.mli
+++ b/src/ui/pages/binaries/binaries_page.mli
@@ -48,6 +48,8 @@ type state = {
       (** list of expanded managed octez versions *)
   expanded_registered : string list;
       (** list of expanded registered directory aliases *)
+  download_tick : int;
+      (** incremented on each download progress update to force re-render *)
 }
 
 (** Message type (unused, placeholder for Miaou page signature). *)

--- a/src/ui/pages/binaries/binaries_types.ml
+++ b/src/ui/pages/binaries/binaries_types.ml
@@ -48,6 +48,8 @@ type state = {
       (** list of expanded managed octez versions *)
   expanded_registered : string list;
       (** list of expanded registered directory aliases *)
+  download_tick : int;
+      (** incremented on each download progress update to force re-render *)
 }
 
 type msg = unit

--- a/src/ui/pages/binaries/binaries_types.mli
+++ b/src/ui/pages/binaries/binaries_types.mli
@@ -40,6 +40,8 @@ type state = {
   expanded_octez_majors : int list;
   expanded_managed_octez_items : string list;
   expanded_registered : string list;
+  download_tick : int;
+      (** incremented on each download progress update to force re-render *)
 }
 
 type msg = unit

--- a/test/test_binaries_page_pure.ml
+++ b/test/test_binaries_page_pure.ml
@@ -56,6 +56,7 @@ let mk_state ?(managed_octez = []) ?(managed_signatory = []) ?(registered = [])
       expanded_octez_majors;
       expanded_managed_octez_items;
       expanded_registered;
+      download_tick = 0;
     }
 
 (* ── format_size ──────────────────────────────────────────────── *)


### PR DESCRIPTION
## Summary
- Download progress bar was updating in memory but the screen never refreshed until a keypress, making downloads appear stuck
- Add a `download_dirty` atomic flag in `Context` set by all `multi_progress_*` functions
- `auto_refresh` in the binaries page now checks this flag and increments a `download_tick` counter to force a state change without triggering a full data refetch

## Changes
- `src/ui/context.ml` / `.mli`: add `download_dirty` atomic, `mark_download_dirty`, `consume_download_dirty`; call `mark_download_dirty ()` in `multi_progress_start`, `multi_progress_update`, `multi_progress_complete`, `multi_progress_checksum`, and `multi_progress_finish`
- `src/ui/pages/binaries/binaries_types.ml` / `.mli`: add `download_tick : int` field to `state`
- `src/ui/pages/binaries/binaries_page.ml` / `.mli`: initialize `download_tick = 0` in `init` and `refresh_data`; update `auto_refresh` to increment `download_tick` when `consume_download_dirty ()` is true
- `test/test_binaries_page_pure.ml`: add `download_tick = 0` to `mk_state` helper

## AGENTS.md Compliance
- No I/O in view functions: ✓ (only atomic flag reads in `auto_refresh`)
- Flex_layout used: N/A (no new layout)
- Typed comparators: ✓
- ppx_forbid clean: ✓
- Copyright headers: ✓
- arch_query metrics: no regression ✓

## Tests
- Existing `test/test_binaries_page_pure.ml` updated to include `download_tick`; all tests pass
- The `download_tick` field is intentionally not rendered — it only forces state inequality to trigger a re-render

## Changelog
- Entry added to CHANGELOG.md: ✓

Closes #798