### PR TITLE
fix(git): remove mistakenly committed _opam symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _build/
 _opam/
+_opam
 .install/
 *.install
 *.merlin

--- a/_opam
+++ b/_opam
@@ -1,1 +1,0 @@
-../octez-manager/_opam


### PR DESCRIPTION
## Summary

- Removes the accidentally committed `_opam` symlink from the repository
- Updates `.gitignore` to prevent both `_opam` directory and `_opam` file/symlink from being tracked in the future

## Context

The `_opam` file was a symlink that was mistakenly committed to the repository. This is a local development artifact (likely created when using git worktrees with shared dependencies) that should not be version controlled.

## Changes

- `git rm _opam` - removes the symlink from version control
- Updated `.gitignore` to include `_opam` (file/symlink) in addition to the existing `_opam/` (directory) pattern

## Testing

- Verified the file is removed from git tracking
- Verified `.gitignore` patterns prevent future commits