### PR TITLE
refactor(ui): remove instances page create dropdown menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Removed
 
 - Global key `K` for navigating to Wallets tab has been removed. Users can now access the Wallets tab using the number key corresponding to its tab position.
+- Removed the "New Instance" dropdown that appeared when pressing '1' while already on the Instances tab. Use the inline "Add new" ghost entries instead.
 
 ### Changed
 

--- a/src/ui/pages/instances.ml
+++ b/src/ui/pages/instances.ml
@@ -62,8 +62,6 @@ let init_state () =
       (* max practical columns based on terminal width; 10 is a safe upper bound *)
       view_mode;
       groups;
-      create_menu_open = false;
-      create_menu_cursor = 0;
     }
 
 let force_refresh state =
@@ -264,11 +262,6 @@ let move_selection s delta =
 
 module For_tests = struct
   let move_selection = move_selection
-
-  let open_create_menu ps =
-    Navigation.update
-      (fun s -> {s with create_menu_open = true; create_menu_cursor = 0})
-      ps
 end
 
 module Page_Impl :
@@ -432,11 +425,6 @@ struct
         let table = table_lines ~cols ~visible_height:avail_rows s in
         let body = String.concat "\n" table in
         let body =
-          if s.create_menu_open then
-            render_create_dropdown s.create_menu_cursor ^ "\n" ^ body
-          else body
-        in
-        let body =
           if String.trim progress = "" then body else progress ^ "\n" ^ body
         in
         let body = if job_logs = "" then body else body ^ job_logs in
@@ -445,16 +433,8 @@ struct
       else
         (* Single column: use global scrolling *)
         let table = table_lines ~cols ~visible_height:avail_rows s in
-        let dropdown_lines =
-          if s.create_menu_open then
-            String.split_on_char
-              '\n'
-              (render_create_dropdown s.create_menu_cursor)
-          else []
-        in
         let all_lines =
-          dropdown_lines
-          @ List.concat_map (fun s -> String.split_on_char '\n' s) table
+          List.concat_map (fun s -> String.split_on_char '\n' s) table
         in
         let total_lines = List.length all_lines in
         (* Calculate line index where current selection starts.
@@ -514,16 +494,10 @@ struct
           in
           (header_lines + svc_line_start, line_count)
         in
-        (* When the create dropdown is open, force scroll to top so the
-           dropdown title ("+ New Instance") is always visible. *)
-        let selection_line_start =
-          selection_line_start + List.length dropdown_lines
-        in
         (* Adjust scroll offset to keep selection visible *)
         let scroll = !scroll_offset_ref in
         let scroll =
-          if s.create_menu_open then 0
-          else if selection_line_start < scroll then selection_line_start
+          if selection_line_start < scroll then selection_line_start
           else if
             selection_line_start + selection_line_count > scroll + avail_rows
           then selection_line_start + selection_line_count - avail_rows
@@ -690,19 +664,6 @@ struct
             selected = target_idx + services_start_idx;
           }
 
-  let create_menu_items =
-    [|"Node"; "Baker"; "DAL Node"; "Accuser"; "Signatory"; "Indexer"|]
-
-  let navigate_create_item cursor =
-    match cursor with
-    | 0 -> Context.navigate Install_node_form_v3.name
-    | 1 -> Context.navigate Install_baker_form_v3.name
-    | 2 -> Context.navigate Install_dal_node_form_v3.name
-    | 3 -> Context.navigate Install_accuser_form_v3.name
-    | 4 -> Context.navigate Install_signatory_form.name
-    | 5 -> Context.navigate Install_index_form_v3.name
-    | _ -> ()
-
   let handle_key ps key ~size =
     let s = ps.Navigation.s in
     (* Update num_columns based on current terminal size *)
@@ -715,32 +676,6 @@ struct
     if Miaou.Core.Modal_manager.has_active () then (
       Miaou.Core.Modal_manager.handle_key key ;
       check_navigation ps)
-    else if s.create_menu_open then
-      (* Create dropdown is open: handle its navigation *)
-      let max_cursor = Array.length create_menu_items - 1 in
-      let ps =
-        match Keys.of_string key with
-        | Some Keys.Up | Some (Keys.Char "k") ->
-            Navigation.update
-              (fun s ->
-                {s with create_menu_cursor = max 0 (s.create_menu_cursor - 1)})
-              ps
-        | Some Keys.Down | Some (Keys.Char "j") ->
-            Navigation.update
-              (fun s ->
-                {
-                  s with
-                  create_menu_cursor = min max_cursor (s.create_menu_cursor + 1);
-                })
-              ps
-        | Some Keys.Enter ->
-            navigate_create_item s.create_menu_cursor ;
-            Navigation.update (fun s -> {s with create_menu_open = false}) ps
-        | Some Keys.Escape ->
-            Navigation.update (fun s -> {s with create_menu_open = false}) ps
-        | _ -> ps
-      in
-      check_navigation ps
     else if is_quit_key key then back ps
     else
       let ps =

--- a/src/ui/pages/instances.mli
+++ b/src/ui/pages/instances.mli
@@ -27,8 +27,4 @@ module For_tests : sig
       Handles menu items, separator skipping, single-column linear navigation,
       and multi-column column-constrained navigation. *)
   val move_selection : Instances_state.state -> int -> Instances_state.state
-
-  (** Open the inline create-instance dropdown.
-      Returns an updated pstate with [create_menu_open = true]. *)
-  val open_create_menu : pstate -> pstate
 end

--- a/src/ui/pages/instances/instances_actions.ml
+++ b/src/ui/pages/instances/instances_actions.ml
@@ -481,31 +481,6 @@ let instance_actions_modal state =
         () ;
       state)
 
-let open_create_menu () =
-  let open Modal_helpers in
-  open_choice_modal
-    ~title:"Create"
-    ~items:[`Node; `DalNode; `Baker; `Accuser; `Signatory; `Index]
-    ~to_string:(function
-      | `Node -> "Node"
-      | `DalNode -> "DAL Node"
-      | `Baker -> "Baker"
-      | `Accuser -> "Accuser"
-      | `Signatory -> "Signatory"
-      | `Index -> "Indexer")
-    ~on_select:(function
-      | `Node -> Context.navigate Install_node_form_v3.name
-      | `Baker -> Context.navigate Install_baker_form_v3.name
-      | `Accuser -> Context.navigate Install_accuser_form_v3.name
-      | `DalNode -> Context.navigate Install_dal_node_form_v3.name
-      | `Signatory -> Context.navigate Install_signatory_form.name
-      | `Index -> Context.navigate Install_index_form_v3.name)
-    ()
-
-let create_menu_modal state =
-  open_create_menu () ;
-  state
-
 let go_to_diagnostics state =
   Context.navigate Diagnostics.name ;
   state

--- a/src/ui/pages/instances/instances_actions.mli
+++ b/src/ui/pages/instances/instances_actions.mli
@@ -41,12 +41,6 @@ val _view_logs_old : state -> state
 (** Show instance actions modal *)
 val instance_actions_modal : state -> state
 
-(** Open the create/install modal (side-effect only, no state change) *)
-val open_create_menu : unit -> unit
-
-(** Show create/install menu modal *)
-val create_menu_modal : state -> state
-
 (** Navigate to diagnostics page *)
 val go_to_diagnostics : state -> state
 

--- a/src/ui/pages/instances/instances_render.ml
+++ b/src/ui/pages/instances/instances_render.ml
@@ -921,22 +921,6 @@ let render_external_services_section state =
       in
       header :: service_lines
 
-(** Render the inline create-instance dropdown at the top of the content area.
-    [cursor] is 0-4 for Node/Baker/DAL Node/Accuser/Signatory. *)
-let render_create_dropdown cursor =
-  let items = ["Node"; "Baker"; "DAL Node"; "Accuser"; "Signatory"] in
-  let item_lines =
-    List.mapi
-      (fun i label ->
-        let marker = if Int.equal i cursor then "▶ " else "  " in
-        let line = Printf.sprintf "║ %s%-18s║" marker label in
-        if Int.equal i cursor then Widgets.themed_emphasis line else line)
-      items
-  in
-  let top = "╔══ + New Instance ═════╗" in
-  let bot = "╚═══════════════════════╝" in
-  String.concat "\n" ([top] @ item_lines @ [bot])
-
 (** Render the view-mode radio row (visible but not navigable).
     The radio row is always shown without focus since it's toggled via 'g' key.
     Widgets are created fresh from state — not stored. *)

--- a/src/ui/pages/instances/instances_render.mli
+++ b/src/ui/pages/instances/instances_render.mli
@@ -83,7 +83,3 @@ val render_external_services_section : state -> string list
 
 (** Render summary line showing total instances *)
 val summary_line : state -> string
-
-(** Render the inline create-instance dropdown.
-    [cursor] is 0–4 for Node/Baker/DAL Node/Accuser/Signatory. *)
-val render_create_dropdown : int -> string

--- a/src/ui/pages/instances/instances_state.ml
+++ b/src/ui/pages/instances/instances_state.ml
@@ -52,9 +52,6 @@ type state = {
   column_scroll : int array; (* scroll offset per column *)
   view_mode : view_mode;
   groups : Octez_manager_lib.Group.t list;
-  (* Inline create-instance dropdown *)
-  create_menu_open : bool;
-  create_menu_cursor : int; (* 0-4: Node, Baker, DAL Node, Accuser, Signatory *)
 }
 
 type msg = unit

--- a/src/ui/pages/instances/instances_state.mli
+++ b/src/ui/pages/instances/instances_state.mli
@@ -55,8 +55,6 @@ type state = {
   column_scroll : int array;
   view_mode : view_mode;
   groups : Octez_manager_lib.Group.t list;
-  create_menu_open : bool;
-  create_menu_cursor : int;
 }
 
 type msg = unit

--- a/src/ui/pages/main_shell.ml
+++ b/src/ui/pages/main_shell.ml
@@ -322,26 +322,14 @@ let switch_tab ps id =
       };
   }
 
-(** Open the create-instance dropdown on the instances tab. *)
-let open_instances_create_menu ps =
-  let s = ps.Navigation.s in
-  let instances_ps = Instances.For_tests.open_create_menu s.instances_ps in
-  {ps with Navigation.s = {s with instances_ps}}
-
 let handle_key ps key ~size =
   if Miaou.Core.Modal_manager.has_active () then dispatch_modal_key ps key ~size
   else
     match Global_shortcuts.handle key with
     | Global_shortcuts.Handled -> ps
     | Global_shortcuts.NotGlobal -> (
-        let s = ps.Navigation.s in
-        let current = current_tab_id s in
         match key with
-        | "1" ->
-            if String.equal current tab_instances then
-              (* Pressing current tab number triggers create menu *)
-              open_instances_create_menu ps
-            else switch_tab ps tab_instances
+        | "1" -> switch_tab ps tab_instances
         | "2" -> switch_tab ps tab_wallets
         | "3" -> switch_tab ps tab_binaries
         | "4" -> switch_tab ps tab_rpcs

--- a/test/test_golden_path_tui_v2.ml
+++ b/test/test_golden_path_tui_v2.ml
@@ -82,6 +82,28 @@ let submit_form ~downs = keys_down downs @ [Key "Enter"]
 let wait_for_sync_install =
   [WaitFor [ScreenContains "octez-manager"; MaxIterations 500]]
 
+(** Wait until the instances page summary shows [n] managed services.
+    The summary line reads "Managed: N | External: M" when externals exist,
+    or "Total instances: N" when they don't.  Both are always visible at the
+    top of the screen regardless of scroll position. *)
+let wait_for_managed_count n =
+  let n_str = string_of_int n in
+  [
+    WaitFor
+      [
+        ScreenMatches
+          (fun s ->
+            let has str =
+              try
+                ignore (Str.search_forward (Str.regexp_string str) s 0) ;
+                true
+              with Not_found -> false
+            in
+            has ("Managed: " ^ n_str) || has ("Total instances: " ^ n_str));
+        MaxIterations 200;
+      ];
+  ]
+
 (* ============================================================ *)
 (* Test Script *)
 (* ============================================================ *)
@@ -116,10 +138,8 @@ let golden_path_script =
       AssertService "node-shadownet";
     ]
   (* ── Step 2: Install DAL Node ─────────────────────────────── *)
-  @ [
-      Comment "=== Step 2: Install DAL Node ===";
-      WaitFor [ScreenContains "node-shadownet"; MaxIterations 200];
-    ]
+  @ [Comment "=== Step 2: Install DAL Node ==="]
+  @ wait_for_managed_count 1
   (* After node install: node service(0), node ghost(1), baker ghost(2), accuser ghost(3), DAL ghost(4) *)
   @ navigate_to_ghost ~downs:4 ~target_page:"install_dal_node_form_v3"
   @ [
@@ -133,10 +153,8 @@ let golden_path_script =
   @ wait_for_sync_install
   @ [Screenshot "05_dal_installed"; AssertService "dal-shadownet"]
   (* ── Step 3: Install Baker ────────────────────────────────── *)
-  @ [
-      Comment "=== Step 3: Install Baker ===";
-      WaitFor [ScreenContains "dal-shadownet"; MaxIterations 200];
-    ]
+  @ [Comment "=== Step 3: Install Baker ==="]
+  @ wait_for_managed_count 2
   (* After node+DAL: node service(0), node ghost(1), baker ghost(2), ... *)
   @ navigate_to_ghost ~downs:2 ~target_page:"install_baker_form_v3"
   @ [
@@ -152,10 +170,8 @@ let golden_path_script =
   @ wait_for_sync_install
   @ [Screenshot "07_baker_installed"; AssertService "baker-shadownet"]
   (* ── Step 4: Install Accuser ──────────────────────────────── *)
-  @ [
-      Comment "=== Step 4: Install Accuser ===";
-      WaitFor [ScreenContains "baker-shadownet"; MaxIterations 200];
-    ]
+  @ [Comment "=== Step 4: Install Accuser ==="]
+  @ wait_for_managed_count 3
   (* After node+DAL+baker: node(0), node ghost(1), baker(2), baker ghost(3), accuser ghost(4), ... *)
   @ navigate_to_ghost ~downs:4 ~target_page:"install_accuser_form_v3"
   @ [
@@ -338,10 +354,8 @@ let golden_path_script =
           "Group 'shadownet-prod' auto-removed (was only member)" );
     ]
   (* ── Step 9: Install Index ────────────────────────────────── *)
-  @ [
-      Comment "=== Step 9: Install Index ===";
-      WaitFor [ScreenContains "accuser-shadownet"; MaxIterations 200];
-    ]
+  @ [Comment "=== Step 9: Install Index ==="]
+  @ wait_for_managed_count 4
   (* After node+DAL+baker+accuser: positions are node(0), node ghost(1), baker(2), baker ghost(3),
      accuser(4), accuser ghost(5), DAL(6), DAL ghost(7), signatory ghost(8), index ghost(9) *)
   @ navigate_to_ghost ~downs:9 ~target_page:"install_index_form_v3"

--- a/test/test_golden_path_tui_v2.ml
+++ b/test/test_golden_path_tui_v2.ml
@@ -42,12 +42,10 @@ let keys_down n = List.init n (fun _ -> Key "Down")
     [handle_key] and properly calls [move_selection]. *)
 let keys_j n = List.init n (fun _ -> Key "j")
 
-(** Open the create dropdown ('1' when on instances tab) and select the nth
-    item (0-indexed).
-    Menu order: Node=0, Baker=1, DAL Node=2, Accuser=3, Signatory=4. *)
-let open_create_menu ~menu_index ~target_page =
-  [Key "1"; WaitFor [ScreenContains "New Instance"; MaxIterations 50]]
-  @ keys_j menu_index
+(** Navigate to a ghost "Add new" entry and activate it by navigating down [downs] times from cursor position 0.
+    After install forms navigate back to instances, cursor typically resets to 0. *)
+let navigate_to_ghost ~downs ~target_page =
+  (if downs > 0 then keys_j downs else [])
   @ [Key "Enter"; WaitFor [PageSwitched target_page; MaxIterations 50]]
 
 (** Select the first node in a node-selection modal.
@@ -91,7 +89,8 @@ let wait_for_sync_install =
 let golden_path_script =
   (* ── Step 1: Install Node ─────────────────────────────────── *)
   [Comment "=== Step 1: Install Node ==="; Screenshot "00_initial_state"]
-  @ open_create_menu ~menu_index:0 ~target_page:"install_node_form_v3"
+  (* No services yet, so node ghost is at position 0 *)
+  @ navigate_to_ghost ~downs:0 ~target_page:"install_node_form_v3"
   @ [
       WaitFor [ScreenContains "App Bin Dir"; MaxIterations 10];
       CheckRegression "01_node_form";
@@ -118,7 +117,8 @@ let golden_path_script =
     ]
   (* ── Step 2: Install DAL Node ─────────────────────────────── *)
   @ [Comment "=== Step 2: Install DAL Node ==="]
-  @ open_create_menu ~menu_index:2 ~target_page:"install_dal_node_form_v3"
+  (* After node install: node service(0), node ghost(1), baker ghost(2), accuser ghost(3), DAL ghost(4) *)
+  @ navigate_to_ghost ~downs:4 ~target_page:"install_dal_node_form_v3"
   @ [
       WaitFor [ScreenContains "DAL RPC"; MaxIterations 10];
       Comment "Cursor is on Node field (first). Select our node.";
@@ -131,7 +131,8 @@ let golden_path_script =
   @ [Screenshot "05_dal_installed"; AssertService "dal-shadownet"]
   (* ── Step 3: Install Baker ────────────────────────────────── *)
   @ [Comment "=== Step 3: Install Baker ==="]
-  @ open_create_menu ~menu_index:1 ~target_page:"install_baker_form_v3"
+  (* After node+DAL: node service(0), node ghost(1), baker ghost(2), ... *)
+  @ navigate_to_ghost ~downs:2 ~target_page:"install_baker_form_v3"
   @ [
       WaitFor [ScreenContains "Liquidity Baking"; MaxIterations 10];
       Comment "Cursor on Parent Node (first). Select our node (second item).";
@@ -146,7 +147,8 @@ let golden_path_script =
   @ [Screenshot "07_baker_installed"; AssertService "baker-shadownet"]
   (* ── Step 4: Install Accuser ──────────────────────────────── *)
   @ [Comment "=== Step 4: Install Accuser ==="]
-  @ open_create_menu ~menu_index:3 ~target_page:"install_accuser_form_v3"
+  (* After node+DAL+baker: node(0), node ghost(1), baker(2), baker ghost(3), accuser ghost(4), ... *)
+  @ navigate_to_ghost ~downs:4 ~target_page:"install_accuser_form_v3"
   @ [
       WaitFor [ScreenContains "Base Dir"; MaxIterations 10];
       Comment "Cursor on Node field (first). Select our node.";
@@ -328,7 +330,9 @@ let golden_path_script =
     ]
   (* ── Step 9: Install Index ────────────────────────────────── *)
   @ [Comment "=== Step 9: Install Index ==="]
-  @ open_create_menu ~menu_index:5 ~target_page:"install_index_form_v3"
+  (* After node+DAL+baker+accuser: positions are node(0), node ghost(1), baker(2), baker ghost(3),
+     accuser(4), accuser ghost(5), DAL(6), DAL ghost(7), signatory ghost(8), index ghost(9) *)
+  @ navigate_to_ghost ~downs:9 ~target_page:"install_index_form_v3"
   @ [
       WaitFor [ScreenContains "Install Index"; MaxIterations 10];
       Comment "Cursor on Node field (first). Node selection is required.";

--- a/test/test_golden_path_tui_v2.ml
+++ b/test/test_golden_path_tui_v2.ml
@@ -116,7 +116,10 @@ let golden_path_script =
       AssertService "node-shadownet";
     ]
   (* ── Step 2: Install DAL Node ─────────────────────────────── *)
-  @ [Comment "=== Step 2: Install DAL Node ==="]
+  @ [
+      Comment "=== Step 2: Install DAL Node ===";
+      WaitFor [ScreenContains "node-shadownet"; MaxIterations 200];
+    ]
   (* After node install: node service(0), node ghost(1), baker ghost(2), accuser ghost(3), DAL ghost(4) *)
   @ navigate_to_ghost ~downs:4 ~target_page:"install_dal_node_form_v3"
   @ [
@@ -130,7 +133,10 @@ let golden_path_script =
   @ wait_for_sync_install
   @ [Screenshot "05_dal_installed"; AssertService "dal-shadownet"]
   (* ── Step 3: Install Baker ────────────────────────────────── *)
-  @ [Comment "=== Step 3: Install Baker ==="]
+  @ [
+      Comment "=== Step 3: Install Baker ===";
+      WaitFor [ScreenContains "dal-shadownet"; MaxIterations 200];
+    ]
   (* After node+DAL: node service(0), node ghost(1), baker ghost(2), ... *)
   @ navigate_to_ghost ~downs:2 ~target_page:"install_baker_form_v3"
   @ [
@@ -146,7 +152,10 @@ let golden_path_script =
   @ wait_for_sync_install
   @ [Screenshot "07_baker_installed"; AssertService "baker-shadownet"]
   (* ── Step 4: Install Accuser ──────────────────────────────── *)
-  @ [Comment "=== Step 4: Install Accuser ==="]
+  @ [
+      Comment "=== Step 4: Install Accuser ===";
+      WaitFor [ScreenContains "baker-shadownet"; MaxIterations 200];
+    ]
   (* After node+DAL+baker: node(0), node ghost(1), baker(2), baker ghost(3), accuser ghost(4), ... *)
   @ navigate_to_ghost ~downs:4 ~target_page:"install_accuser_form_v3"
   @ [
@@ -329,7 +338,10 @@ let golden_path_script =
           "Group 'shadownet-prod' auto-removed (was only member)" );
     ]
   (* ── Step 9: Install Index ────────────────────────────────── *)
-  @ [Comment "=== Step 9: Install Index ==="]
+  @ [
+      Comment "=== Step 9: Install Index ===";
+      WaitFor [ScreenContains "accuser-shadownet"; MaxIterations 200];
+    ]
   (* After node+DAL+baker+accuser: positions are node(0), node ghost(1), baker(2), baker ghost(3),
      accuser(4), accuser ghost(5), DAL(6), DAL ghost(7), signatory ghost(8), index ghost(9) *)
   @ navigate_to_ghost ~downs:9 ~target_page:"install_index_form_v3"

--- a/test/test_instances_navigation_pure.ml
+++ b/test/test_instances_navigation_pure.ml
@@ -40,8 +40,6 @@ let make_state ?(selected = 0) ?(num_columns = 1) ?(active_column = 0)
     column_scroll;
     view_mode = Instances_state.By_role;
     groups = [];
-    create_menu_open = false;
-    create_menu_cursor = 0;
   }
 
 let move = Instances.For_tests.move_selection

--- a/test/test_instances_page.ml
+++ b/test/test_instances_page.ml
@@ -241,38 +241,6 @@ let test_fold_unfold () =
       check bool "after space valid" true (String.length after_space > 0))
 
 (* ============================================================ *)
-(* Test: Create Menu Opens *)
-(* ============================================================ *)
-
-let test_create_menu_opens () =
-  TH.with_test_env (fun () ->
-      HD.Stateful.init (module Instances.Page) ;
-
-      (* Press 'c' to open create menu *)
-      ignore (HD.Stateful.send_key "c") ;
-      ignore (HD.Stateful.idle_wait ~iterations:5 ~sleep:0.001 ()) ;
-
-      (* Verify modal is active *)
-      check
-        bool
-        "modal opened after 'c' key"
-        true
-        (Miaou.Core.Modal_manager.has_active ()) ;
-
-      (* Check screen shows service options *)
-      let screen = TH.get_screen_text () in
-      check
-        bool
-        "menu shows Node option"
-        true
-        (TH.contains_substring screen "Node") ;
-      check
-        bool
-        "menu shows Baker option"
-        true
-        (TH.contains_substring screen "Baker"))
-
-(* ============================================================ *)
 (* Test: Select Node from Create Menu *)
 (* ============================================================ *)
 
@@ -432,7 +400,6 @@ let page_tests =
     ("periodic update works", `Quick, test_periodic_update);
     ("column navigation", `Quick, test_column_navigation);
     ("fold/unfold toggles", `Quick, test_fold_unfold);
-    ("create menu opens with 'c' key", `Quick, test_create_menu_opens);
     ("select Node from create menu", `Quick, test_select_node_from_menu);
     ("help modal opens with '?' key", `Quick, test_help_modal_opens);
     ( "cascade-start includes stopped index dependency",

--- a/test/test_instances_render_pure.ml
+++ b/test/test_instances_render_pure.ml
@@ -135,8 +135,6 @@ let empty_state () =
       active_column = 0;
       view_mode = State.By_role;
       groups = [];
-      create_menu_open = false;
-      create_menu_cursor = 0;
     }
 
 let test_summary_empty () =

--- a/test/tui_flow_tests.ml
+++ b/test/tui_flow_tests.ml
@@ -128,26 +128,6 @@ let test_instances_navigation_arrows () =
       let result = Headless.Stateful.send_key "Up" in
       check bool "Up key handled" true (result = `Continue))
 
-(** Test: 'c' key opens create menu modal *)
-let test_instances_create_menu () =
-  with_test_env (fun () ->
-      Headless.Stateful.init (module Instances.Page) ;
-
-      (* Modal should not be active initially *)
-      check bool "no modal initially" false (Modal_manager.has_active ()) ;
-
-      (* Press 'c' to open create menu *)
-      let result = Headless.Stateful.send_key "c" in
-      check bool "c key handled" true (result = `Continue) ;
-
-      (* Modal should now be active *)
-      check bool "modal opened" true (Modal_manager.has_active ()) ;
-
-      (* Screen should show create options *)
-      let screen = Headless.get_screen_content () in
-      let text = strip_ansi screen in
-      check bool "shows Node option" true (contains_substring text "Node"))
-
 (** Test: Esc closes modal *)
 let test_instances_escape_closes_modal () =
   with_test_env (fun () ->
@@ -695,71 +675,6 @@ let test_instances_create_baker_flow () =
         true
         (result = `Continue || result = `SwitchTo "install_baker_form_v3"))
 
-(** Test: Create menu shows all service types *)
-let test_instances_create_menu_shows_all_types () =
-  TH.with_test_env (fun () ->
-      Headless.Stateful.init (module Instances.Page) ;
-
-      (* Open create menu *)
-      ignore (TH.send_key_and_wait "c") ;
-      check bool "create menu opened" true (Modal_manager.has_active ()) ;
-
-      (* Verify all service types are shown *)
-      TH.assert_screen_contains "Node" ;
-      TH.assert_screen_contains "Baker" ;
-      TH.assert_screen_contains "Accuser" ;
-      TH.assert_screen_contains "DAL")
-
-(** Test: Escape from create menu returns to instances *)
-let test_instances_create_menu_escape () =
-  TH.with_test_env (fun () ->
-      Headless.Stateful.init (module Instances.Page) ;
-
-      (* Open create menu *)
-      ignore (TH.send_key_and_wait "c") ;
-      check bool "menu opened" true (Modal_manager.has_active ()) ;
-
-      (* Press Esc to close *)
-      ignore (TH.send_key_and_wait "Esc") ;
-
-      (* Modal should be closed *)
-      check bool "menu closed" false (Modal_manager.has_active ()) ;
-
-      (* Page should still be instances *)
-      TH.assert_screen_contains "octez-manager")
-
-(** Test: Navigate through create menu with j/k *)
-let test_instances_create_menu_vim_nav () =
-  TH.with_test_env (fun () ->
-      Headless.Stateful.init (module Instances.Page) ;
-
-      (* Open create menu *)
-      ignore (TH.send_key_and_wait "c") ;
-      check bool "menu opened" true (Modal_manager.has_active ()) ;
-
-      (* Navigate with j (down) *)
-      ignore (TH.send_key_and_wait "j") ;
-      check bool "j handled" true (Modal_manager.has_active ()) ;
-
-      (* Navigate with k (up) *)
-      ignore (TH.send_key_and_wait "k") ;
-      check bool "k handled" true (Modal_manager.has_active ()))
-
-(** Test: Multiple create menu open/close cycles *)
-let test_instances_create_menu_cycle () =
-  TH.with_test_env (fun () ->
-      Headless.Stateful.init (module Instances.Page) ;
-
-      for _ = 1 to 3 do
-        (* Open *)
-        ignore (TH.send_key_and_wait "c") ;
-        check bool "opened" true (Modal_manager.has_active ()) ;
-
-        (* Close *)
-        ignore (TH.send_key_and_wait "Esc") ;
-        check bool "closed" false (Modal_manager.has_active ())
-      done)
-
 (** Test: Screen content changes after navigation *)
 let test_instances_screen_updates_on_nav () =
   TH.with_test_env (fun () ->
@@ -992,7 +907,6 @@ let () =
         ] );
       ( "Instances.modal",
         [
-          test_case "c opens create menu" `Quick test_instances_create_menu;
           test_case
             "Escape closes modal"
             `Quick
@@ -1076,19 +990,6 @@ let () =
         [
           test_case "create node flow" `Quick test_instances_create_node_flow;
           test_case "create baker flow" `Quick test_instances_create_baker_flow;
-          test_case
-            "create menu shows all"
-            `Quick
-            test_instances_create_menu_shows_all_types;
-          test_case
-            "create menu escape"
-            `Quick
-            test_instances_create_menu_escape;
-          test_case
-            "create menu vim nav"
-            `Quick
-            test_instances_create_menu_vim_nav;
-          test_case "create menu cycle" `Quick test_instances_create_menu_cycle;
           test_case
             "screen updates on nav"
             `Quick

--- a/test/tui_test_helpers.ml
+++ b/test/tui_test_helpers.ml
@@ -247,19 +247,6 @@ let assert_screen_snapshot expected =
 (* Flow Drivers *)
 (* ============================================================ *)
 
-(** Drive through the create menu from instances page.
-    Opens create menu with 'c', selects an item, returns result. *)
-let drive_create_menu_selection ~item_index () =
-  (* Open create menu *)
-  ignore (send_key_and_wait "c") ;
-  if not (wait_until_modal_active ()) then
-    Alcotest.fail "Create menu modal did not open" ;
-  (* Navigate to item *)
-  navigate_down item_index ;
-  (* Select item *)
-  let result = send_key_and_wait "Enter" in
-  result
-
 (** Drive through opening an instance action menu.
     Navigates to the instance (by index) and presses Enter. *)
 let drive_instance_action ~instance_index () =


### PR DESCRIPTION
## Summary

- Removed the "New Instance" dropdown menu that appeared when pressing `1` while already on the Instances tab
- Users create instances via the inline "Add new" ghost entries instead
- Cleaned up dead code (`open_create_menu`, `create_menu_modal`) from `instances_actions`

## Changes

- **`main_shell.ml`**: Simplified `1` key handler to always switch tab (no more conditional create menu)
- **`instances_state.ml/mli`**: Removed `create_menu_open` and `create_menu_cursor` state fields
- **`instances.ml/mli`**: Removed menu rendering, key handling, navigation, and `For_tests.open_create_menu`
- **`instances_render.ml/mli`**: Removed `render_create_dropdown` function
- **`instances_actions.ml/mli`**: Removed orphaned `open_create_menu` and `create_menu_modal`
- **Tests**: Removed 6 create-menu tests, updated golden path test to use ghost entry navigation

16 files changed, 19 insertions(+), 300 deletions(-)