### PR TITLE
fix(accuser): sync base-dir when instance name changes in install form

### DIFF
--- a/src/ui/pages/install_accuser_form_v3.ml
+++ b/src/ui/pages/install_accuser_form_v3.ml
@@ -308,18 +308,44 @@ let spec =
             ~original_instance:model.original_instance
             ()
         (* 9. Instance name *)
-        @ core_service_fields
-            ~get_core:(fun m -> m.core)
-            ~set_core:(fun core m -> {m with core})
-            ~binary:"octez-baker"
-            ~subcommand:["run"; "accuser"]
-            ~binary_validator:Form_builder_common.has_octez_baker_binary
-            ~skip_app_bin_dir:true
-            ~skip_extra_args:true
-            ~skip_service_fields:true
-            ~edit_mode:model.edit_mode
-            ~original_instance:model.original_instance
-            ()
+        @ [
+            validated_text
+              ~label:"Instance Name"
+              ~get:(fun m -> m.core.instance_name)
+              ~set:(fun instance_name m ->
+                let old = m.core.instance_name in
+                let new_core = {m.core with instance_name} in
+                (* In edit mode, never change base_dir - data is already there *)
+                if m.edit_mode then {m with core = new_core}
+                else
+                  let default_dir =
+                    Paths.default_role_dir "accuser" instance_name
+                  in
+                  let keep_base_dir =
+                    String.trim m.client.base_dir <> ""
+                    && not
+                         (String.equal
+                            m.client.base_dir
+                            (Paths.default_role_dir "accuser" old))
+                  in
+                  let new_base_dir =
+                    if keep_base_dir then m.client.base_dir else default_dir
+                  in
+                  let new_client = {m.client with base_dir = new_base_dir} in
+                  {m with core = new_core; client = new_client})
+              ~validate:(fun m ->
+                let states =
+                  Form_builder_common.cached_service_states_nonblocking ()
+                in
+                let name = m.core.instance_name in
+                if not (Form_builder_common.is_nonempty name) then
+                  Error "Instance name is required"
+                else if
+                  Form_builder_common.instance_in_use ~states name
+                  && not (m.edit_mode && m.original_instance = Some name)
+                then Error "Instance name already exists"
+                else Ok ());
+          ]
         (* 10. Group *)
         @ [
             group_field
@@ -515,6 +541,21 @@ end)
 
 module For_tests = struct
   let initial_base_dir = (make_initial_model ()).client.base_dir
+
+  (** Simulate setting instance name and return the resulting base_dir.
+      This tests the instance name → base-dir sync logic. *)
+  let base_dir_after_set_instance_name ~instance_name =
+    let model = make_initial_model () in
+    let old = model.core.instance_name in
+    let default_dir = Paths.default_role_dir "accuser" instance_name in
+    let keep_base_dir =
+      String.trim model.client.base_dir <> ""
+      && not
+           (String.equal
+              model.client.base_dir
+              (Paths.default_role_dir "accuser" old))
+    in
+    if keep_base_dir then model.client.base_dir else default_dir
 end
 
 let page : Miaou.Core.Registry.page = (module Page)

--- a/src/ui/pages/install_accuser_form_v3.mli
+++ b/src/ui/pages/install_accuser_form_v3.mli
@@ -21,4 +21,7 @@ module Page : Miaou.Core.Tui_page.PAGE_SIG
 
 module For_tests : sig
   val initial_base_dir : string
+
+  (** Test helper: simulate setting instance name and return resulting base_dir *)
+  val base_dir_after_set_instance_name : instance_name:string -> string
 end

--- a/test/ui_regressions/accuser_instance_name_filled.screen
+++ b/test/ui_regressions/accuser_instance_name_filled.screen
@@ -7,12 +7,12 @@ SIZE:240x24
 ├───────────────────────┼──────────────────────────────────────────────┼───────┤
 │ Node                  │ None ⚠ Node selection is required            │ ✗     │
 │ App Bin Dir           │ /usr/bin ⚠ Binary 'octez-baker' not …        │ ✗     │
-│ Base Dir              │ …sion/.local/share/octez/accuser-accuser     │ ✓     │
+│ Base Dir              │ …on/.local/share/octez/accuser-my-accuser    │ ✓     │
 │ Extra Args            │ (none)                                       │ ✓     │
 │ Service User          │ mathias                                      │ ✓     │
 │ Enable on Boot        │ true                                         │ ✓     │
 │ Start Now             │ true                                         │ ✓     │
-│ Instance Name         │ accuser                                      │ ✓     │
+│ Instance Name         │ my-accuser                                   │ ✓     │
 │ Confirm & Install     │ Incomplete                                   │ ✗     │
 └───────────────────────┴──────────────────────────────────────────────┴───────┘
 

--- a/test/unit_tests.ml
+++ b/test/unit_tests.ml
@@ -736,6 +736,38 @@ let install_node_form_v3_snapshot_filtering () =
        archive_slug_entry
        ~history_mode:"rolling")
 
+(** Regression test for accuser instance name → base-dir sync bug.
+    When the user changes the instance name, the base-dir should update
+    to match the new name (unless the user manually customized base-dir). *)
+let install_accuser_form_v3_instance_name_sync () =
+  let module F = Octez_manager_ui.Install_accuser_form_v3.For_tests in
+  (* Test 1: Default instance name "accuser" → base-dir "accuser-accuser" *)
+  let initial_model_base_dir = F.initial_base_dir in
+  Alcotest.(check bool)
+    "initial base_dir contains default instance name"
+    true
+    (String.ends_with ~suffix:"accuser-accuser" initial_model_base_dir) ;
+  (* Test 2: Change instance name to "my-accuser" → base-dir syncs *)
+  let new_base_dir =
+    F.base_dir_after_set_instance_name ~instance_name:"my-accuser"
+  in
+  Alcotest.(check bool)
+    "base_dir syncs with new instance name"
+    true
+    (String.ends_with ~suffix:"accuser-my-accuser" new_base_dir) ;
+  Alcotest.(check bool)
+    "base_dir does not contain old default name"
+    false
+    (String.ends_with ~suffix:"accuser-accuser" new_base_dir) ;
+  (* Test 3: Change instance name that already has prefix *)
+  let prefixed_base_dir =
+    F.base_dir_after_set_instance_name ~instance_name:"accuser-testnet"
+  in
+  Alcotest.(check bool)
+    "base_dir does not double-prefix"
+    true
+    (String.ends_with ~suffix:"accuser-testnet" prefixed_base_dir)
+
 let runtime_probe_writable_directory () =
   let dir = Filename.temp_file "octez_manager_probe" "" in
   Sys.remove dir ;
@@ -6383,6 +6415,10 @@ let () =
                    Octez_manager_ui.Install_accuser_form_v3.For_tests
                    .initial_base_dir
                 <> ""));
+          Alcotest.test_case
+            "accuser instance name syncs base-dir"
+            `Quick
+            install_accuser_form_v3_instance_name_sync;
           Alcotest.test_case
             "binary help parses"
             `Quick


### PR DESCRIPTION
## Summary

- Fix accuser install form so that changing the instance name automatically updates the base-dir field (matching baker form behavior)
- Add unit test and update UI regression golden file to prevent regression

## Bug

When creating an accuser instance in the TUI, modifying the instance name did **not** update the base-dir field. For bakers, this sync worked correctly. The accuser form was using a generic `core_service_fields` bundle for the instance name field, which only updated `core.instance_name` without touching `client.base_dir`.

## Fix

Replaced the generic bundle call with a custom `validated_text` field that mirrors the baker's instance name → base-dir sync logic:
- In create mode: base-dir updates to `Paths.default_role_dir "accuser" <new_name>`
- In edit mode: base-dir is preserved (data already exists at that path)
- Manually customized base-dir values are preserved

## Tests

- **Unit test**: `install_accuser_form_v3_instance_name_sync` — validates initial base-dir, sync on name change, and no double-prefixing
- **UI regression**: Updated `accuser_instance_name_filled.screen` golden file to reflect the fixed behavior