### PR TITLE
fix(validator): strip non-ASCII bytes from pasted PKH input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **PKH validation rejects valid addresses pasted from browsers**: Pasting a Tezos public key hash from a browser or rich-text editor could silently include a unicode non-breaking space (U+00A0) or a BOM (U+FEFF), causing the validator to report "Expected 36 characters, got 38" even for a correct address. The validator now strips these unicode whitespace sequences before checking length and character set.
+
 - Download progress bar now updates in real time instead of requiring a keypress to refresh (fixes #798)
 
 ### Added

--- a/lib/common/string_utils.ml
+++ b/lib/common/string_utils.ml
@@ -99,6 +99,18 @@ let now () =
     tm.tm_min
     tm.tm_sec
 
+(** Strip non-printable and non-ASCII bytes, keeping only printable ASCII
+    (0x20-0x7E). Browsers inject U+00A0, U+200B, U+FEFF and similar when
+    copying from web UIs. *)
+let strip_non_ascii s =
+  let buf = Buffer.create (String.length s) in
+  String.iter
+    (fun c ->
+      let code = Char.code c in
+      if code >= 0x20 && code <= 0x7E then Buffer.add_char buf c)
+    s ;
+  Buffer.contents buf
+
 (** {1 Size Formatting} *)
 
 (** Format a byte count as a human-readable string using integer

--- a/lib/common/string_utils.mli
+++ b/lib/common/string_utils.mli
@@ -35,6 +35,11 @@ val open_in_editor : string -> (unit, [> `Msg of string]) result
 (** Check whether [needle] is a substring of [haystack]. *)
 val string_contains : needle:string -> string -> bool
 
+(** Strip non-printable and non-ASCII bytes, keeping only printable ASCII
+    (0x20-0x7E). Useful for sanitising clipboard input from web UIs that
+    inject U+00A0, U+200B, U+FEFF and similar. *)
+val strip_non_ascii : string -> string
+
 (** {1 Timestamp Utilities} *)
 
 (** Format the current local time as ["YYYY-MM-DD HH:MM:SS"]. *)

--- a/src/ui/pkh_validator.ml
+++ b/src/ui/pkh_validator.ml
@@ -20,7 +20,7 @@ let base58_alphabet =
 let is_base58_char c = String.contains base58_alphabet c
 
 let validate_format pkh =
-  let pkh = String.trim pkh in
+  let pkh = pkh |> String_utils.strip_non_ascii |> String.trim in
   let len = String.length pkh in
   if len = 0 then Invalid "Empty address"
   else if len <> 36 then

--- a/src/ui/pkh_validator.mli
+++ b/src/ui/pkh_validator.mli
@@ -28,7 +28,9 @@ type validation_result =
   | Invalid of string  (** Reason the PKH is invalid *)
 
 (** Validate PKH format without any I/O.
-    Checks prefix (tz1-4) and base58check character set and length. *)
+    Strips unicode whitespace (e.g. non-breaking spaces inserted by browsers
+    when copying addresses) before checking prefix (tz1-4), base58check
+    character set, and length. *)
 val validate_format : string -> validation_result
 
 (** Enrich a valid PKH with on-chain data.

--- a/test/test_pkh_validator.ml
+++ b/test/test_pkh_validator.ml
@@ -59,6 +59,31 @@ let test_valid_tz4 () =
 let test_valid_with_whitespace () =
   check_valid "trimmed whitespace" "  tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx  "
 
+let test_valid_with_nbsp () =
+  (* U+00A0 non-breaking space (\xc2\xa0 in UTF-8) — common when copying from
+     browsers or rich-text editors *)
+  check_valid
+    "non-breaking space stripped"
+    "\xc2\xa0tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx\xc2\xa0"
+
+let test_valid_with_bom () =
+  (* U+FEFF BOM / zero-width no-break space (\xef\xbb\xbf in UTF-8) —
+     sometimes prepended when copying from Windows applications *)
+  check_valid "BOM stripped" "\xef\xbb\xbftz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx"
+
+let test_valid_with_zwsp () =
+  (* U+200B ZERO-WIDTH SPACE (\xe2\x80\x8b in UTF-8) — injected by some
+     web UIs between characters *)
+  check_valid
+    "zero-width space stripped"
+    ("tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" ^ "\xe2\x80\x8b")
+
+let test_valid_with_mixed_unicode () =
+  (* BOM at start + NBSP at end — realistic tzkt copy-paste scenario *)
+  check_valid
+    "BOM + NBSP mixed stripped"
+    ("\xef\xbb\xbf" ^ "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" ^ "\xc2\xa0")
+
 (* ============================================================ *)
 (* Invalid PKH Tests *)
 (* ============================================================ *)
@@ -103,6 +128,10 @@ let valid_tests =
     ("valid tz3", `Quick, test_valid_tz3);
     ("valid tz4", `Quick, test_valid_tz4);
     ("valid with whitespace", `Quick, test_valid_with_whitespace);
+    ("valid with non-breaking space", `Quick, test_valid_with_nbsp);
+    ("valid with BOM", `Quick, test_valid_with_bom);
+    ("valid with zero-width space", `Quick, test_valid_with_zwsp);
+    ("valid with mixed unicode", `Quick, test_valid_with_mixed_unicode);
   ]
 
 let invalid_tests =


### PR DESCRIPTION
## Summary

- Browsers inject Unicode characters (U+00A0 NBSP, U+200B ZWSP, U+FEFF BOM) when copying addresses from web UIs like tzkt. `String.trim` only strips ASCII whitespace, leaving these bytes and causing a spurious length validation error ("Expected 36 characters, got 38").
- Added `String_utils.strip_non_ascii` (keeps only bytes 0x20–0x7E) to `lib/common/string_utils.ml` and applied it before `String.trim` in `Pkh_validator.validate_format`.
- Added 4 regression tests covering NBSP, BOM, ZWSP, and mixed combinations.

## Test plan

- [ ] `dune runtest test/test_pkh_validator` — all 19 tests pass including 4 new unicode_paste cases
- [ ] Manually paste a PKH from tzkt.io into the import key prompt — should import successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)