### PR TITLE
feat(wallet): consensus key alias fix + companion key action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- **Update Consensus Key sending wrong octez-client command**: The command used `update consensus key for <delegate> to <key>` instead of the correct `update consensus key of <delegate> to <key>`, causing an "Unrecognized command" error from octez-client.
+- **Update Consensus Key sending wrong octez-client command**: The command used `update consensus key of <delegate> to <key>` instead of the correct `set consensus key for <delegate> to <key>`, causing an "Unrecognized command" error from octez-client.
 - **Extra args help explorer showing debug info**: Removed debug leftovers from the extra-args flag browser modal (used in node, baker, accuser, DAL, and index forms). The modal title bar was displaying the last key pressed, scroll offset, and cursor position.
 - **Baker form delegates reset on base dir change**: When creating a baker, changing the Baker Base Dir or changing the Instance Name in a way that updates the base dir now clears the previously selected delegates. This prevents stale delegate selections from a different base directory being carried over.
 - **DAL node data dir not tracking instance name**: When installing a DAL node, the data directory was always initialised to `dal-node-dal` regardless of the chosen instance name or selected node. The data dir now stays in sync with the instance name in all three cases: manual name edits, initial node selection (autoname), and node switches after autoname.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- **Update Consensus Key sending wrong octez-client command**: The command used `update consensus key of <delegate> to <key>` instead of the correct `set consensus key for <delegate> to <key>`, causing an "Unrecognized command" error from octez-client.
+- **Update Consensus Key sending wrong octez-client command**: The command now correctly issues `set consensus key for <delegate_alias> to <key_alias>`, using key aliases known to the baker's base-dir client rather than raw public key hashes. Previously the wrong verb (`update consensus key of`) and PKHs instead of aliases were used, causing octez-client to reject the operation.
 - **Extra args help explorer showing debug info**: Removed debug leftovers from the extra-args flag browser modal (used in node, baker, accuser, DAL, and index forms). The modal title bar was displaying the last key pressed, scroll offset, and cursor position.
 - **Baker form delegates reset on base dir change**: When creating a baker, changing the Baker Base Dir or changing the Instance Name in a way that updates the base dir now clears the previously selected delegates. This prevents stale delegate selections from a different base directory being carried over.
 - **DAL node data dir not tracking instance name**: When installing a DAL node, the data directory was always initialised to `dal-node-dal` regardless of the chosen instance name or selected node. The data dir now stays in sync with the instance name in all three cases: manual name edits, initial node selection (autoname), and node switches after autoname.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Key selector for Update Consensus Key**: The "Update Consensus Key" action in the baker wallet modal now shows a picker listing all keys found in the baker's base directory (alias and truncated public key hash). Selecting "Enter address manually…" falls back to the previous free-text input. The fallback is also used when no keys are found in the base directory.
+
 ### Fixed
 
+- **Update Consensus Key sending wrong octez-client command**: The command used `update consensus key for <delegate> to <key>` instead of the correct `update consensus key of <delegate> to <key>`, causing an "Unrecognized command" error from octez-client.
 - **Extra args help explorer showing debug info**: Removed debug leftovers from the extra-args flag browser modal (used in node, baker, accuser, DAL, and index forms). The modal title bar was displaying the last key pressed, scroll offset, and cursor position.
 - **Baker form delegates reset on base dir change**: When creating a baker, changing the Baker Base Dir or changing the Instance Name in a way that updates the base dir now clears the previously selected delegates. This prevents stale delegate selections from a different base directory being carried over.
 - **DAL node data dir not tracking instance name**: When installing a DAL node, the data directory was always initialised to `dal-node-dal` regardless of the chosen instance name or selected node. The data dir now stays in sync with the instance name in all three cases: manual name edits, initial node selection (autoname), and node switches after autoname.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **Key selector for Update Consensus Key**: The "Update Consensus Key" action in the baker wallet modal now shows a picker listing all keys found in the baker's base directory (alias and truncated public key hash). Selecting "Enter address manually…" falls back to the previous free-text input. The fallback is also used when no keys are found in the base directory.
+- **Update Companion Key in baker wallet**: Added "Update Companion Key" to the baker wallet action list. Works identically to "Update Consensus Key" but issues `octez-client set companion key for <delegate> to <key>`. Both TUI key picker and CLI `baker <instance> set-companion-key <key-alias>` are supported.
 
 ### Fixed
 

--- a/src/cli/cmd_baker.ml
+++ b/src/cli/cmd_baker.ml
@@ -536,19 +536,42 @@ let set_delegate_params_cmd =
 
 let key_arg = Arg.(required & pos 1 (some string) None & info [] ~docv:"KEY")
 
-let update_consensus_key_run instance key delegate_opt json yes =
+let update_consensus_key_run instance key_alias delegate_opt json yes =
   with_baker_service ~instance (fun svc ->
       match resolve_baker_context svc ~delegate_opt with
       | Error msg -> Cli_helpers.cmdliner_error msg
-      | Ok (endpoint, pkh) ->
-          run_operation
-            ~instance
-            ~svc
-            ~endpoint
-            ~pkh
-            ~op:(Baker_ops.Update_consensus_key {key})
-            ~json
-            ~yes)
+      | Ok (endpoint, pkh) -> (
+          let base_dir = resolve_baker_base_dir svc in
+          let delegate_alias =
+            match base_dir with
+            | None -> None
+            | Some dir -> (
+                match Keys_reader.read_public_key_hashes ~base_dir:dir with
+                | Error _ -> None
+                | Ok ks ->
+                    List.find_opt
+                      (fun k -> String.equal k.Keys_reader.value pkh)
+                      ks
+                    |> Option.map (fun k -> k.Keys_reader.name))
+          in
+          match delegate_alias with
+          | None ->
+              Cli_helpers.cmdliner_error
+                (Printf.sprintf
+                   "Delegate '%s' alias not found in base-dir — cannot update \
+                    consensus key"
+                   pkh)
+          | Some da ->
+              run_operation
+                ~instance
+                ~svc
+                ~endpoint
+                ~pkh
+                ~op:
+                  (Baker_ops.Update_consensus_key
+                     {delegate_alias = da; key_alias})
+                ~json
+                ~yes))
 
 let update_consensus_key_cmd =
   let info =

--- a/src/cli/cmd_baker.ml
+++ b/src/cli/cmd_baker.ml
@@ -584,6 +584,54 @@ let update_consensus_key_cmd =
         (const update_consensus_key_run
         $ instance_arg $ key_arg $ delegate_opt $ json_flag $ yes_flag))
 
+(* ── baker <instance> set-companion-key <key> ───────────── *)
+
+let set_companion_key_run instance key_alias delegate_opt json yes =
+  with_baker_service ~instance (fun svc ->
+      match resolve_baker_context svc ~delegate_opt with
+      | Error msg -> Cli_helpers.cmdliner_error msg
+      | Ok (endpoint, pkh) -> (
+          let base_dir = resolve_baker_base_dir svc in
+          let delegate_alias =
+            match base_dir with
+            | None -> None
+            | Some dir -> (
+                match Keys_reader.read_public_key_hashes ~base_dir:dir with
+                | Error _ -> None
+                | Ok ks ->
+                    List.find_opt
+                      (fun k -> String.equal k.Keys_reader.value pkh)
+                      ks
+                    |> Option.map (fun k -> k.Keys_reader.name))
+          in
+          match delegate_alias with
+          | None ->
+              Cli_helpers.cmdliner_error
+                (Printf.sprintf
+                   "Delegate '%s' alias not found in base-dir — cannot update \
+                    companion key"
+                   pkh)
+          | Some da ->
+              run_operation
+                ~instance
+                ~svc
+                ~endpoint
+                ~pkh
+                ~op:
+                  (Baker_ops.Update_companion_key
+                     {delegate_alias = da; key_alias})
+                ~json
+                ~yes))
+
+let set_companion_key_cmd =
+  let info = Cmd.info "set-companion-key" ~doc:"Update baker companion key" in
+  Cmd.v
+    info
+    Term.(
+      ret
+        (const set_companion_key_run
+        $ instance_arg $ key_arg $ delegate_opt $ json_flag $ yes_flag))
+
 (* ── baker <instance> vote <value> ───────────────────────── *)
 
 let vote_value_arg =
@@ -696,5 +744,6 @@ let baker_cmd =
       transfer_cmd;
       set_delegate_params_cmd;
       update_consensus_key_cmd;
+      set_companion_key_cmd;
       vote_cmd;
     ]

--- a/src/ui/baker_ops.ml
+++ b/src/ui/baker_ops.ml
@@ -66,7 +66,7 @@ let build_command ~octez_client_bin ~endpoint ~base_dir ~password_file ~alias
           edge_frac;
         ]
     | Update_consensus_key {key} ->
-        ["update"; "consensus"; "key"; "of"; alias; "to"; key]
+        ["set"; "consensus"; "key"; "for"; alias; "to"; key]
     | Submit_proposals {proposals} ->
         ["submit"; "proposals"; "for"; alias] @ proposals
     | Submit_ballot {proposal; ballot} ->

--- a/src/ui/baker_ops.ml
+++ b/src/ui/baker_ops.ml
@@ -21,6 +21,7 @@ type wallet_operation =
   | Transfer of {amount : string; destination : string}
   | Set_delegate_params of {limit : int; edge : int}
   | Update_consensus_key of {delegate_alias : string; key_alias : string}
+  | Update_companion_key of {delegate_alias : string; key_alias : string}
   | Submit_proposals of {proposals : string list}
   | Submit_ballot of {proposal : string; ballot : Baker_wallet_data.ballot_vote}
 
@@ -67,6 +68,8 @@ let build_command ~octez_client_bin ~endpoint ~base_dir ~password_file ~alias
         ]
     | Update_consensus_key {delegate_alias; key_alias} ->
         ["set"; "consensus"; "key"; "for"; delegate_alias; "to"; key_alias]
+    | Update_companion_key {delegate_alias; key_alias} ->
+        ["set"; "companion"; "key"; "for"; delegate_alias; "to"; key_alias]
     | Submit_proposals {proposals} ->
         ["submit"; "proposals"; "for"; alias] @ proposals
     | Submit_ballot {proposal; ballot} ->
@@ -205,6 +208,8 @@ let describe_operation = function
         edge
   | Update_consensus_key {key_alias; _} ->
       Printf.sprintf "Update Consensus Key to %s" key_alias
+  | Update_companion_key {key_alias; _} ->
+      Printf.sprintf "Update Companion Key to %s" key_alias
   | Submit_proposals {proposals} ->
       Printf.sprintf
         "Submit Proposal%s: %s"

--- a/src/ui/baker_ops.ml
+++ b/src/ui/baker_ops.ml
@@ -66,7 +66,7 @@ let build_command ~octez_client_bin ~endpoint ~base_dir ~password_file ~alias
           edge_frac;
         ]
     | Update_consensus_key {key} ->
-        ["update"; "consensus"; "key"; "for"; alias; "to"; key]
+        ["update"; "consensus"; "key"; "of"; alias; "to"; key]
     | Submit_proposals {proposals} ->
         ["submit"; "proposals"; "for"; alias] @ proposals
     | Submit_ballot {proposal; ballot} ->

--- a/src/ui/baker_ops.ml
+++ b/src/ui/baker_ops.ml
@@ -20,7 +20,7 @@ type wallet_operation =
   | Finalize_unstake
   | Transfer of {amount : string; destination : string}
   | Set_delegate_params of {limit : int; edge : int}
-  | Update_consensus_key of {key : string}
+  | Update_consensus_key of {delegate_alias : string; key_alias : string}
   | Submit_proposals of {proposals : string list}
   | Submit_ballot of {proposal : string; ballot : Baker_wallet_data.ballot_vote}
 
@@ -65,8 +65,8 @@ let build_command ~octez_client_bin ~endpoint ~base_dir ~password_file ~alias
           "--edge-of-baking-over-staking";
           edge_frac;
         ]
-    | Update_consensus_key {key} ->
-        ["set"; "consensus"; "key"; "for"; alias; "to"; key]
+    | Update_consensus_key {delegate_alias; key_alias} ->
+        ["set"; "consensus"; "key"; "for"; delegate_alias; "to"; key_alias]
     | Submit_proposals {proposals} ->
         ["submit"; "proposals"; "for"; alias] @ proposals
     | Submit_ballot {proposal; ballot} ->
@@ -203,8 +203,8 @@ let describe_operation = function
         "Set Delegate Parameters (limit: %dx, edge: %d%%)"
         limit
         edge
-  | Update_consensus_key {key} ->
-      Printf.sprintf "Update Consensus Key to %s" key
+  | Update_consensus_key {key_alias; _} ->
+      Printf.sprintf "Update Consensus Key to %s" key_alias
   | Submit_proposals {proposals} ->
       Printf.sprintf
         "Submit Proposal%s: %s"

--- a/src/ui/baker_ops.mli
+++ b/src/ui/baker_ops.mli
@@ -24,7 +24,7 @@ type wallet_operation =
   | Finalize_unstake
   | Transfer of {amount : string; destination : string}
   | Set_delegate_params of {limit : int; edge : int}
-  | Update_consensus_key of {key : string}
+  | Update_consensus_key of {delegate_alias : string; key_alias : string}
   | Submit_proposals of {proposals : string list}
   | Submit_ballot of {proposal : string; ballot : Baker_wallet_data.ballot_vote}
 

--- a/src/ui/baker_ops.mli
+++ b/src/ui/baker_ops.mli
@@ -25,6 +25,7 @@ type wallet_operation =
   | Transfer of {amount : string; destination : string}
   | Set_delegate_params of {limit : int; edge : int}
   | Update_consensus_key of {delegate_alias : string; key_alias : string}
+  | Update_companion_key of {delegate_alias : string; key_alias : string}
   | Submit_proposals of {proposals : string list}
   | Submit_ballot of {proposal : string; ballot : Baker_wallet_data.ballot_vote}
 

--- a/src/ui/pages/instances/instances_wallet.ml
+++ b/src/ui/pages/instances/instances_wallet.ml
@@ -612,25 +612,29 @@ let dispatch_action svc pkh _data ~node_endpoint action =
             | Ok ks -> ks
             | Error _ -> [])
       in
-      let run_with_key key =
-        run_wallet_operation
-          ~svc
-          ~pkh
-          ~op:(Baker_ops.Update_consensus_key {key})
+      let delegate_alias =
+        List.find_opt (fun k -> String.equal k.Keys_reader.value pkh) keys
+        |> Option.map (fun k -> k.Keys_reader.name)
+      in
+      let run_with_key key_alias =
+        match delegate_alias with
+        | None ->
+            Context.toast_error
+              "Delegate alias not found in base-dir — cannot update consensus \
+               key"
+        | Some da ->
+            run_wallet_operation
+              ~svc
+              ~pkh
+              ~op:
+                (Baker_ops.Update_consensus_key {delegate_alias = da; key_alias})
       in
       let prompt_manually () =
         Modal_helpers.prompt_validated_text_modal
           ~title:"Update Consensus Key"
-          ~placeholder:(Some "tz1... pkh")
+          ~placeholder:(Some "key alias")
           ~validator:(fun s ->
-            let len = String.length s in
-            if
-              len >= 36
-              && (String.sub s 0 3 = "tz1"
-                 || String.sub s 0 3 = "tz2"
-                 || String.sub s 0 3 = "tz3")
-            then Ok ()
-            else Error "Enter a valid tz1/tz2/tz3 public key hash")
+            if String.length s > 0 then Ok () else Error "Enter a key alias")
           ~on_submit:run_with_key
           ()
       in
@@ -649,7 +653,7 @@ let dispatch_action svc pkh _data ~node_endpoint action =
                   Printf.sprintf "%s (%s)" name (truncate_pkh value))
             ~on_select:(function
               | None -> prompt_manually ()
-              | Some {Keys_reader.value = key; _} -> run_with_key key)
+              | Some {Keys_reader.name = key_alias; _} -> run_with_key key_alias)
             ())
   | Vote -> (
       match Baker_wallet_data.get_voting_info ~node_endpoint with

--- a/src/ui/pages/instances/instances_wallet.ml
+++ b/src/ui/pages/instances/instances_wallet.ml
@@ -603,25 +603,54 @@ let dispatch_action svc pkh _data ~node_endpoint action =
                 ~op:(Baker_ops.Set_delegate_params {limit; edge}))
             ())
         ()
-  | Update_consensus_key ->
-      Modal_helpers.prompt_validated_text_modal
-        ~title:"Update Consensus Key"
-        ~placeholder:(Some "tz1... key alias or pkh")
-        ~validator:(fun s ->
-          let len = String.length s in
-          if
-            len >= 36
-            && (String.sub s 0 3 = "tz1"
-               || String.sub s 0 3 = "tz2"
-               || String.sub s 0 3 = "tz3")
-          then Ok ()
-          else Error "Enter a valid tz1/tz2/tz3 public key hash")
-        ~on_submit:(fun key ->
-          run_wallet_operation
-            ~svc
-            ~pkh
-            ~op:(Baker_ops.Update_consensus_key {key}))
-        ()
+  | Update_consensus_key -> (
+      let keys =
+        match baker_base_dir svc with
+        | None -> []
+        | Some dir -> (
+            match Keys_reader.read_public_key_hashes ~base_dir:dir with
+            | Ok ks -> ks
+            | Error _ -> [])
+      in
+      let run_with_key key =
+        run_wallet_operation
+          ~svc
+          ~pkh
+          ~op:(Baker_ops.Update_consensus_key {key})
+      in
+      let prompt_manually () =
+        Modal_helpers.prompt_validated_text_modal
+          ~title:"Update Consensus Key"
+          ~placeholder:(Some "tz1... pkh")
+          ~validator:(fun s ->
+            let len = String.length s in
+            if
+              len >= 36
+              && (String.sub s 0 3 = "tz1"
+                 || String.sub s 0 3 = "tz2"
+                 || String.sub s 0 3 = "tz3")
+            then Ok ()
+            else Error "Enter a valid tz1/tz2/tz3 public key hash")
+          ~on_submit:run_with_key
+          ()
+      in
+      match keys with
+      | [] -> prompt_manually ()
+      | _ ->
+          let items : Keys_reader.key_info option list =
+            List.map Option.some keys @ [None]
+          in
+          Modal_helpers.open_choice_modal
+            ~title:"Update Consensus Key"
+            ~items
+            ~to_string:(function
+              | None -> "Enter address manually…"
+              | Some {Keys_reader.name; value} ->
+                  Printf.sprintf "%s (%s)" name (truncate_pkh value))
+            ~on_select:(function
+              | None -> prompt_manually ()
+              | Some {Keys_reader.value = key; _} -> run_with_key key)
+            ())
   | Vote -> (
       match Baker_wallet_data.get_voting_info ~node_endpoint with
       | None ->

--- a/src/ui/pages/instances/instances_wallet.ml
+++ b/src/ui/pages/instances/instances_wallet.ml
@@ -29,6 +29,7 @@ type wallet_action =
   | Transfer
   | Set_delegate_params
   | Update_consensus_key
+  | Update_companion_key
   | Register
   | Vote
 
@@ -121,7 +122,11 @@ let build_operations_list (data : Baker_wallet_data.t) ~node_endpoint:_ =
       | [] -> items
       | _ -> items @ [Finalize_unstake]
     in
-    items @ [Transfer; Set_delegate_params; Update_consensus_key] @ [Vote]
+    items
+    @ [
+        Transfer; Set_delegate_params; Update_consensus_key; Update_companion_key;
+      ]
+    @ [Vote]
 
 let action_to_string (data : Baker_wallet_data.t) ~node_endpoint action =
   match action with
@@ -144,6 +149,7 @@ let action_to_string (data : Baker_wallet_data.t) ~node_endpoint action =
   | Transfer -> "Transfer"
   | Set_delegate_params -> "Set Delegate Parameters"
   | Update_consensus_key -> "Update Consensus Key"
+  | Update_companion_key -> "Update Companion Key"
   | Vote -> (
       match Baker_wallet_data.get_voting_info ~node_endpoint with
       | Some info ->
@@ -646,6 +652,58 @@ let dispatch_action svc pkh _data ~node_endpoint action =
           in
           Modal_helpers.open_choice_modal
             ~title:"Update Consensus Key"
+            ~items
+            ~to_string:(function
+              | None -> "Enter address manually…"
+              | Some {Keys_reader.name; value} ->
+                  Printf.sprintf "%s (%s)" name (truncate_pkh value))
+            ~on_select:(function
+              | None -> prompt_manually ()
+              | Some {Keys_reader.name = key_alias; _} -> run_with_key key_alias)
+            ())
+  | Update_companion_key -> (
+      let keys =
+        match baker_base_dir svc with
+        | None -> []
+        | Some dir -> (
+            match Keys_reader.read_public_key_hashes ~base_dir:dir with
+            | Ok ks -> ks
+            | Error _ -> [])
+      in
+      let delegate_alias =
+        List.find_opt (fun k -> String.equal k.Keys_reader.value pkh) keys
+        |> Option.map (fun k -> k.Keys_reader.name)
+      in
+      let run_with_key key_alias =
+        match delegate_alias with
+        | None ->
+            Context.toast_error
+              "Delegate alias not found in base-dir — cannot update companion \
+               key"
+        | Some da ->
+            run_wallet_operation
+              ~svc
+              ~pkh
+              ~op:
+                (Baker_ops.Update_companion_key {delegate_alias = da; key_alias})
+      in
+      let prompt_manually () =
+        Modal_helpers.prompt_validated_text_modal
+          ~title:"Update Companion Key"
+          ~placeholder:(Some "key alias")
+          ~validator:(fun s ->
+            if String.length s > 0 then Ok () else Error "Enter a key alias")
+          ~on_submit:run_with_key
+          ()
+      in
+      match keys with
+      | [] -> prompt_manually ()
+      | _ ->
+          let items : Keys_reader.key_info option list =
+            List.map Option.some keys @ [None]
+          in
+          Modal_helpers.open_choice_modal
+            ~title:"Update Companion Key"
             ~items
             ~to_string:(function
               | None -> "Enter address manually…"

--- a/test/test_baker_ops.ml
+++ b/test/test_baker_ops.ml
@@ -203,10 +203,10 @@ let test_build_update_consensus_key () =
       bin;
       "--endpoint";
       endpoint;
-      "update";
+      "set";
       "consensus";
       "key";
-      "of";
+      "for";
       alias;
       "to";
       "edpkNew...";

--- a/test/test_baker_ops.ml
+++ b/test/test_baker_ops.ml
@@ -217,6 +217,37 @@ let test_build_update_consensus_key () =
     ]
     cmd
 
+let test_build_update_companion_key () =
+  let cmd =
+    BO.build_command
+      ~octez_client_bin:bin
+      ~endpoint
+      ~base_dir:None
+      ~password_file:None
+      ~alias
+      ~op:
+        (Update_companion_key
+           {delegate_alias = alias; key_alias = "companion-key"})
+  in
+  check
+    (list string)
+    "update companion key"
+    [
+      bin;
+      "--endpoint";
+      endpoint;
+      "set";
+      "companion";
+      "key";
+      "for";
+      alias;
+      "to";
+      "companion-key";
+      "--burn-cap";
+      "1";
+    ]
+    cmd
+
 let test_build_submit_proposals () =
   let cmd =
     BO.build_command
@@ -444,6 +475,10 @@ let () =
             "update_consensus_key"
             `Quick
             test_build_update_consensus_key;
+          test_case
+            "update_companion_key"
+            `Quick
+            test_build_update_companion_key;
           test_case "submit_proposals" `Quick test_build_submit_proposals;
           test_case "submit_ballot yay" `Quick test_build_submit_ballot;
           test_case "submit_ballot nay" `Quick test_build_submit_ballot_nay;

--- a/test/test_baker_ops.ml
+++ b/test/test_baker_ops.ml
@@ -206,7 +206,7 @@ let test_build_update_consensus_key () =
       "update";
       "consensus";
       "key";
-      "for";
+      "of";
       alias;
       "to";
       "edpkNew...";

--- a/test/test_baker_ops.ml
+++ b/test/test_baker_ops.ml
@@ -194,7 +194,9 @@ let test_build_update_consensus_key () =
       ~base_dir:None
       ~password_file:None
       ~alias
-      ~op:(Update_consensus_key {key = "edpkNew..."})
+      ~op:
+        (Update_consensus_key
+           {delegate_alias = alias; key_alias = "consensus-key"})
   in
   check
     (list string)
@@ -209,7 +211,7 @@ let test_build_update_consensus_key () =
       "for";
       alias;
       "to";
-      "edpkNew...";
+      "consensus-key";
       "--burn-cap";
       "1";
     ]


### PR DESCRIPTION
## Summary

- **Fix**: `set consensus key for <delegate> to <key>` now uses key aliases from the baker's base-dir client instead of raw public key hashes. Both `<delegate>` and `<key>` are resolved via `Keys_reader.read_public_key_hashes` against the baker's base directory.
- **Feat**: Added "Update Companion Key" to the baker wallet action list, issuing `octez-client set companion key for <delegate_alias> to <key_alias>`. Mirrors the Update Consensus Key flow exactly (key picker, manual fallback, CLI subcommand).

## Test plan

- [ ] Build passes: `dune build`
- [ ] All tests pass: `dune runtest`
- [ ] Completions up to date: `make completions-check`
- [ ] TUI: open baker wallet → "Update Consensus Key" shows key picker with aliases; selecting a key shows confirmation with alias (not PKH) in the command
- [ ] TUI: "Update Companion Key" appears in the action list and behaves identically
- [ ] CLI: `baker <instance> update-consensus-key <alias>` resolves delegate alias and submits correct command
- [ ] CLI: `baker <instance> set-companion-key <alias>` works the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)