### PR TITLE
feat(ui): remove global key K for Wallets navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Removed
+
+- Global key `K` for navigating to Wallets tab has been removed. Users can now access the Wallets tab using the number key corresponding to its tab position.
+
 ### Changed
 
 - Extract `register_and_init` and `shutdown` helpers in `manager_app.ml`

--- a/src/ui/pages/manager_app.ml
+++ b/src/ui/pages/manager_app.ml
@@ -73,11 +73,9 @@ let open_theme_picker () =
       Style_context.set_theme original_theme)
     ()
 
-(** Register global key handler for Ctrl+T *)
+(** Register global key handlers *)
 let register_global_keys () =
   Context.register_global_key "C-t" (fun () -> open_theme_picker ()) ;
-  Context.register_global_key "K" (fun () ->
-      Context.set_pending_tab Context.Tab_wallets) ;
   Context.register_global_key "R" (fun () -> Context.navigate Rewards_page.name)
 
 let register_and_init ?(log = false) ?logfile () =


### PR DESCRIPTION
## Summary

- Removes the global key `K` for navigating to the Wallets tab
- Users can now access the Wallets tab using the number key corresponding to its tab position

## Changes

- Removed `Context.register_global_key "K"` registration from `manager_app.ml`
- Added CHANGELOG entry under "Removed" section
- Updated comment from "Register global key handler for Ctrl+T" to "Register global key handlers"

## Motivation

Simplifies global key bindings and encourages use of the tab-based navigation system.