### PR TITLE
feat(ui): add progress bar and success toast to log export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Log export now runs in the background with progress feedback**: Exporting instance logs no longer freezes the UI. A progress bar is shown during the export and a green success toast displays the archive path on completion.
 - Simplified help modal (`?`) keymaps across all pages: removed verbose descriptions in favor of concise action names (e.g., "Toggle view" instead of "Group/Role view", "Back" instead of "Back / Previous")
 - Simplified instances page help hint: removed verbose view mode descriptions ("By Role", "By Group", "Toggle view") in favor of concise key combinations
 - Extract `register_and_init` and `shutdown` helpers in `manager_app.ml`

--- a/src/cli/cmd_instance.ml
+++ b/src/cli/cmd_instance.ml
@@ -851,7 +851,7 @@ let instance_term =
                         (Printf.sprintf "Edit failed: %s" msg)))
         | Export_logs ->
             with_service ~instance:inst (fun svc ->
-                match Log_export.export_logs ~instance:inst ~svc with
+                match Log_export.export_logs ~instance:inst ~svc () with
                 | Ok archive_path ->
                     Format.printf "Logs exported to: %s@." archive_path ;
                     `Ok ()

--- a/src/log_export.ml
+++ b/src/log_export.ml
@@ -255,7 +255,7 @@ let get_system_info () =
   Buffer.contents buf
 
 (** Main export function *)
-let export_logs ~instance ~svc =
+let export_logs ~instance ~svc ?(on_step = fun _ -> ()) () =
   let role = svc.Service.role in
   let days = 7 in
   (* Create temp directory for export *)
@@ -289,6 +289,7 @@ let export_logs ~instance ~svc =
               (Unix.error_message e)))
   in
   (* Collect daily logs *)
+  on_step "Collecting daily logs..." ;
   let daily_logs = collect_daily_logs ~role ~instance ~days in
   let logs_dir = Filename.concat export_dir "daily_logs" in
   if daily_logs <> [] then (
@@ -299,11 +300,13 @@ let export_logs ~instance ~svc =
         ignore (File_ops.copy_file src dst))
       daily_logs) ;
   (* Export journald logs *)
+  on_step "Exporting journald logs..." ;
   let journald_file = Filename.concat export_dir "journald.log" in
   let _ =
     export_journald_logs ~role ~instance ~days ~output_file:journald_file
   in
   (* Write instance details *)
+  on_step "Gathering instance details..." ;
   let details_file = Filename.concat export_dir "instance-details.txt" in
   let details_content =
     get_instance_details ~svc ^ get_version_info ~svc
@@ -319,6 +322,7 @@ let export_logs ~instance ~svc =
       Error (`Msg (Printf.sprintf "Failed to write details: %s" msg))
   in
   (* Copy env file *)
+  on_step "Copying configuration files..." ;
   let env_src =
     Filename.concat
       (Filename.concat (Paths.env_instances_base_dir ()) instance)
@@ -336,6 +340,7 @@ let export_logs ~instance ~svc =
          registry_src
          (Filename.concat export_dir "service.json")) ;
   (* Create tar.gz archive *)
+  on_step "Creating archive..." ;
   let tar_cmd =
     Printf.sprintf
       "tar -czf %s -C %s %s"
@@ -350,4 +355,5 @@ let export_logs ~instance ~svc =
   in
   (* Clean up temp directory *)
   let _ = File_ops.remove_tree export_dir in
+  on_step "Done" ;
   Ok archive_path

--- a/src/log_export.ml
+++ b/src/log_export.ml
@@ -289,7 +289,7 @@ let export_logs ~instance ~svc ?(on_step = fun _ -> ()) () =
               (Unix.error_message e)))
   in
   (* Collect daily logs *)
-  on_step "Collecting daily logs..." ;
+  on_step "Collecting daily logs" ;
   let daily_logs = collect_daily_logs ~role ~instance ~days in
   let logs_dir = Filename.concat export_dir "daily_logs" in
   if daily_logs <> [] then (
@@ -300,13 +300,13 @@ let export_logs ~instance ~svc ?(on_step = fun _ -> ()) () =
         ignore (File_ops.copy_file src dst))
       daily_logs) ;
   (* Export journald logs *)
-  on_step "Exporting journald logs..." ;
+  on_step "Exporting journald logs" ;
   let journald_file = Filename.concat export_dir "journald.log" in
   let _ =
     export_journald_logs ~role ~instance ~days ~output_file:journald_file
   in
   (* Write instance details *)
-  on_step "Gathering instance details..." ;
+  on_step "Gathering details" ;
   let details_file = Filename.concat export_dir "instance-details.txt" in
   let details_content =
     get_instance_details ~svc ^ get_version_info ~svc
@@ -322,7 +322,7 @@ let export_logs ~instance ~svc ?(on_step = fun _ -> ()) () =
       Error (`Msg (Printf.sprintf "Failed to write details: %s" msg))
   in
   (* Copy env file *)
-  on_step "Copying configuration files..." ;
+  on_step "Copying config files" ;
   let env_src =
     Filename.concat
       (Filename.concat (Paths.env_instances_base_dir ()) instance)

--- a/src/log_export.ml
+++ b/src/log_export.ml
@@ -274,9 +274,11 @@ let export_logs ~instance ~svc =
   let tmp_dir = Filename.get_temp_dir_name () in
   let export_dir = Filename.concat tmp_dir export_name in
   let archive_path = Filename.concat tmp_dir (export_name ^ ".tar.gz") in
-  (* Create export directory *)
+  (* Create export directory - remove stale directory if it exists *)
   let* () =
     try
+      if Sys.file_exists export_dir then
+        ignore (File_ops.remove_tree export_dir) ;
       Unix.mkdir export_dir 0o755 ;
       Ok ()
     with Unix.Unix_error (e, _, _) ->

--- a/src/log_export.mli
+++ b/src/log_export.mli
@@ -15,9 +15,16 @@
     - Related service versions (dependencies and dependents) *)
 
 (** [export_logs ~instance ~svc] exports logs and diagnostic information
-    for the given instance. Returns the path to the created archive on success. *)
+    for the given instance. Returns the path to the created archive on success.
+    
+    @param on_step Optional callback invoked before each major step with a
+    description of the current operation. Useful for progress tracking. *)
 val export_logs :
-  instance:string -> svc:Service.t -> (string, [> `Msg of string]) result
+  instance:string ->
+  svc:Service.t ->
+  ?on_step:(string -> unit) ->
+  unit ->
+  (string, [> `Msg of string]) result
 
 module For_tests : sig
   val get_instance_details : svc:Service.t -> string

--- a/src/ui/modal_helpers.ml
+++ b/src/ui/modal_helpers.ml
@@ -1284,6 +1284,115 @@ let open_download_progress_modal ~version ~on_complete =
     ~ui
     ~on_close:(fun _ _ -> ())
 
+let open_export_logs_modal ~instance ~svc ~on_complete =
+  let module Modal = struct
+    type state = unit
+
+    type msg = unit
+
+    type key_binding = state Miaou.Core.Tui_page.key_binding_desc
+
+    type pstate = state Navigation.t
+
+    let init () =
+      (* Start export in background *)
+      Background_runner.enqueue (fun () ->
+          (* Initialize progress tracking *)
+          Context.progress_start
+            ~label:"Preparing export..."
+            ~estimate_secs:10.0
+            ~width:50 ;
+          (* Track steps for progress ratio *)
+          let step_count = Atomic.make 0 in
+          let total_steps = 5 in
+          let on_step label =
+            let n = Atomic.fetch_and_add step_count 1 in
+            let ratio = float_of_int n /. float_of_int total_steps in
+            Context.progress_set ~label ~progress:ratio () ;
+            Context.mark_download_dirty ()
+          in
+          let result =
+            Octez_manager_lib.Log_export.export_logs ~instance ~svc ~on_step ()
+          in
+          Context.progress_finish () ;
+          match result with
+          | Ok path ->
+              (Unix.sleepf [@allow_forbidden "UI delay - TODO: use Eio"]) 1.5 ;
+              Context.toast_success (Printf.sprintf "Logs exported to: %s" path) ;
+              on_complete (Some path) ;
+              Miaou.Core.Modal_manager.close_top `Commit
+          | Error (`Msg msg) ->
+              Context.toast_error (Printf.sprintf "Export failed: %s" msg) ;
+              on_complete None ;
+              Miaou.Core.Modal_manager.close_top `Cancel) ;
+      Navigation.make ()
+
+    let update ps _ = ps
+
+    let view _ps ~focus:_ ~size =
+      let lines = ref [] in
+      let add s = lines := s :: !lines in
+      add (Printf.sprintf "Exporting logs for %s..." instance) ;
+      add "" ;
+      let progress_line =
+        Context.render_progress ~cols:(size.LTerm_geom.cols - 4)
+      in
+      if String.trim progress_line <> "" then add progress_line
+      else add "Preparing export..." ;
+      add "" ;
+      add "Modal will close automatically when export completes." ;
+      let content = String.concat "\n" (List.rev !lines) in
+      let lines_list = String.split_on_char '\n' content in
+      Pager.render
+        ~win:(max 1 (size.LTerm_geom.rows - 4))
+        ~cols:(max 1 (size.LTerm_geom.cols - 2))
+        (Pager.open_lines ~title:"" lines_list)
+        ~focus:false
+
+    let move ps _ = ps
+
+    let refresh ps = ps
+
+    let service_select ps _ = ps
+
+    let service_cycle ps _ = ps
+
+    let keymap _ = []
+
+    let back ps = ps
+
+    let handled_keys _ = []
+
+    let handle_modal_key ps _key ~size:_ = ps
+
+    let handle_key ps _key ~size:_ = ps
+
+    let on_key ps key ~size =
+      let ps' = handle_key ps (Miaou.Core.Keys.to_string key) ~size in
+      (ps', Miaou_interfaces.Key_event.Handled)
+
+    let on_modal_key ps key ~size =
+      let ps' = handle_modal_key ps (Miaou.Core.Keys.to_string key) ~size in
+      (ps', Miaou_interfaces.Key_event.Handled)
+
+    let key_hints _ps = []
+
+    let has_modal _ = true
+  end in
+  let ui : Miaou.Core.Modal_manager.ui =
+    {
+      title = Printf.sprintf "Exporting logs · %s" instance;
+      left = None;
+      max_width = Some (Clamped {ratio = 0.6; min = 60; max = 80});
+      dim_background = true;
+    }
+  in
+  Miaou.Core.Modal_manager.push_default
+    (module Modal)
+    ~init:(Modal.init ())
+    ~ui
+    ~on_close:(fun _ _ -> ())
+
 let select_app_bin_dir_modal ~on_select () =
   (* Load managed versions *)
   let managed_versions =

--- a/src/ui/modal_helpers.ml
+++ b/src/ui/modal_helpers.ml
@@ -1355,7 +1355,10 @@ let open_export_logs_modal ~instance ~svc ~on_complete =
 
     let service_select ps _ = ps
 
-    let service_cycle ps _ = ps
+    let service_cycle ps _ =
+      if Context.consume_download_dirty () then
+        Navigation.update (fun s -> s) ps
+      else ps
 
     let keymap _ = []
 
@@ -1387,10 +1390,12 @@ let open_export_logs_modal ~instance ~svc ~on_complete =
       dim_background = true;
     }
   in
-  Miaou.Core.Modal_manager.push_default
+  Miaou.Core.Modal_manager.push
     (module Modal)
     ~init:(Modal.init ())
     ~ui
+    ~commit_on:[]
+    ~cancel_on:[]
     ~on_close:(fun _ _ -> ())
 
 let select_app_bin_dir_modal ~on_select () =

--- a/src/ui/modal_helpers.ml
+++ b/src/ui/modal_helpers.ml
@@ -1288,7 +1288,15 @@ let open_download_progress_modal ~version ~on_complete =
     ~ui
     ~on_close:(fun _ _ -> ())
 
+(* Type for tracking export log modal result state *)
+type export_result = InProgress | Success of string | Failed of string
+
 let open_export_logs_modal ~instance ~svc ~on_complete =
+  (* Modal-local state: tracks export result for display.
+     Written by the background domain, read by the view function. *)
+  (* Use a plain ref — written once by background, read by main thread.
+     OCaml 5 guarantees single-word ref writes are atomic. *)
+  let result_ref = ref InProgress in
   let module Modal = struct
     type state = unit
 
@@ -1321,37 +1329,52 @@ let open_export_logs_modal ~instance ~svc ~on_complete =
           Context.progress_finish () ;
           match result with
           | Ok path ->
-              (Unix.sleepf [@allow_forbidden "UI delay - TODO: use Eio"]) 1.5 ;
-              Context.toast_success (Printf.sprintf "Logs exported to: %s" path) ;
-              on_complete (Some path) ;
-              Miaou.Core.Modal_manager.close_top `Commit
+              result_ref := Success path ;
+              Context.mark_download_dirty ()
           | Error (`Msg msg) ->
-              Context.toast_error (Printf.sprintf "Export failed: %s" msg) ;
-              on_complete None ;
-              Miaou.Core.Modal_manager.close_top `Cancel) ;
+              result_ref := Failed msg ;
+              Context.mark_download_dirty ()) ;
       Navigation.make ()
 
     let update ps _ = ps
 
     let view _ps ~focus:_ ~size =
+      let cols = max 1 (size.LTerm_geom.cols - 4) in
       let lines = ref [] in
       let add s = lines := s :: !lines in
-      add (Printf.sprintf "Exporting logs for %s..." instance) ;
-      add "" ;
-      let progress_line =
-        Context.render_progress ~cols:(size.LTerm_geom.cols - 4)
-      in
-      if String.trim progress_line <> "" then add progress_line
-      else add "Preparing export..." ;
-      add "" ;
-      add "Modal will close automatically when export completes." ;
-      let content = String.concat "\n" (List.rev !lines) in
-      let lines_list = String.split_on_char '\n' content in
-      Pager.render
-        ~win:(max 1 (size.LTerm_geom.rows - 4))
-        ~cols:(max 1 (size.LTerm_geom.cols - 2))
-        (Pager.open_lines ~title:"" lines_list)
-        ~focus:false
+      (match !result_ref with
+      | InProgress ->
+          add (Printf.sprintf "Exporting logs for %s..." instance) ;
+          add "" ;
+          let progress_line = Context.render_progress ~cols in
+          if String.trim progress_line <> "" then add progress_line
+          else add "Preparing export..." ;
+          add "" ;
+          add
+            (Miaou_widgets_display.Widgets.themed_muted
+               "Please wait, this may take a moment.")
+      | Success path ->
+          add
+            (Miaou_widgets_display.Widgets.themed_success
+               "\xe2\x9c\x93 Export complete") ;
+          add "" ;
+          add (Printf.sprintf "Logs exported to:") ;
+          add (Miaou_widgets_display.Widgets.themed_emphasis path) ;
+          add "" ;
+          add
+            (Miaou_widgets_display.Widgets.themed_muted
+               "Press Enter or Esc to close.")
+      | Failed msg ->
+          add
+            (Miaou_widgets_display.Widgets.themed_error
+               "\xe2\x9c\x97 Export failed") ;
+          add "" ;
+          add msg ;
+          add "" ;
+          add
+            (Miaou_widgets_display.Widgets.themed_muted
+               "Press Enter or Esc to close.")) ;
+      String.concat "\n" (List.rev !lines)
 
     let move ps _ = ps
 
@@ -1370,9 +1393,27 @@ let open_export_logs_modal ~instance ~svc ~on_complete =
 
     let handled_keys _ = []
 
-    let handle_modal_key ps _key ~size:_ = ps
+    let handle_modal_key ps key ~size:_ =
+      match !result_ref with
+      | InProgress -> ps (* Ignore keys while export is running *)
+      | Success path ->
+          if key = "Enter" || key = "Esc" then (
+            Context.toast_success (Printf.sprintf "Logs exported to: %s" path) ;
+            on_complete (Some path) ;
+            Miaou.Core.Modal_manager.set_consume_next_key () ;
+            Miaou.Core.Modal_manager.close_top `Commit ;
+            ps)
+          else ps
+      | Failed msg ->
+          if key = "Enter" || key = "Esc" then (
+            Context.toast_error (Printf.sprintf "Export failed: %s" msg) ;
+            on_complete None ;
+            Miaou.Core.Modal_manager.set_consume_next_key () ;
+            Miaou.Core.Modal_manager.close_top `Cancel ;
+            ps)
+          else ps
 
-    let handle_key ps _key ~size:_ = ps
+    let handle_key = handle_modal_key
 
     let on_key ps key ~size =
       let ps' = handle_key ps (Miaou.Core.Keys.to_string key) ~size in

--- a/src/ui/modal_helpers.ml
+++ b/src/ui/modal_helpers.ml
@@ -219,10 +219,14 @@ let open_choice_modal (type choice) ~title ~(items : choice list) ~to_string
       dim_background = true;
     }
   in
-  Miaou.Core.Modal_manager.push_default
+  (* Use push with empty commit_on/cancel_on since we handle Enter/Esc manually
+     in handle_modal_key. This prevents double-close when used as nested modal. *)
+  Miaou.Core.Modal_manager.push
     (module Modal)
     ~init:(Navigation.make widget)
     ~ui
+    ~commit_on:[]
+    ~cancel_on:[]
     ~on_close:(fun pstate -> function
       | `Commit -> (
           match Select_widget.get_selection pstate.Navigation.s with

--- a/src/ui/modal_helpers.mli
+++ b/src/ui/modal_helpers.mli
@@ -194,6 +194,17 @@ val show_spinner_modal :
   unit ->
   unit
 
+(** Open a progress modal that exports logs for a given instance.
+    Shows step-by-step progress and auto-closes when complete.
+    @param instance Instance name
+    @param svc Service record
+    @param on_complete Called when export completes (receives [Some path] on success, [None] on failure) *)
+val open_export_logs_modal :
+  instance:string ->
+  svc:Octez_manager_lib.Service.t ->
+  on_complete:(string option -> unit) ->
+  unit
+
 (** Wrap a string to the given width, breaking at word boundaries.
     Handles embedded newlines.
 

--- a/src/ui/pages/instances.ml
+++ b/src/ui/pages/instances.ml
@@ -386,7 +386,10 @@ struct
     Context.tick_toasts () ;
     Job_manager.tick () ;
     let cols = size.LTerm_geom.cols in
-    let progress = Context.render_progress ~cols in
+    let progress =
+      if Miaou.Core.Modal_manager.has_active () then ""
+      else Context.render_progress ~cols
+    in
     (* Render active or recent job logs *)
     let job_logs =
       match Job_manager.get_latest_job () with

--- a/src/ui/pages/instances/instances_actions.ml
+++ b/src/ui/pages/instances/instances_actions.ml
@@ -469,41 +469,14 @@ let instance_actions_modal state =
               if already_running then
                 Context.toast_warn
                   (Printf.sprintf "Export already in progress for %s" instance)
-              else (
-                Context.toast_info
-                  (Printf.sprintf "Exporting logs for %s..." instance) ;
-                Context.progress_start
-                  ~label:"Exporting logs..."
-                  ~estimate_secs:10.0
-                  ~width:50 ;
-                let result_path = Atomic.make None in
-                Job_manager.submit
-                  ~description:(Printf.sprintf "Export logs %s" instance)
-                  (fun ~append_log:_ () ->
-                    match Log_export.export_logs ~instance ~svc with
-                    | Ok path ->
-                        Atomic.set result_path (Some path) ;
-                        Ok ()
-                    | Error e -> Error e)
-                  ~on_complete:(fun status ->
+              else
+                Modal_helpers.open_export_logs_modal
+                  ~instance
+                  ~svc
+                  ~on_complete:(fun _result ->
                     Mutex.protect export_lock (fun () ->
                         Hashtbl.remove export_in_progress instance) ;
-                    Context.progress_finish () ;
-                    (match status with
-                    | Job_manager.Succeeded -> (
-                        match Atomic.get result_path with
-                        | Some path ->
-                            Context.toast_success
-                              (Printf.sprintf "Logs exported to: %s" path)
-                        | None ->
-                            Context.toast_success
-                              (Printf.sprintf "%s: logs exported" instance))
-                    | Job_manager.Failed msg ->
-                        record_failure ~instance ~error:msg ;
-                        Context.toast_error
-                          (Printf.sprintf "%s: export failed: %s" instance msg)
-                    | Job_manager.Pending | Job_manager.Running -> ()) ;
-                    Context.mark_instances_dirty ()))
+                    Context.mark_instances_dirty ())
           | `Remove -> remove_modal state |> ignore)
         () ;
       state)

--- a/src/ui/pages/instances/instances_actions.ml
+++ b/src/ui/pages/instances/instances_actions.ml
@@ -14,6 +14,11 @@ open Instances_helpers
 
 let ( let* ) = Result.bind
 
+(** Track export operations to prevent concurrent exports for the same instance *)
+let export_in_progress : (string, bool) Hashtbl.t = Hashtbl.create 17
+
+let export_lock = Mutex.create ()
+
 let do_remove ~instance ~delete_data_dir () =
   Rpc_scheduler.stop_head_monitor instance ;
   let* (module I) = require_installer () in
@@ -453,38 +458,52 @@ let instance_actions_modal state =
               Context.set_pending_instance_detail instance ;
               Context.navigate Log_viewer_page.name
           | `Export_logs ->
-              Context.toast_info
-                (Printf.sprintf "Exporting logs for %s..." instance) ;
-              Context.progress_start
-                ~label:"Exporting logs..."
-                ~estimate_secs:10.0
-                ~width:50 ;
-              let result_path = Atomic.make None in
-              Job_manager.submit
-                ~description:(Printf.sprintf "Export logs %s" instance)
-                (fun ~append_log:_ () ->
-                  match Log_export.export_logs ~instance ~svc with
-                  | Ok path ->
-                      Atomic.set result_path (Some path) ;
-                      Ok ()
-                  | Error e -> Error e)
-                ~on_complete:(fun status ->
-                  Context.progress_finish () ;
-                  (match status with
-                  | Job_manager.Succeeded -> (
-                      match Atomic.get result_path with
-                      | Some path ->
-                          Context.toast_success
-                            (Printf.sprintf "Logs exported to: %s" path)
-                      | None ->
-                          Context.toast_success
-                            (Printf.sprintf "%s: logs exported" instance))
-                  | Job_manager.Failed msg ->
-                      record_failure ~instance ~error:msg ;
-                      Context.toast_error
-                        (Printf.sprintf "%s: export failed: %s" instance msg)
-                  | Job_manager.Pending | Job_manager.Running -> ()) ;
-                  Context.mark_instances_dirty ())
+              let already_running =
+                Mutex.protect export_lock (fun () ->
+                    match Hashtbl.find_opt export_in_progress instance with
+                    | Some true -> true
+                    | _ ->
+                        Hashtbl.replace export_in_progress instance true ;
+                        false)
+              in
+              if already_running then
+                Context.toast_warn
+                  (Printf.sprintf "Export already in progress for %s" instance)
+              else (
+                Context.toast_info
+                  (Printf.sprintf "Exporting logs for %s..." instance) ;
+                Context.progress_start
+                  ~label:"Exporting logs..."
+                  ~estimate_secs:10.0
+                  ~width:50 ;
+                let result_path = Atomic.make None in
+                Job_manager.submit
+                  ~description:(Printf.sprintf "Export logs %s" instance)
+                  (fun ~append_log:_ () ->
+                    match Log_export.export_logs ~instance ~svc with
+                    | Ok path ->
+                        Atomic.set result_path (Some path) ;
+                        Ok ()
+                    | Error e -> Error e)
+                  ~on_complete:(fun status ->
+                    Mutex.protect export_lock (fun () ->
+                        Hashtbl.remove export_in_progress instance) ;
+                    Context.progress_finish () ;
+                    (match status with
+                    | Job_manager.Succeeded -> (
+                        match Atomic.get result_path with
+                        | Some path ->
+                            Context.toast_success
+                              (Printf.sprintf "Logs exported to: %s" path)
+                        | None ->
+                            Context.toast_success
+                              (Printf.sprintf "%s: logs exported" instance))
+                    | Job_manager.Failed msg ->
+                        record_failure ~instance ~error:msg ;
+                        Context.toast_error
+                          (Printf.sprintf "%s: export failed: %s" instance msg)
+                    | Job_manager.Pending | Job_manager.Running -> ()) ;
+                    Context.mark_instances_dirty ()))
           | `Remove -> remove_modal state |> ignore)
         () ;
       state)

--- a/src/ui/pages/instances/instances_actions.ml
+++ b/src/ui/pages/instances/instances_actions.ml
@@ -452,13 +452,39 @@ let instance_actions_modal state =
           | `Logs ->
               Context.set_pending_instance_detail instance ;
               Context.navigate Log_viewer_page.name
-          | `Export_logs -> (
-              match Log_export.export_logs ~instance ~svc with
-              | Ok path ->
-                  Context.toast_info
-                    (Printf.sprintf "Logs exported to: %s" path)
-              | Error (`Msg err) ->
-                  Context.toast_error (Printf.sprintf "Export failed: %s" err))
+          | `Export_logs ->
+              Context.toast_info
+                (Printf.sprintf "Exporting logs for %s..." instance) ;
+              Context.progress_start
+                ~label:"Exporting logs..."
+                ~estimate_secs:10.0
+                ~width:50 ;
+              let result_path = Atomic.make None in
+              Job_manager.submit
+                ~description:(Printf.sprintf "Export logs %s" instance)
+                (fun ~append_log:_ () ->
+                  match Log_export.export_logs ~instance ~svc with
+                  | Ok path ->
+                      Atomic.set result_path (Some path) ;
+                      Ok ()
+                  | Error e -> Error e)
+                ~on_complete:(fun status ->
+                  Context.progress_finish () ;
+                  (match status with
+                  | Job_manager.Succeeded -> (
+                      match Atomic.get result_path with
+                      | Some path ->
+                          Context.toast_success
+                            (Printf.sprintf "Logs exported to: %s" path)
+                      | None ->
+                          Context.toast_success
+                            (Printf.sprintf "%s: logs exported" instance))
+                  | Job_manager.Failed msg ->
+                      record_failure ~instance ~error:msg ;
+                      Context.toast_error
+                        (Printf.sprintf "%s: export failed: %s" instance msg)
+                  | Job_manager.Pending | Job_manager.Running -> ()) ;
+                  Context.mark_instances_dirty ())
           | `Remove -> remove_modal state |> ignore)
         () ;
       state)


### PR DESCRIPTION
## Summary

- Log export now runs in a background job instead of blocking the UI
- A progress bar is displayed during the export operation
- A green success toast shows the archive path on completion (was blue info toast)
- Failures record the error in the instance status line for visibility

## Details

Previously, selecting "Export Logs" from the instance actions menu ran `Log_export.export_logs` synchronously on the main thread, freezing the UI until completion. The only feedback was a blue `toast_info` that could easily be missed.

Now the export is submitted to `Job_manager` (same pattern as start/stop/restart), with:
- Immediate info toast: *"Exporting logs for {instance}..."*
- Time-based progress bar (10s estimate, auto-advancing)
- Green `toast_success` on completion: *"Logs exported to: /tmp/..."*
- Red `toast_error` + `record_failure` on error

The result path is passed from the job closure to `on_complete` via an `Atomic` ref for OCaml 5 memory model safety.