### PR TITLE
fix(ui): wallet modal empty delegates + validation enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Wallets page missing baker/accuser wallets**: The Wallets page now discovers wallet directories from installed baker and accuser services. Previously, only `~/.tezos-client` was shown; service-specific base directories (e.g., `~/.local/share/octez/baker-bakingnet`) were invisible because the installer did not register them in the directory registry.
 - **Wallets page fold/unfold keybinding**: Changed fold/unfold base directory groups from Space to Tab for consistency with common TUI conventions. Space now switches between the list and detail panels.
 - **Wallet modal misleading error with no delegates**: The baker wallet modal now shows "No delegates found in wallet" instead of "Unable to fetch wallet data — node may be unreachable" when the baker's base directory contains no keys.
+- **Validated text modals not enforcing validation**: Pressing Enter in validated text input modals (e.g., key alias, transfer amount) could bypass validation and submit invalid values. Validation errors like "Alias cannot be empty" are now properly enforced.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Instances page help modal now documents arrow key navigation**: The help modal (`?`) on the Instances page now includes arrow keys (↑/↓/←/→) and vim keys (j/k/h/l) for navigation, making keyboard shortcuts more discoverable.
 - **Wallets page missing baker/accuser wallets**: The Wallets page now discovers wallet directories from installed baker and accuser services. Previously, only `~/.tezos-client` was shown; service-specific base directories (e.g., `~/.local/share/octez/baker-bakingnet`) were invisible because the installer did not register them in the directory registry.
 - **Wallets page fold/unfold keybinding**: Changed fold/unfold base directory groups from Space to Tab for consistency with common TUI conventions. Space now switches between the list and detail panels.
+- **Wallet modal misleading error with no delegates**: The baker wallet modal now shows "No delegates found in wallet" instead of "Unable to fetch wallet data — node may be unreachable" when the baker's base directory contains no keys.
 
 ### Removed
 

--- a/src/ui/delegate_scheduler.ml
+++ b/src/ui/delegate_scheduler.ml
@@ -213,3 +213,13 @@ let clear () =
   Mutex.protect config_lock (fun () -> Hashtbl.clear config_cache)
 
 let shutdown () = Atomic.set shutdown_requested true
+
+(** {1 Testing helpers} *)
+
+module Internal_for_tests = struct
+  (** Set cached config for an instance (for tests that need to inject data) *)
+  let set_config ~instance ~delegates ~node_endpoint ~has_dal =
+    let config = {delegates; node_endpoint; has_dal} in
+    Mutex.protect config_lock (fun () ->
+        Hashtbl.replace config_cache instance config)
+end

--- a/src/ui/delegate_scheduler.mli
+++ b/src/ui/delegate_scheduler.mli
@@ -38,3 +38,19 @@ val clear : unit -> unit
 
 (** Shutdown the background scheduler. *)
 val shutdown : unit -> unit
+
+(** {1 Testing} *)
+
+(**/**)
+
+module Internal_for_tests : sig
+  (** Set cached config for an instance (for tests that need to inject data). *)
+  val set_config :
+    instance:string ->
+    delegates:string list ->
+    node_endpoint:string option ->
+    has_dal:bool ->
+    unit
+end
+
+(**/**)

--- a/src/ui/modal_helpers.ml
+++ b/src/ui/modal_helpers.ml
@@ -797,10 +797,12 @@ let prompt_validated_text_modal ?title ?(width = 60) ?initial ?placeholder
           Miaou_widgets_input.Validated_textbox_widget.flush_validation s
         in
         if Miaou_widgets_input.Validated_textbox_widget.is_valid s then (
+          Miaou.Core.Modal_manager.set_consume_next_key () ;
           Miaou.Core.Modal_manager.close_top `Commit ;
           Navigation.update (fun _ -> s) ps)
         else Navigation.update (fun _ -> s) ps
       else if key = "Esc" || key = "Escape" then (
+        Miaou.Core.Modal_manager.set_consume_next_key () ;
         Miaou.Core.Modal_manager.close_top `Cancel ;
         ps)
       else
@@ -843,15 +845,22 @@ let prompt_validated_text_modal ?title ?(width = 60) ?initial ?placeholder
       ()
   in
   let modal_title = Option.value ~default:"Input" title in
-  Miaou.Core.Modal_manager.prompt
+  let ui : Miaou.Core.Modal_manager.ui =
+    {title = modal_title; left = None; max_width = None; dim_background = true}
+  in
+  Miaou.Core.Modal_manager.push
     (module Modal)
     ~init:(Navigation.make widget)
-    ~title:modal_title
-    ~extract:(fun pstate ->
-      Some
-        (Miaou_widgets_input.Validated_textbox_widget.value pstate.Navigation.s))
-    ~on_result:(function Some text -> on_submit text | None -> ())
-    ()
+    ~ui
+    ~commit_on:[]
+    ~cancel_on:[]
+    ~on_close:(fun pstate outcome ->
+      match outcome with
+      | `Commit ->
+          on_submit
+            (Miaou_widgets_input.Validated_textbox_widget.value
+               pstate.Navigation.s)
+      | `Cancel -> ())
 
 let wrap_text ~width s =
   let wrap_line s =

--- a/src/ui/pages/instances/instances_wallet.ml
+++ b/src/ui/pages/instances/instances_wallet.ml
@@ -708,41 +708,52 @@ let dispatch_action svc pkh _data ~node_endpoint action =
 (* ── Wallet header rendering ──────────────────────────────── *)
 
 let render_wallet_header ~pkh ~delegates ~cols =
-  match Baker_wallet_data.get ~pkh with
-  | None ->
+  match delegates with
+  | [] ->
       String.concat
         "\n"
         [
-          Printf.sprintf "  Delegate: %s" (Widgets.themed_muted pkh);
+          "  " ^ Widgets.themed_muted "No delegates found in wallet";
           "";
-          Widgets.themed_error
-            "  Unable to fetch wallet data — node may be unreachable";
+          "  Import or generate keys to manage this baker.";
           "";
         ]
-  | Some data ->
-      let delegate_line =
-        Printf.sprintf
-          "  Delegate: %s%s"
-          data.pkh
-          (if List.length delegates > 1 then
-             "                   " ^ Widgets.themed_muted "[Tab] to switch"
-           else "")
-      in
-      let parts =
-        [
-          delegate_line;
-          "";
-          render_balance_box ~cols data;
-          "";
-          render_status_line data;
-        ]
-        @ (let p = render_staking_params data in
-           if p = "" then [] else [p])
-        @ (let u = render_pending_unstakes data in
-           if u = "" then [] else [u])
-        @ [""]
-      in
-      String.concat "\n" parts
+  | _ -> (
+      match Baker_wallet_data.get ~pkh with
+      | None ->
+          String.concat
+            "\n"
+            [
+              Printf.sprintf "  Delegate: %s" (Widgets.themed_muted pkh);
+              "";
+              Widgets.themed_error
+                "  Unable to fetch wallet data — node may be unreachable";
+              "";
+            ]
+      | Some data ->
+          let delegate_line =
+            Printf.sprintf
+              "  Delegate: %s%s"
+              data.pkh
+              (if List.length delegates > 1 then
+                 "                   " ^ Widgets.themed_muted "[Tab] to switch"
+               else "")
+          in
+          let parts =
+            [
+              delegate_line;
+              "";
+              render_balance_box ~cols data;
+              "";
+              render_status_line data;
+            ]
+            @ (let p = render_staking_params data in
+               if String.equal p "" then [] else [p])
+            @ (let u = render_pending_unstakes data in
+               if String.equal u "" then [] else [u])
+            @ [""]
+          in
+          String.concat "\n" parts)
 
 let count_lines s =
   let n = ref 1 in
@@ -760,33 +771,54 @@ let wallet_modal ~svc =
     | None -> ""
   in
   let initial_pkh = match delegates with first :: _ -> first | [] -> "" in
+  let to_string_item ~action_display = function
+    | `Empty_wallet -> Widgets.themed_muted "No operations available"
+    | `Error_state -> Widgets.themed_error "Unable to fetch wallet data"
+    | `Action action -> action_display action
+  in
   let build_select pkh :
-      [`Error_state | `Action of wallet_action] Select_widget.t =
-    match Baker_wallet_data.get ~pkh with
-    | None ->
+      [`Error_state | `Action of wallet_action | `Empty_wallet] Select_widget.t
+      =
+    match delegates with
+    | [] ->
         Select_widget.open_centered
           ~title:""
           ~items:
-            ([`Error_state] : [`Error_state | `Action of wallet_action] list)
-          ~to_string:(function
-            | `Error_state -> Widgets.themed_error "Unable to fetch wallet data"
-            | `Action _ -> "...")
+            ([`Empty_wallet]
+              : [`Error_state | `Action of wallet_action | `Empty_wallet] list)
+          ~to_string:(to_string_item ~action_display:(fun _ -> "..."))
           ()
-    | Some data ->
-        let actions = build_operations_list data ~node_endpoint in
-        Select_widget.open_centered
-          ~title:""
-          ~items:(List.map (fun a -> `Action a) actions)
-          ~to_string:(function
-            | `Error_state -> Widgets.themed_error "Unable to fetch wallet data"
-            | `Action action -> action_to_string data ~node_endpoint action)
-          ()
+    | _ -> (
+        match Baker_wallet_data.get ~pkh with
+        | None ->
+            Select_widget.open_centered
+              ~title:""
+              ~items:
+                ([`Error_state]
+                  : [`Error_state | `Action of wallet_action | `Empty_wallet]
+                    list)
+              ~to_string:(to_string_item ~action_display:(fun _ -> "..."))
+              ()
+        | Some data ->
+            let actions = build_operations_list data ~node_endpoint in
+            Select_widget.open_centered
+              ~title:""
+              ~items:
+                (List.map (fun a -> `Action a) actions
+                  : [`Error_state | `Action of wallet_action | `Empty_wallet]
+                    list)
+              ~to_string:
+                (to_string_item
+                   ~action_display:(action_to_string data ~node_endpoint))
+              ())
   in
   let title = Printf.sprintf "Wallet · %s" instance in
   let module Wallet_modal = struct
     type state = {
       current_pkh : string;
-      select : [`Error_state | `Action of wallet_action] Select_widget.t;
+      select :
+        [`Error_state | `Action of wallet_action | `Empty_wallet]
+        Select_widget.t;
     }
 
     type msg = unit
@@ -863,7 +895,7 @@ let wallet_modal ~svc =
                   Modal_manager.close_top `Commit ;
                   dispatch_action svc s.current_pkh data ~node_endpoint action ;
                   ps)
-          | Some `Error_state | None -> ps)
+          | Some `Error_state | Some `Empty_wallet | None -> ps)
       | Some Keys.Escape ->
           Modal_manager.set_consume_next_key () ;
           Modal_manager.close_top `Cancel ;
@@ -913,3 +945,9 @@ let wallet_modal ~svc =
     ~commit_on:[]
     ~cancel_on:[]
     ~on_close:(fun _ _ -> ())
+
+(** {1 Testing} *)
+
+module Internal_for_tests = struct
+  let render_wallet_header = render_wallet_header
+end

--- a/src/ui/pages/instances/instances_wallet.mli
+++ b/src/ui/pages/instances/instances_wallet.mli
@@ -41,3 +41,15 @@ val poll_operation :
 
     @param svc The baker service to show wallet for. *)
 val wallet_modal : svc:Octez_manager_lib.Service.t -> unit
+
+(** {1 Testing} *)
+
+(**/**)
+
+module Internal_for_tests : sig
+  (** Render the wallet header section. Exposed for regression testing. *)
+  val render_wallet_header :
+    pkh:string -> delegates:string list -> cols:int -> string
+end
+
+(**/**)

--- a/test/dune
+++ b/test/dune
@@ -335,6 +335,21 @@
   (backend bisect_ppx)))
 
 (test
+ (name test_wallet_empty_delegates)
+ (libraries
+  alcotest
+  octez_manager_lib
+  octez-manager.ui
+  miaou-core.lib
+  miaou-core.lib_miaou_internal
+  lambda-term
+  tui_test_helpers_lib
+  mock_service_helpers_lib)
+ (modules test_wallet_empty_delegates)
+ (instrumentation
+  (backend bisect_ppx)))
+
+(test
  (name test_binary_registry)
  (libraries alcotest octez_manager_lib yojson)
  (modules test_binary_registry)

--- a/test/test_golden_path_tui_v2.ml
+++ b/test/test_golden_path_tui_v2.ml
@@ -357,7 +357,9 @@ let golden_path_script =
       (* text prompt appeared *)
       Type "tz1golden";
       Key "Enter";
-      (* submit address - text prompt closes, multiselect also closes *)
+      (* submit address - text prompt closes, multiselect stays open *)
+      Key "Esc";
+      (* close the multiselect modal *)
       WaitFor [ModalClosed; MaxIterations 10];
       Comment
         "Index form: 13 fields. Cursor now on field 5 (Watched Addresses).";

--- a/test/test_modal_interactions.ml
+++ b/test/test_modal_interactions.ml
@@ -17,6 +17,7 @@
 open Alcotest
 module HD = Lib_miaou_internal.Headless_driver
 module Install_node_form = Octez_manager_ui.Install_node_form_v3
+module Modal_helpers = Octez_manager_ui.Modal_helpers
 module TH = Tui_test_helpers_lib.Tui_test_helpers
 
 (* ============================================================ *)
@@ -256,6 +257,77 @@ let test_form_state_preserved () =
         && TH.contains_substring final "Parameter"))
 
 (* ============================================================ *)
+(* Test: Validated Text Modal Blocks Invalid Submission *)
+(* ============================================================ *)
+
+let test_validated_modal_blocks_empty_submit () =
+  TH.with_test_env (fun () ->
+      let submitted = ref false in
+      let submitted_value = ref "" in
+
+      (* Open a validated text modal with non-empty validator *)
+      Modal_helpers.prompt_validated_text_modal
+        ~title:"Test Alias"
+        ~width:40
+        ~initial:""
+        ~validator:(fun text ->
+          let trimmed = String.trim text in
+          if String.length trimmed = 0 then Error "Alias cannot be empty"
+          else Ok ())
+        ~on_submit:(fun text ->
+          submitted := true ;
+          submitted_value := text)
+        () ;
+
+      Unix.sleepf 0.02 ;
+
+      (* Modal should be open *)
+      check
+        bool
+        "modal open initially"
+        true
+        (Miaou.Core.Modal_manager.has_active ()) ;
+
+      (* Press Enter without typing anything (should fail validation) *)
+      ignore (TH.send_key_and_wait "Enter") ;
+      Unix.sleepf 0.02 ;
+
+      (* Modal should STILL be open (validation blocked submission) *)
+      check
+        bool
+        "modal still open after empty Enter"
+        true
+        (Miaou.Core.Modal_manager.has_active ()) ;
+
+      (* on_submit should NOT have been called *)
+      check bool "on_submit not called with invalid input" false !submitted ;
+
+      (* Now type valid text *)
+      ignore (TH.send_key_and_wait "t") ;
+      Unix.sleepf 0.01 ;
+      ignore (TH.send_key_and_wait "e") ;
+      Unix.sleepf 0.01 ;
+      ignore (TH.send_key_and_wait "s") ;
+      Unix.sleepf 0.01 ;
+      ignore (TH.send_key_and_wait "t") ;
+      Unix.sleepf 0.02 ;
+
+      (* Press Enter with valid text *)
+      ignore (TH.send_key_and_wait "Enter") ;
+      Unix.sleepf 0.02 ;
+
+      (* Modal should now be closed *)
+      check
+        bool
+        "modal closed after valid Enter"
+        false
+        (Miaou.Core.Modal_manager.has_active ()) ;
+
+      (* on_submit should have been called with the valid text *)
+      check bool "on_submit called with valid input" true !submitted ;
+      check string "submitted correct value" "test" !submitted_value)
+
+(* ============================================================ *)
 (* Test Suite *)
 (* ============================================================ *)
 
@@ -268,6 +340,9 @@ let modal_tests =
     ("modal selection with enter", `Quick, test_modal_selection);
     ("field edit workflow", `Quick, test_field_edit_workflow);
     ("form state preserved after modal", `Quick, test_form_state_preserved);
+    ( "validated modal blocks empty submit",
+      `Quick,
+      test_validated_modal_blocks_empty_submit );
   ]
 
 let () =

--- a/test/test_wallet_empty_delegates.ml
+++ b/test/test_wallet_empty_delegates.ml
@@ -1,0 +1,116 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Regression test for wallet modal with 0 delegates.
+    
+    Bug: When a baker instance has 0 delegates configured in its base dir,
+    the wallet modal shows "Unable to fetch wallet data — node may be unreachable"
+    which is misleading (the node may be fine, there are just no keys).
+    
+    Expected: The modal should show a clear "No delegates found" message instead. *)
+
+open Alcotest
+module HD = Lib_miaou_internal.Headless_driver
+module TH = Tui_test_helpers_lib.Tui_test_helpers
+module Mock = Mock_service_helpers_lib.Mock_service_helpers
+module Delegate_scheduler = Octez_manager_ui.Delegate_scheduler
+module Instances_wallet = Octez_manager_ui.Instances_wallet
+
+(* ============================================================ *)
+(* Test: render_wallet_header with empty delegates *)
+(* ============================================================ *)
+
+let test_render_wallet_header_empty_delegates () =
+  TH.with_test_env (fun () ->
+      (* Inject test data: baker with empty delegates *)
+      Delegate_scheduler.Internal_for_tests.set_config
+        ~instance:"test-baker"
+        ~delegates:[]
+        ~node_endpoint:(Some "http://localhost:8732")
+        ~has_dal:false ;
+
+      (* Call render_wallet_header with empty delegates list *)
+      let header =
+        Instances_wallet.Internal_for_tests.render_wallet_header
+          ~pkh:""
+          ~delegates:[]
+          ~cols:80
+      in
+
+      (* The header should NOT show the misleading error *)
+      check
+        bool
+        "does not show misleading node unreachable error"
+        false
+        (TH.contains_substring header "node may be unreachable"
+        || TH.contains_substring header "Unable to fetch wallet data") ;
+
+      (* Instead, it should show a helpful message about no delegates *)
+      check
+        bool
+        "shows no delegates message"
+        true
+        (TH.contains_substring header "No delegate"
+        || TH.contains_substring header "no delegate") ;
+
+      (* Check for exact message *)
+      check
+        bool
+        "shows exact empty wallet message"
+        true
+        (TH.contains_substring header "No delegates found in wallet"))
+
+(* ============================================================ *)
+(* Test: render_wallet_header with delegates but no cache *)
+(* ============================================================ *)
+
+let test_render_wallet_header_with_delegates_no_cache () =
+  TH.with_test_env (fun () ->
+      (* Set up baker with delegates but no wallet data in cache *)
+      Delegate_scheduler.Internal_for_tests.set_config
+        ~instance:"test-baker-2"
+        ~delegates:["tz1abc123"]
+        ~node_endpoint:(Some "http://localhost:8732")
+        ~has_dal:false ;
+
+      (* Call render_wallet_header with a delegate but no cached wallet data *)
+      let header =
+        Instances_wallet.Internal_for_tests.render_wallet_header
+          ~pkh:"tz1abc123"
+          ~delegates:["tz1abc123"]
+          ~cols:80
+      in
+
+      (* This SHOULD show the "node may be unreachable" error
+         because we have a delegate but can't fetch its data *)
+      check
+        bool
+        "shows node unreachable error when delegate exists but data missing"
+        true
+        (TH.contains_substring header "node may be unreachable"
+        || TH.contains_substring header "Unable to fetch wallet data"))
+
+(* ============================================================ *)
+(* Test Suite *)
+(* ============================================================ *)
+
+let () =
+  run
+    "Wallet Modal - Empty Delegates"
+    [
+      ( "render_wallet_header",
+        [
+          test_case
+            "shows correct message with empty delegates"
+            `Quick
+            test_render_wallet_header_empty_delegates;
+          test_case
+            "shows node error when delegate exists but no cache"
+            `Quick
+            test_render_wallet_header_with_delegates_no_cache;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- **Wallet modal shows correct message when baker has 0 delegates** instead of the misleading "Unable to fetch wallet data — node may be unreachable"
- **Validated text modals now enforce validation** — pressing Enter with invalid input (e.g., empty alias) no longer bypasses the validation gate

## Fix 1: Empty delegates message

When opening the Wallet modal for a baker whose base directory contains no keys, `delegates = []` caused `initial_pkh = ""`, and `Baker_wallet_data.get ~pkh:""` returned `None`, hitting the "node unreachable" error branch. The modal now checks `delegates` first and shows "No delegates found in wallet — Import or generate keys to manage this baker."

## Fix 2: Validation enforcement

`prompt_validated_text_modal` used `Modal_manager.prompt` which internally sets `commit_on:["Enter"]`. The modal manager unconditionally closes on Enter after calling `handle_key`, bypassing the `is_valid` gate in `handle_modal_key`. This affected all 26 call sites (key alias, transfer amounts, stake amounts, etc.).

Fixed by switching to `Modal_manager.push` with `commit_on:[]` so `handle_modal_key` is the sole authority on when to close.

## Tests

- `test_wallet_empty_delegates.ml`: 2 tests — empty delegates shows correct message; delegates with no cache preserves "node unreachable" error
- `test_modal_interactions.ml`: 1 test — validates that Enter is blocked on invalid input and succeeds on valid input

## Changelog

Added entries under `[Unreleased] > Fixed`.