### PR TITLE
fix(wallets): reload key list immediately after import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Imported key not visible until restart**: After importing a watch-only address in the Wallets page, the key list now updates immediately without requiring an app restart.
+
 - Download progress bar now updates in real time instead of requiring a keypress to refresh (fixes #798)
 
 ### Added

--- a/src/ui/pages/wallets_page.ml
+++ b/src/ui/pages/wallets_page.ml
@@ -346,7 +346,34 @@ let init () =
 
 let update ps _ = ps
 
-let refresh ps = ps
+let reload_if_dirty ps =
+  if Context.consume_keys_dirty () then (
+    let all_dirs = get_all_base_dirs () in
+    let regular_groups =
+      all_dirs
+      |> List.map load_enriched_group
+      |> List.filter (fun g ->
+          g.keys <> [] || g.error <> None || g.services <> [])
+    in
+    let sandbox_groups = get_sandbox_wallet_groups () in
+    let groups = regular_groups @ sandbox_groups in
+    let s = ps.Navigation.s in
+    let nav_items = build_nav_items ~folded:s.folded groups in
+    let total_keys = count_keys groups in
+    let cursor = min s.cursor (max 0 (List.length nav_items - 1)) in
+    (* Update scheduler with new key set *)
+    let keys_by_dir =
+      List.map
+        (fun (g : enriched_group) ->
+          ( g.base_dir,
+            List.map (fun (k : Keys_reader.key_metadata) -> k.pkh) g.keys ))
+        groups
+    in
+    Keys_scheduler.set_keys keys_by_dir ;
+    {ps with s = {s with groups; nav_items; total_keys; cursor}})
+  else ps
+
+let refresh ps = reload_if_dirty ps
 
 let move ps _ = ps
 
@@ -360,33 +387,7 @@ let focused_since : float ref = ref 0.0
 let focus_debounce = 2.0
 
 let service_cycle ps _ =
-  let ps =
-    if Context.consume_keys_dirty () then (
-      let all_dirs = get_all_base_dirs () in
-      let regular_groups =
-        all_dirs
-        |> List.map load_enriched_group
-        |> List.filter (fun g ->
-            g.keys <> [] || g.error <> None || g.services <> [])
-      in
-      let sandbox_groups = get_sandbox_wallet_groups () in
-      let groups = regular_groups @ sandbox_groups in
-      let s = ps.Navigation.s in
-      let nav_items = build_nav_items ~folded:s.folded groups in
-      let total_keys = count_keys groups in
-      let cursor = min s.cursor (max 0 (List.length nav_items - 1)) in
-      (* Update scheduler with new key set *)
-      let keys_by_dir =
-        List.map
-          (fun (g : enriched_group) ->
-            ( g.base_dir,
-              List.map (fun (k : Keys_reader.key_metadata) -> k.pkh) g.keys ))
-          groups
-      in
-      Keys_scheduler.set_keys keys_by_dir ;
-      {ps with s = {s with groups; nav_items; total_keys; cursor}})
-    else ps
-  in
+  let ps = reload_if_dirty ps in
   (* Auto-fetch for the focused key after debounce *)
   let s = ps.Navigation.s in
   let current_pkh =

--- a/test/dune
+++ b/test/dune
@@ -322,7 +322,14 @@
 
 (test
  (name test_wallets_page)
- (libraries alcotest octez_manager_lib octez-manager.ui)
+ (libraries
+  alcotest
+  octez_manager_lib
+  octez-manager.ui
+  miaou-core.lib
+  miaou-core.lib_miaou_internal
+  lambda-term
+  tui_test_helpers_lib)
  (modules test_wallets_page)
  (instrumentation
   (backend bisect_ppx)))

--- a/test/test_wallets_page.ml
+++ b/test/test_wallets_page.ml
@@ -14,6 +14,9 @@
 open Alcotest
 open Octez_manager_lib
 module Keys_page = Octez_manager_ui.Wallets_page
+module HD = Lib_miaou_internal.Headless_driver
+module TH = Tui_test_helpers_lib.Tui_test_helpers
+module Context = Octez_manager_ui.Context
 
 (* ============================================================ *)
 (* Base Directory Deduplication Tests *)
@@ -109,6 +112,71 @@ let test_get_all_base_dirs_trailing_slash () =
   check bool "trailing slash normalized" true (count <= 1)
 
 (* ============================================================ *)
+(* TUI Regression: key appears after import without restart     *)
+(* ============================================================ *)
+
+(** Write a single-entry public_key_hashs JSON file to base_dir. *)
+let write_key_file ~base_dir ~alias ~pkh =
+  let oc = open_out (Filename.concat base_dir "public_key_hashs") in
+  Printf.fprintf oc {|[{"name":"%s","value":"%s"}]|} alias pkh ;
+  close_out oc
+
+(** Create a temp dir, register it as a Client_base_dir, and clean up after. *)
+let with_tmp_wallet f =
+  let base_dir =
+    let d =
+      Filename.concat
+        (Filename.get_temp_dir_name ())
+        ("om-test-wallet-" ^ string_of_int (Unix.getpid ()))
+    in
+    (try Unix.mkdir d 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ()) ;
+    d
+  in
+  ignore
+    (Directory_registry.add
+       ~path:base_dir
+       ~dir_type:Client_base_dir
+       ~registered_services:[]) ;
+  Fun.protect
+    ~finally:(fun () -> ignore (Directory_registry.remove base_dir))
+    (fun () -> f base_dir)
+
+(** Regression test for bug: key not visible after import until restart.
+    Root cause: refresh = fun ps -> ps (no-op), dirty flag only consumed in
+    service_cycle which never fires for the wallets page. Fix: refresh calls
+    reload_if_dirty. *)
+let test_imported_key_appears_without_restart () =
+  TH.with_test_env (fun () ->
+      with_tmp_wallet (fun base_dir ->
+          (* Pre-populate alice so the page loads with content *)
+          write_key_file
+            ~base_dir
+            ~alias:"alice"
+            ~pkh:"tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" ;
+          HD.Stateful.init (module Keys_page.Page) ;
+          let screen_before = TH.get_screen_text () in
+          check
+            bool
+            "alice visible on initial load"
+            true
+            (TH.contains_substring screen_before "alice") ;
+          (* Simulate import: overwrite key file with bob added, mark dirty *)
+          let oc = open_out (Filename.concat base_dir "public_key_hashs") in
+          Printf.fprintf
+            oc
+            {|[{"name":"alice","value":"tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx"},{"name":"bob","value":"tz1TzuXMpCEEFBkiKF3U2PnMuBStnMF3nFRK"}]|} ;
+          close_out oc ;
+          Context.mark_keys_dirty () ;
+          (* Trigger a tick — refresh must call reload_if_dirty *)
+          ignore (HD.Stateful.idle_wait ~iterations:10 ~sleep:0.001 ()) ;
+          let screen_after = TH.get_screen_text () in
+          check
+            bool
+            "bob visible after import without restart"
+            true
+            (TH.contains_substring screen_after "bob")))
+
+(* ============================================================ *)
 (* Test Suite *)
 (* ============================================================ *)
 
@@ -125,5 +193,17 @@ let base_dir_tests =
       test_get_all_base_dirs_trailing_slash );
   ]
 
+let refresh_tests =
+  [
+    ( "imported key appears without restart",
+      `Quick,
+      test_imported_key_appears_without_restart );
+  ]
+
 let () =
-  Alcotest.run "Wallets_page" [("base_dir_deduplication", base_dir_tests)]
+  Alcotest.run
+    "Wallets_page"
+    [
+      ("base_dir_deduplication", base_dir_tests);
+      ("refresh_on_dirty_flag", refresh_tests);
+    ]


### PR DESCRIPTION
## Summary

- `refresh` in `wallets_page.ml` was a no-op (`fun ps -> ps`), so the dirty flag set by `Context.mark_keys_dirty()` after key import was only ever consumed by `service_cycle`, which never fires for the wallets page in practice. Keys stayed invisible until app restart.
- Extracted `reload_if_dirty` from `service_cycle` and wired it into `refresh`, so the key list updates on the next tick after any import, rename, or forget operation.
- Added a TUI regression test using the headless driver: writes real key files to a temp dir registered as `Client_base_dir`, simulates an import, and asserts the new key alias appears in the rendered screen without restarting.

## Test plan

- [ ] `dune runtest test/test_wallets_page.exe` — all 4 tests pass including `imported key appears without restart`
- [ ] Manually import a watch-only address in the Wallets page — key should appear immediately without restarting

🤖 Generated with [Claude Code](https://claude.com/claude-code)