### PR TITLE
test(signatory): fix flaky registry check in 01-install test

### DIFF
--- a/test/integration/cli-tester/tests/signatory/01-install.sh
+++ b/test/integration/cli-tester/tests/signatory/01-install.sh
@@ -66,17 +66,19 @@ fi
 echo "HTTP address configured correctly"
 
 # Verify registry entry
-if ! om list 2>&1 | grep -q "$TEST_INSTANCE"; then
+om list 2>&1 | tee /tmp/signatory-install-list.txt
+
+if ! grep -q "$TEST_INSTANCE" /tmp/signatory-install-list.txt; then
 	echo "ERROR: Instance not in registry"
-	om list 2>&1 || true
+	cat /tmp/signatory-install-list.txt
 	exit 1
 fi
 echo "Instance registered successfully"
 
 # Verify instance shows as signatory role
-if ! om list 2>&1 | grep "$TEST_INSTANCE" | grep -q "signatory"; then
+if ! grep "$TEST_INSTANCE" /tmp/signatory-install-list.txt | grep -q "signatory"; then
 	echo "ERROR: Instance not registered as signatory"
-	om list 2>&1 || true
+	cat /tmp/signatory-install-list.txt
 	exit 1
 fi
 echo "Instance role verified"


### PR DESCRIPTION
## Summary

Fixes a flaky integration test that was intermittently failing in CI.

## Problem

The signatory/01-install test was using the pattern:
```bash
if ! om list 2>&1 | grep -q "$TEST_INSTANCE"; then
```

This can fail due to:
- **Pipe race condition**: grep -q exits immediately upon finding a match, which can close the pipe before om list finishes writing, causing a broken pipe signal
- **Output buffering**: When multiple processes are connected via pipes, buffering can cause timing issues

## Solution

Capture the om list output to a file before grepping, matching the pattern already used in signatory/03-key-management.sh:
```bash
om list 2>&1 | tee /tmp/signatory-install-list.txt

if ! grep -q "$TEST_INSTANCE" /tmp/signatory-install-list.txt; then
```

This eliminates the pipe race condition and makes the test more reliable.

## Testing

- The test now follows the same pattern as other signatory tests that don't exhibit flakiness
- No functional changes to what is being tested, only how the output is captured

## Related

This issue was observed in CI for PR #819 (though unrelated to those changes).

Co-Authored-By: Claude <noreply@anthropic.com>