### PR TITLE
fix(ui): enable arrow key navigation on Instances page with no services

### DIFF
--- a/.opencode/agents/explore.md
+++ b/.opencode/agents/explore.md
@@ -1,0 +1,113 @@
+---
+description: Fast agent specialized for exploring codebases - finds files by patterns, searches code for keywords, answers architecture questions
+mode: subagent
+model: github-copilot/claude-haiku-4.5
+temperature: 0.2
+permission:
+  edit: deny
+  bash:
+    "*": deny
+    "ls *": allow
+    "git log*": allow
+    "git show*": allow
+    "dune exec tools/arch_query*": allow
+  webfetch: deny
+---
+
+# Explore
+
+You are a fast, read-only codebase exploration specialist for octez-manager, an OCaml 5 TUI application built with Dune and the Miaou library.
+
+Token discipline:
+- minimal output
+- direct answers
+- file:line references
+
+## Your Mission
+
+Answer architecture questions and find code patterns quickly using read-only tools:
+- `glob` for file pattern matching
+- `grep` for content search
+- `read` for reading files
+- `arch_query` for querying the architecture database
+
+## Thoroughness Levels
+
+When called, you'll be given a thoroughness level:
+- **quick** — basic searches, single pass, first reasonable answer
+- **medium** — check multiple locations and common naming variations
+- **very thorough** — comprehensive analysis across all likely locations
+
+Match your effort to the requested level. Don't over-search for quick queries.
+
+## octez-manager Architecture Quick Reference
+
+```
+src/                      # Main library (octez_manager_lib)
+src/ui/                   # TUI components (Miaou-based)
+src/ui/pages/             # Individual page implementations
+src/ui/form_builder.ml    # Form system for install/edit wizards
+src/ui/*_scheduler.ml     # Background data polling (feeds views)
+test/                     # Unit tests
+test/integration/         # Integration tests
+tools/                    # Architecture DB and CI metrics
+```
+
+## Common Queries You'll Handle
+
+**Where is X implemented?**
+1. Use `arch_query search "description"` first
+2. If not found, use `grep` with relevant patterns
+3. Return file:line references
+
+**What does X do?**
+1. Use `glob` to find the file
+2. Use `read` to examine the implementation
+3. Summarize concisely
+
+**How does feature X work?**
+1. Find entry points with `grep`
+2. Read key files
+3. Explain data flow in 2-3 sentences
+
+## Output Format
+
+Always provide:
+- **Direct answer** to the question
+- **File:line references** for code locations
+- **Minimal explanation** — just enough context
+
+Example:
+```
+Baker status is polled in src/ui/baker_scheduler.ml:45
+It calls Node_rpc.get_baker_status every 5 seconds.
+The result is cached in baker_cache and read by Baker_page.view.
+```
+
+## Rules
+
+- Never modify files (read-only mode)
+- Use arch_query before grepping when searching for functionality
+- Prefer glob over bash ls/find
+- Prefer grep over bash grep/rg
+- Return file:line references for all code locations
+- Keep explanations under 5 sentences unless "very thorough" is specified
+- If you can't find something, say so immediately — don't speculate
+
+## octez-manager Specifics
+
+Key patterns to recognize:
+- **Schedulers** (`*_scheduler.ml`) — background polling that feeds UI
+- **Pages** (`src/ui/pages/*.ml`) — TUI page implementations
+- **Forms** (`form_builder.ml`) — install/edit wizard system
+- **RPC** (`node_rpc.ml`) — Octez node communication
+- **arch_query** — always available for semantic code search
+
+Common question patterns:
+- "Where is X polled?" → look for `*_scheduler.ml`
+- "How is Y displayed?" → look in `src/ui/pages/`
+- "Where does Z form live?" → look for `form_builder` or `pages/*_page.ml`
+
+## Version
+
+Current version: 1.0.0 (octez-manager customized)

--- a/.opencode/agents/governor.md
+++ b/.opencode/agents/governor.md
@@ -1,7 +1,7 @@
 ---
 description: Generates and maintains governance rules from project context and risk posture
 mode: subagent
-model: github-copilot/claude-opus-4.5
+model: github-copilot/claude-opus-4.6
 temperature: 0.3
 permission:
   edit: allow

--- a/.opencode/agents/reviewer.md
+++ b/.opencode/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 description: Performs structured code review focused on correctness, OCaml patterns, and regression risk
 mode: subagent
-model: github-copilot/claude-opus-4.5
+model: github-copilot/claude-opus-4.6
 temperature: 0.1
 permission:
   edit: deny

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Instances page arrow key navigation to "Add new" entries**: Fixed arrow key navigation on the Instances page when no services are installed. Previously, pressing ↓ from the "By Role / By Group" selector would not navigate to the "Add new Node", "Add new Baker", etc. entries. Navigation now correctly moves to these ghost entries even when the service list is empty.
 - **Instances page help modal now documents arrow key navigation**: The help modal (`?`) on the Instances page now includes arrow keys (↑/↓/←/→) and vim keys (j/k/h/l) for navigation, making keyboard shortcuts more discoverable.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- **Instances page arrow key navigation to "Add new" entries**: Fixed arrow key navigation on the Instances page when no services are installed. Previously, pressing ↓ from the "By Role / By Group" selector would not navigate to the "Add new Node", "Add new Baker", etc. entries. Navigation now correctly moves to these ghost entries even when the service list is empty.
+- **Instances page arrow key navigation to "Add new" entries**: Fixed arrow key navigation on the Instances page when no services are installed. Previously, pressing ↓ from the "By Role / By Group" selector would not navigate to the "Add new Node", "Add new Baker", etc. entries, especially in wide terminals with multi-column layout. The issue was caused by `ensure_valid_column` resetting the selection to 0 on every refresh cycle (~1 second). Navigation now correctly moves to these ghost entries even when the service list is empty.
 - **Instances page help modal now documents arrow key navigation**: The help modal (`?`) on the Instances page now includes arrow keys (↑/↓/←/→) and vim keys (j/k/h/l) for navigation, making keyboard shortcuts more discoverable.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Instances page help modal now documents arrow key navigation**: The help modal (`?`) on the Instances page now includes arrow keys (↑/↓/←/→) and vim keys (j/k/h/l) for navigation, making keyboard shortcuts more discoverable.
+
 ### Removed
 
 - Global key `K` for navigating to Wallets tab has been removed. Users can now access the Wallets tab using the number key corresponding to its tab position.

--- a/src/ui/pages/instances.ml
+++ b/src/ui/pages/instances.ml
@@ -289,8 +289,7 @@ let move_selection_managed s delta =
 (** Move selection up or down by [delta] steps, handling menu items,
     separator skipping, and multi-column navigation. *)
 let move_selection s delta =
-  if s.services = [] && s.external_services = [] then {s with selected = 0}
-  else if s.num_columns <= 1 then move_selection_single_column s delta
+  if s.num_columns <= 1 then move_selection_single_column s delta
   else if s.selected < services_start_idx then move_selection_menu s delta
   else
     let current_idx = s.selected - services_start_idx in

--- a/src/ui/pages/instances.ml
+++ b/src/ui/pages/instances.ml
@@ -342,8 +342,11 @@ struct
       {Miaou.Core.Tui_page.key; action = noop; help; display_only = true}
     in
     [
+      kb "↑/↓ or j/k" "Navigate";
+      kb "←/→ or h/l" "Switch column";
       kb "Enter" "Open";
-      kb "g" "Group/Role view";
+      kb "Tab" "Fold/Unfold";
+      kb "g" "Toggle view";
       kb "G" "Group actions";
       kb "d" "Diagnostics";
       kb "x" "Clear failure";

--- a/src/ui/pages/instances/instances_layout.ml
+++ b/src/ui/pages/instances/instances_layout.ml
@@ -346,13 +346,10 @@ let find_non_empty_column ~num_columns ~sections ~display_items =
   find 0
 
 (** Ensure active_column points to a non-empty column, adjusting selection if needed.
-    If all columns are empty (no services), move selection to menu. *)
+    Ghosts are navigable, so we only check display_items, not real services. *)
 let ensure_valid_column state =
   let display_items = display_ordered_items state in
-  if state.services = [] && state.external_services = [] then
-    (* No services at all, go to first item (radio buttons) *)
-    {state with selected = 0; active_column = 0}
-  else if state.num_columns <= 1 then state
+  if state.num_columns <= 1 then state
   else
     let sections = sections_of_state state in
     let current_indices =

--- a/test/test_instances_navigation_pure.ml
+++ b/test/test_instances_navigation_pure.ml
@@ -200,10 +200,37 @@ let test_empty_state_multi_column_navigates_to_ghost () =
   let s = make_state ~selected:0 ~num_columns:2 [] in
   let s' = move s 1 in
   check
-    bool
+    int
     "radio row -> first ghost (multi column)"
-    true
-    (s'.selected >= services_start_idx)
+    services_start_idx
+    s'.selected
+
+let test_empty_state_ensure_valid_column_preserves_selection () =
+  (* ensure_valid_column should NOT reset selection when navigating to ghosts *)
+  let s = make_state ~selected:services_start_idx ~num_columns:3 [] in
+  let s' = Instances_layout.ensure_valid_column s in
+  check
+    int
+    "ensure_valid_column preserves ghost selection"
+    services_start_idx
+    s'.selected
+
+let test_empty_state_wide_terminal_multi_column_navigation () =
+  (* User scenario: very wide terminal (many columns), empty services, press Down from radio row *)
+  let s = make_state ~selected:0 ~num_columns:5 [] in
+  let s' = move s 1 in
+  check
+    int
+    "radio row -> first ghost (5 columns)"
+    services_start_idx
+    s'.selected ;
+  (* Now simulate refresh (which calls ensure_valid_column) *)
+  let s'' = Instances_layout.ensure_valid_column s' in
+  check
+    int
+    "ensure_valid_column after nav preserves ghost selection"
+    services_start_idx
+    s''.selected
 
 (* ============================================================ *)
 (* Test Suite                                                   *)
@@ -254,5 +281,11 @@ let () =
           ( "navigates to ghost (multi column)",
             `Quick,
             test_empty_state_multi_column_navigates_to_ghost );
+          ( "ensure_valid_column preserves ghost selection",
+            `Quick,
+            test_empty_state_ensure_valid_column_preserves_selection );
+          ( "wide terminal multi-column navigation",
+            `Quick,
+            test_empty_state_wide_terminal_multi_column_navigation );
         ] );
     ]

--- a/test/test_instances_navigation_pure.ml
+++ b/test/test_instances_navigation_pure.ml
@@ -185,17 +185,25 @@ let test_multi_column_roundtrip () =
 (* Empty state tests                                            *)
 (* ============================================================ *)
 
-let test_empty_state_stays_at_install () =
+let test_empty_state_navigates_to_ghost () =
+  (* When there are no services, ghost "Add new" entries should still be navigable *)
   let s = make_state ~selected:0 ~num_columns:1 [] in
   let s' = move s 1 in
-  check int "stays at Install" 0 s'.selected ;
-  let s' = move s (-1) in
-  check int "stays at Install (up)" 0 s'.selected
+  check
+    int
+    "radio row -> first ghost (single column)"
+    services_start_idx
+    s'.selected
 
-let test_empty_state_multi_column () =
+let test_empty_state_multi_column_navigates_to_ghost () =
+  (* Multi-column: should navigate from radio row to first ghost *)
   let s = make_state ~selected:0 ~num_columns:2 [] in
   let s' = move s 1 in
-  check int "stays at Install" 0 s'.selected
+  check
+    bool
+    "radio row -> first ghost (multi column)"
+    true
+    (s'.selected >= services_start_idx)
 
 (* ============================================================ *)
 (* Test Suite                                                   *)
@@ -240,9 +248,11 @@ let () =
         ] );
       ( "empty-state",
         [
-          ("stays at Install", `Quick, test_empty_state_stays_at_install);
-          ( "multi-column stays at Install",
+          ( "navigates to ghost (single column)",
             `Quick,
-            test_empty_state_multi_column );
+            test_empty_state_navigates_to_ghost );
+          ( "navigates to ghost (multi column)",
+            `Quick,
+            test_empty_state_multi_column_navigates_to_ghost );
         ] );
     ]


### PR DESCRIPTION
## Summary

Fixes arrow key navigation on the Instances page when no services are installed. Previously, pressing ↓ from the "By Role / By Group" selector did not navigate to the "Add new Node", "Add new Baker", etc. ghost entries, especially in wide terminals with multi-column layout.

## Root Cause

The bug was caused by `ensure_valid_column` (called on every refresh cycle ~1 second) resetting the selection to index 0 whenever `services=[]` and `external_services=[]`. Even though `move_selection` correctly moved the cursor to ghost entries, the next refresh would immediately reset it back, making arrow keys appear to do nothing.

## Changes

### Bug Fixes

1. **Removed early-exit check in `move_selection`** (src/ui/pages/instances.ml:292):
   - Removed `if s.services = [] && s.external_services = [] then {s with selected = 0}`
   - This check prevented any navigation when services list was empty, ignoring ghost entries

2. **Fixed `ensure_valid_column` reset behavior** (src/ui/pages/instances/instances_layout.ml:350):
   - Removed check that forced selection back to 0 when no real services exist
   - Ghost entries are navigable items in `display_items` and should not trigger a reset

### Documentation

3. **Added arrow key documentation to help modal** (src/ui/pages/instances.ml:345):
   - Added `↑/↓ or j/k` → Navigate
   - Added `←/→ or h/l` → Switch column
   - Added `Tab` → Fold/Unfold
   - Makes keyboard shortcuts discoverable via `?` help modal

### Testing

4. **Added comprehensive regression tests** (test/test_instances_navigation_pure.ml):
   - Test navigation to ghosts in single-column mode
   - Test navigation to ghosts in multi-column mode (exact index verification)
   - Test `ensure_valid_column` preserves ghost selection
   - Test wide terminal scenario with navigation + refresh cycle
   - Total: 13 tests (was 11), all passing

### Agent Team Updates

5. **Upgraded agent models** (.opencode/agents/):
   - Upgraded reviewer from claude-opus-4.5 to claude-opus-4.6
   - Upgraded governor from claude-opus-4.5 to claude-opus-4.6
   - Added explore agent on claude-haiku-4.5 for fast codebase navigation

## Testing

```bash
dune build && dune exec test/test_instances_navigation_pure.exe
# All 13 tests pass

dune runtest
# Full test suite passes
```

**Manual testing:**
1. Launch octez-manager with no services installed
2. Press ↓ from "By Role / By Group" selector
3. Cursor now correctly moves to "Add new Node" (index 2) and stays there
4. Works in both narrow (single-column) and wide (multi-column) terminals

## Commits

- `c5390084` chore(agents): upgrade reviewer & governor to opus-4.6, add explore agent
- `57c82d17` docs(ui): add arrow key navigation to instances page keymap
- `82ba6ed3` fix(ui): enable arrow key navigation to 'Add new' entries when no services exist
- `3cffad00` fix(ui): prevent ensure_valid_column from resetting ghost navigation

## Checklist

- [x] Code compiles and builds successfully
- [x] All tests pass (13/13 navigation tests + full suite)
- [x] CHANGELOG.md updated
- [x] Commits follow conventional commit format
- [x] Code formatted with `dune fmt`
- [x] Copyright headers present