### PR TITLE
fix: Wallets page base dir discovery and fold/unfold keybinding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Instances page arrow key navigation to "Add new" entries**: Fixed arrow key navigation on the Instances page when no services are installed. Previously, pressing ↓ from the "By Role / By Group" selector would not navigate to the "Add new Node", "Add new Baker", etc. entries, especially in wide terminals with multi-column layout. The issue was caused by `ensure_valid_column` resetting the selection to 0 on every refresh cycle (~1 second). Navigation now correctly moves to these ghost entries even when the service list is empty.
 - **Instances page help modal now documents arrow key navigation**: The help modal (`?`) on the Instances page now includes arrow keys (↑/↓/←/→) and vim keys (j/k/h/l) for navigation, making keyboard shortcuts more discoverable.
+- **Wallets page missing baker/accuser wallets**: The Wallets page now discovers wallet directories from installed baker and accuser services. Previously, only `~/.tezos-client` was shown; service-specific base directories (e.g., `~/.local/share/octez/baker-bakingnet`) were invisible because the installer did not register them in the directory registry.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Instances page arrow key navigation to "Add new" entries**: Fixed arrow key navigation on the Instances page when no services are installed. Previously, pressing ↓ from the "By Role / By Group" selector would not navigate to the "Add new Node", "Add new Baker", etc. entries, especially in wide terminals with multi-column layout. The issue was caused by `ensure_valid_column` resetting the selection to 0 on every refresh cycle (~1 second). Navigation now correctly moves to these ghost entries even when the service list is empty.
 - **Instances page help modal now documents arrow key navigation**: The help modal (`?`) on the Instances page now includes arrow keys (↑/↓/←/→) and vim keys (j/k/h/l) for navigation, making keyboard shortcuts more discoverable.
 - **Wallets page missing baker/accuser wallets**: The Wallets page now discovers wallet directories from installed baker and accuser services. Previously, only `~/.tezos-client` was shown; service-specific base directories (e.g., `~/.local/share/octez/baker-bakingnet`) were invisible because the installer did not register them in the directory registry.
+- **Wallets page fold/unfold keybinding**: Changed fold/unfold base directory groups from Space to Tab for consistency with common TUI conventions. Space now switches between the list and detail panels.
 
 ### Removed
 

--- a/src/directory_registry.ml
+++ b/src/directory_registry.ml
@@ -248,8 +248,18 @@ let add ~path ~dir_type ~registered_services =
       let new_entry =
         match existing_entry with
         | Some e ->
-            (* Update existing: keep created_at, update last_used_at *)
-            {e with last_used_at = timestamp; registered_services; dir_type}
+            (* Update existing: keep created_at, update last_used_at, merge services *)
+            let merged_services =
+              List.sort_uniq
+                String.compare
+                (e.registered_services @ registered_services)
+            in
+            {
+              e with
+              last_used_at = timestamp;
+              registered_services = merged_services;
+              dir_type;
+            }
         | None ->
             (* New entry *)
             {

--- a/src/installer/accuser.ml
+++ b/src/installer/accuser.ml
@@ -94,6 +94,13 @@ let install_accuser ?(quiet = false) (request : accuser_request) =
         preserve_data = request.preserve_data;
       }
   in
+  (* Register accuser's base_dir in Directory_registry for wallet discovery *)
+  let* () =
+    Directory_registry.add
+      ~path:base_dir
+      ~dir_type:Client_base_dir
+      ~registered_services:[request.instance]
+  in
   (* Register as dependent on parent node (avoid duplicates) *)
   let* () =
     match node_mode with

--- a/src/installer/baker.ml
+++ b/src/installer/baker.ml
@@ -227,6 +227,13 @@ let install_baker ?(quiet = false) (request : baker_request) =
     }
   in
   let* () = Service_registry.write service_with_signer in
+  (* Register baker's base_dir in Directory_registry for wallet discovery *)
+  let* () =
+    Directory_registry.add
+      ~path:base_dir
+      ~dir_type:Client_base_dir
+      ~registered_services:[request.instance]
+  in
   (* Rewrite dropin with all dependencies (node + signatory if applicable) *)
   let* () =
     match all_dependencies_for_systemd with

--- a/src/installer/removal.ml
+++ b/src/installer/removal.ml
@@ -155,6 +155,12 @@ let purge_service ?(quiet = false) ~force_purge ~prompt_yes_no ~instance () =
                  services): %s@.Used by: %s@."
                 base_dir
                 (String.concat ", " other_users) ;
+            (* Update Directory_registry: remove instance from registered_services *)
+            let _ =
+              Directory_registry.update_registered_services
+                ~path:base_dir
+                ~registered_services:other_users
+            in
             Ok ())
           else
             (* Base-dir not shared - proceed with deletion logic *)
@@ -165,7 +171,12 @@ let purge_service ?(quiet = false) ~force_purge ~prompt_yes_no ~instance () =
                   (Format.sprintf "Purge base-dir %S?" base_dir)
                   ~default:false
             in
-            if remove_base_dir then File_ops.remove_tree base_dir else Ok ()
+            let* () =
+              if remove_base_dir then File_ops.remove_tree base_dir else Ok ()
+            in
+            (* Clean up Directory_registry: no other users, remove entry *)
+            let _ = Directory_registry.remove base_dir in
+            Ok ()
         else Ok ()
       in
       (* Also remove per-instance env files under XDG_CONFIG_HOME or /etc when purging *)

--- a/src/ui/pages/wallets_page.ml
+++ b/src/ui/pages/wallets_page.ml
@@ -2477,10 +2477,10 @@ let handle_key ps key ~size =
         | Some Keys.Down | Some (Keys.Char "j") -> move_cursor 1 ~size ps
         | Some (Keys.Char "g") -> jump_to_top ~size ps
         | Some (Keys.Char "G") -> jump_to_bottom ~size ps
-        | Some (Keys.Char " ") ->
+        | Some Keys.Tab ->
             if ps.Navigation.s.multi_select then toggle_selection ps
             else toggle_fold ~size ps
-        | Some Keys.Tab -> switch_panel ps
+        | Some (Keys.Char " ") -> switch_panel ps
         | Some Keys.Enter ->
             if ps.Navigation.s.multi_select then open_batch_modal ps
             else action_on_selected ps
@@ -2564,8 +2564,8 @@ module Page_Impl : Miaou.Core.Tui_page.PAGE_SIG = struct
     Miaou.Core.Tui_page.
       [
         {key = "j/k"; help = "Navigate"};
-        {key = "Tab"; help = "Panel"};
-        {key = "Space"; help = "Fold"};
+        {key = "Tab"; help = "Fold"};
+        {key = "Space"; help = "Panel"};
         {key = "+/n"; help = "New key"};
         {key = "Esc"; help = "Back"};
         {key = "?"; help = "Help"};

--- a/src/ui/pages/wallets_page.ml
+++ b/src/ui/pages/wallets_page.ml
@@ -75,6 +75,30 @@ let normalize_path path =
   if len > 1 && String.get path (len - 1) = '/' then String.sub path 0 (len - 1)
   else path
 
+(** Discover base directories from installed baker/accuser service env files.
+    This handles services installed before Directory_registry integration. *)
+let discover_base_dirs_from_services () =
+  let services = Data.load_service_states () in
+  List.filter_map
+    (fun (st : Data.Service_state.t) ->
+      let key =
+        match st.service.role with
+        | "baker" -> Some "OCTEZ_BAKER_BASE_DIR"
+        | "accuser" -> Some "OCTEZ_CLIENT_BASE_DIR"
+        | _ -> None
+      in
+      match key with
+      | None -> None
+      | Some env_key -> (
+          match Node_env.read ~inst:st.service.instance with
+          | Ok pairs -> (
+              match List.assoc_opt env_key pairs with
+              | Some dir when not (String.equal (String.trim dir) "") ->
+                  Some (String.trim dir)
+              | _ -> None)
+          | Error _ -> None))
+    services
+
 let get_all_base_dirs () =
   let default_dir = default_client_base_dir () in
   let managed_dirs =
@@ -85,7 +109,8 @@ let get_all_base_dirs () =
           entries
     | Error _ -> []
   in
-  let all_dirs = default_dir :: managed_dirs in
+  let service_dirs = discover_base_dirs_from_services () in
+  let all_dirs = (default_dir :: managed_dirs) @ service_dirs in
   let normalized = List.map normalize_path all_dirs in
   List.sort_uniq String.compare normalized |> List.sort String.compare
 

--- a/test/test_wallets_page.ml
+++ b/test/test_wallets_page.ml
@@ -14,6 +14,7 @@
 open Alcotest
 open Octez_manager_lib
 module Keys_page = Octez_manager_ui.Wallets_page
+module Main_shell = Octez_manager_ui.Main_shell
 module HD = Lib_miaou_internal.Headless_driver
 module TH = Tui_test_helpers_lib.Tui_test_helpers
 module Context = Octez_manager_ui.Context
@@ -270,6 +271,108 @@ let test_imported_key_appears_without_restart () =
             true
             (TH.contains_substring screen_after "bob")))
 
+(** Regression test: Tab key toggles fold/unfold on group headers.
+    When cursor is on a GroupHeader and Tab is pressed, keys within
+    the group should be hidden (folded) and the fold indicator should change. *)
+let test_tab_toggles_fold () =
+  TH.with_test_env (fun () ->
+      with_tmp_wallet (fun base_dir ->
+          (* Pre-populate with a key so the group is visible *)
+          write_key_file
+            ~base_dir
+            ~alias:"alice"
+            ~pkh:"tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" ;
+          HD.Stateful.init (module Keys_page.Page) ;
+          let screen_before = TH.get_screen_text () in
+          (* Cursor starts at position 0 (first GroupHeader). Keys are visible. *)
+          check
+            bool
+            "alice visible before fold"
+            true
+            (TH.contains_substring screen_before "alice") ;
+          (* Press Tab to fold *)
+          ignore (TH.send_key_and_wait "Tab") ;
+          let screen_after = TH.get_screen_text () in
+          (* After folding, "alice" should be hidden *)
+          check
+            bool
+            "alice hidden after fold"
+            false
+            (TH.contains_substring screen_after "alice") ;
+          (* Press Tab again to unfold *)
+          ignore (TH.send_key_and_wait "Tab") ;
+          let screen_unfolded = TH.get_screen_text () in
+          (* After unfolding, "alice" should be visible again *)
+          check
+            bool
+            "alice visible after unfold"
+            true
+            (TH.contains_substring screen_unfolded "alice")))
+
+(** Integration test: Tab key toggles fold/unfold through main_shell.
+    This tests the ACTUAL user experience with the full TUI including tab bar.
+    The standalone test above works, but users report fold doesn't work in the
+    real TUI. This test reproduces the real scenario. *)
+let test_tab_toggles_fold_via_main_shell () =
+  TH.with_test_env (fun () ->
+      with_tmp_wallet (fun base_dir ->
+          (* Pre-populate with a key so the group is visible *)
+          write_key_file
+            ~base_dir
+            ~alias:"alice"
+            ~pkh:"tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" ;
+
+          (* Initialize with Main_shell (full TUI with tab bar) *)
+          HD.Stateful.init (module Main_shell.Page) ;
+
+          (* Wait for initial render *)
+          ignore (HD.Stateful.idle_wait ~iterations:2 ~sleep:0.001 ()) ;
+
+          (* Main_shell starts on tab 1 (Instances). Switch to tab 2 (Wallets). *)
+          ignore (TH.send_key_and_wait "2") ;
+
+          (* Wait for tab switch *)
+          ignore (HD.Stateful.idle_wait ~iterations:3 ~sleep:0.001 ()) ;
+
+          let screen_before = TH.get_screen_text () in
+
+          (* Verify we're on the wallets tab and alice is visible *)
+          check
+            bool
+            "alice visible before fold (via main_shell)"
+            true
+            (TH.contains_substring screen_before "alice") ;
+
+          (* Press Tab to fold. Cursor should be on first group header. *)
+          ignore (TH.send_key_and_wait "Tab") ;
+
+          (* Wait for fold to complete *)
+          ignore (HD.Stateful.idle_wait ~iterations:2 ~sleep:0.001 ()) ;
+
+          let screen_after = TH.get_screen_text () in
+
+          (* After folding, "alice" should be hidden *)
+          check
+            bool
+            "alice hidden after fold (via main_shell)"
+            false
+            (TH.contains_substring screen_after "alice") ;
+
+          (* Press Tab again to unfold *)
+          ignore (TH.send_key_and_wait "Tab") ;
+
+          (* Wait for unfold *)
+          ignore (HD.Stateful.idle_wait ~iterations:2 ~sleep:0.001 ()) ;
+
+          let screen_unfolded = TH.get_screen_text () in
+
+          (* After unfolding, "alice" should be visible again *)
+          check
+            bool
+            "alice visible after unfold (via main_shell)"
+            true
+            (TH.contains_substring screen_unfolded "alice")))
+
 (* ============================================================ *)
 (* Test Suite *)
 (* ============================================================ *)
@@ -303,10 +406,19 @@ let refresh_tests =
       test_imported_key_appears_without_restart );
   ]
 
+let fold_tests =
+  [
+    ("tab toggles fold on group header", `Quick, test_tab_toggles_fold);
+    ( "tab toggles fold via main_shell integration",
+      `Quick,
+      test_tab_toggles_fold_via_main_shell );
+  ]
+
 let () =
   Alcotest.run
     "Wallets_page"
     [
       ("base_dir_deduplication", base_dir_tests);
+      ("fold_unfold", fold_tests);
       ("refresh_on_dirty_flag", refresh_tests);
     ]

--- a/test/test_wallets_page.ml
+++ b/test/test_wallets_page.ml
@@ -111,6 +111,100 @@ let test_get_all_base_dirs_trailing_slash () =
   (* If the directory was added, it should appear at most once after normalization *)
   check bool "trailing slash normalized" true (count <= 1)
 
+(** Test that base directories registered in Directory_registry appear in get_all_base_dirs.
+    This ensures the fix for wallet discovery from baker/accuser installations works. *)
+let test_registry_dirs_appear_in_get_all () =
+  let test_dir = "/home/test/.local/share/octez/baker-bakingnet" in
+
+  (* Register a base_dir with a service *)
+  let _ =
+    Directory_registry.add
+      ~path:test_dir
+      ~dir_type:Client_base_dir
+      ~registered_services:["baker-test"]
+  in
+
+  (* Get all base directories *)
+  let dirs = Keys_page.Internal_for_tests.get_all_base_dirs () in
+
+  (* Check the registered directory appears *)
+  let contains_test_dir = List.exists (String.equal test_dir) dirs in
+
+  (* Cleanup *)
+  let _ = Directory_registry.remove test_dir in
+
+  (* Assert: registered directory should appear in the list *)
+  check bool "registry dir appears" true contains_test_dir
+
+(** Test that removing a directory from the registry makes it disappear from get_all_base_dirs. *)
+let test_registry_removal_works () =
+  let test_dir = "/home/test/.local/share/octez/accuser-test" in
+
+  (* Register, verify, then remove *)
+  let _ =
+    Directory_registry.add
+      ~path:test_dir
+      ~dir_type:Client_base_dir
+      ~registered_services:["accuser-test"]
+  in
+
+  let dirs_before = Keys_page.Internal_for_tests.get_all_base_dirs () in
+  let appears_before = List.exists (String.equal test_dir) dirs_before in
+
+  (* Remove from registry *)
+  let _ = Directory_registry.remove test_dir in
+
+  let dirs_after = Keys_page.Internal_for_tests.get_all_base_dirs () in
+  let appears_after = List.exists (String.equal test_dir) dirs_after in
+
+  (* Assert: should appear before removal, not after *)
+  check bool "appears before removal" true appears_before ;
+  check bool "absent after removal" false appears_after
+
+(** Test that adding the same path twice merges registered_services lists.
+    This prevents losing service registrations when multiple services share a base_dir. *)
+let test_registry_merges_services () =
+  let test_dir = "/home/test/.local/share/octez/shared-base-dir" in
+
+  (* First service registers the base_dir *)
+  let _ =
+    Directory_registry.add
+      ~path:test_dir
+      ~dir_type:Client_base_dir
+      ~registered_services:["baker-alice"]
+  in
+
+  (* Second service registers the same base_dir *)
+  let _ =
+    Directory_registry.add
+      ~path:test_dir
+      ~dir_type:Client_base_dir
+      ~registered_services:["baker-bob"]
+  in
+
+  (* Check that both services are registered *)
+  let entry =
+    match Directory_registry.find_by_path test_dir with
+    | Ok (Some e) -> e
+    | _ -> failwith "Entry not found"
+  in
+
+  (* Cleanup *)
+  let _ = Directory_registry.remove test_dir in
+
+  (* Assert: both services should be in the merged list *)
+  check
+    bool
+    "contains baker-alice"
+    true
+    (List.mem "baker-alice" entry.registered_services) ;
+  check
+    bool
+    "contains baker-bob"
+    true
+    (List.mem "baker-bob" entry.registered_services) ;
+  check int "has exactly 2 services" 2 (List.length entry.registered_services)
+
 (* ============================================================ *)
 (* TUI Regression: key appears after import without restart     *)
 (* ============================================================ *)
@@ -182,15 +276,24 @@ let test_imported_key_appears_without_restart () =
 
 let base_dir_tests =
   [
-    ( "deduplicates default dir when in registry",
+    ( "deduplicates default dir when also in registry",
       `Quick,
       test_get_all_base_dirs_deduplicates );
-    ( "ensures uniqueness with multiple managed dirs",
+    ( "deduplicates multiple managed dirs",
       `Quick,
       test_get_all_base_dirs_multiple_managed );
     ( "normalizes trailing slashes during deduplication",
       `Quick,
       test_get_all_base_dirs_trailing_slash );
+    ( "registry directories appear in get_all_base_dirs",
+      `Quick,
+      test_registry_dirs_appear_in_get_all );
+    ( "registry removal removes dir from get_all_base_dirs",
+      `Quick,
+      test_registry_removal_works );
+    ( "registry merges services when path added twice",
+      `Quick,
+      test_registry_merges_services );
   ]
 
 let refresh_tests =


### PR DESCRIPTION
## Summary

- Register baker/accuser `base_dir` in `Directory_registry` during installation so the Wallets page discovers them
- Add fallback discovery from service env files for services installed before this fix
- Clean up `Directory_registry` entries on service purge
- Fix `Directory_registry.add` to merge `registered_services` instead of replacing (prevents data loss when services share a base_dir)
- **Bind Tab to fold/unfold** base directory groups on the Wallets page (was Space)

## Problem

Two issues on the Wallets page:

1. **Missing wallets**: Only `~/.tezos-client` was shown; baker base directories like `~/.local/share/octez/baker-bakingnet` were invisible because the installer never registered them in `Directory_registry`.

2. **Fold/unfold not working**: Fold/unfold was bound to Space, but users expect Tab for toggling group expansion.

## Changes

| File | Change |
|------|--------|
| `src/installer/baker.ml` | Call `Directory_registry.add` after service registration |
| `src/installer/accuser.ml` | Call `Directory_registry.add` after service registration |
| `src/directory_registry.ml` | Merge `registered_services` on update (was replacing) |
| `src/ui/pages/wallets_page.ml` | Fallback: scan env files for base dirs; swap Tab/Space bindings |
| `src/installer/removal.ml` | Clean up registry entries on purge |
| `test/test_wallets_page.ml` | 5 new tests: discovery, removal, services merge, fold toggle (standalone + main_shell) |
| `CHANGELOG.md` | Entries under Unreleased > Fixed |

## Testing

- `dune build` ✅
- `dune runtest` ✅ (9 wallets_page tests, including 5 new)
- `dune fmt` ✅
- `./scripts/check-copyright.sh` ✅
- `git rebase --exec 'dune build' main` ✅ (each commit compiles independently)