### PR TITLE
fix(baker): clear delegates when base dir changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Baker form delegates reset on base dir change**: When creating a baker, changing the Baker Base Dir or changing the Instance Name in a way that updates the base dir now clears the previously selected delegates. This prevents stale delegate selections from a different base directory being carried over.
 - **Instances page arrow key navigation to "Add new" entries**: Fixed arrow key navigation on the Instances page when no services are installed. Previously, pressing ↓ from the "By Role / By Group" selector would not navigate to the "Add new Node", "Add new Baker", etc. entries, especially in wide terminals with multi-column layout. The issue was caused by `ensure_valid_column` resetting the selection to 0 on every refresh cycle (~1 second). Navigation now correctly moves to these ghost entries even when the service list is empty.
 - **Instances page help modal now documents arrow key navigation**: The help modal (`?`) on the Instances page now includes arrow keys (↑/↓/←/→) and vim keys (j/k/h/l) for navigation, making keyboard shortcuts more discoverable.
 - **Wallets page missing baker/accuser wallets**: The Wallets page now discovers wallet directories from installed baker and accuser services. Previously, only `~/.tezos-client` was shown; service-specific base directories (e.g., `~/.local/share/octez/baker-bakingnet`) were invisible because the installer did not register them in the directory registry.

--- a/src/ui/pages/install_baker_form_v3.ml
+++ b/src/ui/pages/install_baker_form_v3.ml
@@ -693,7 +693,9 @@ let spec =
               ~label:"Baker Base Dir"
               ~get:(fun m -> m.client.base_dir)
               ~set:(fun base_dir m ->
-                {m with client = {m.client with base_dir}})
+                let m' = {m with client = {m.client with base_dir}} in
+                if String.equal base_dir m.client.base_dir then m'
+                else {m' with delegates = []})
               ~validate:(fun m ->
                 Form_builder_common.is_nonempty m.client.base_dir)
               ()
@@ -847,15 +849,17 @@ let spec =
                             m.client.base_dir
                             (Paths.default_role_dir "baker" old))
                   in
-                  let new_client =
-                    {
-                      m.client with
-                      base_dir =
-                        (if keep_base_dir then m.client.base_dir
-                         else default_dir);
-                    }
+                  let new_base_dir =
+                    if keep_base_dir then m.client.base_dir else default_dir
                   in
-                  {m with core = new_core; client = new_client})
+                  let base_dir_changed =
+                    not (String.equal new_base_dir m.client.base_dir)
+                  in
+                  let new_client =
+                    {m.client with base_dir = new_base_dir}
+                  in
+                  let m' = {m with core = new_core; client = new_client} in
+                  if base_dir_changed then {m' with delegates = []} else m')
               ~validate:(fun m ->
                 let states = Form_builder_common.cached_service_states () in
                 if not (Form_builder_common.is_nonempty m.core.instance_name)

--- a/src/ui/pages/install_baker_form_v3.ml
+++ b/src/ui/pages/install_baker_form_v3.ml
@@ -855,9 +855,7 @@ let spec =
                   let base_dir_changed =
                     not (String.equal new_base_dir m.client.base_dir)
                   in
-                  let new_client =
-                    {m.client with base_dir = new_base_dir}
-                  in
+                  let new_client = {m.client with base_dir = new_base_dir} in
                   let m' = {m with core = new_core; client = new_client} in
                   if base_dir_changed then {m' with delegates = []} else m')
               ~validate:(fun m ->


### PR DESCRIPTION
## Summary

- When the user changes **Baker Base Dir** directly, the delegates list is now cleared
- When changing **Instance Name** causes the base dir to auto-update, the delegates list is also cleared
- Delegates are tied to keys in the base dir, so keeping stale selections from a different dir would be misleading

## Test plan

- [ ] Open Install Baker form
- [ ] Set Instance Name to an existing baker (e.g. `baker-tallinnet`) so the base dir points to a dir with keys
- [ ] Open Delegates modal and select a key
- [ ] Change Instance Name to a new value (e.g. `baker2`) — base dir auto-updates
- [ ] Verify Delegates field is now empty
- [ ] Repeat: manually change Baker Base Dir to a different path — verify Delegates is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)