### PR TITLE
fix: clean up snapshot temp files on exit and startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Snapshot temp files leaked on exit**: Temporary snapshot files (`.snap`) left in the system temp directory when the user exits during a snapshot import are now cleaned up. On shutdown, the active import subprocess is killed so that `Fun.protect` finalizers can remove the file; on startup, any leftover files from a previous aborted run are deleted.
+
 - **Extra args help explorer showing debug info**: Removed debug leftovers from the extra-args flag browser modal (used in node, baker, accuser, DAL, and index forms). The modal title bar was displaying the last key pressed, scroll offset, and cursor position.
 - **Baker form delegates reset on base dir change**: When creating a baker, changing the Baker Base Dir or changing the Instance Name in a way that updates the base dir now clears the previously selected delegates. This prevents stale delegate selections from a different base directory being carried over.
 - **DAL node data dir not tracking instance name**: When installing a DAL node, the data directory was always initialised to `dal-node-dal` regardless of the chosen instance name or selected node. The data dir now stays in sync with the instance name in all three cases: manual name edits, initial node selection (autoname), and node switches after autoname.

--- a/lib/common/cmd_runner.ml
+++ b/lib/common/cmd_runner.ml
@@ -43,6 +43,25 @@ let set_run_out_silent_hook f = run_out_silent_hook := Some f
 
 let set_run_streaming_hook f = run_streaming_hook := Some f
 
+(* Track active streaming subprocess for cleanup on exit. Only one streaming
+   process runs at a time (snapshot import is sequential), so a single ref
+   suffices. *)
+let active_streaming_process :
+    (in_channel * out_channel * in_channel) option ref =
+  ref None
+
+let active_streaming_lock = Mutex.create ()
+
+let kill_active_streaming () =
+  Mutex.protect active_streaming_lock (fun () ->
+      match !active_streaming_process with
+      | None -> ()
+      | Some (ic, oc, ec) -> (
+          active_streaming_process := None ;
+          (try close_in_noerr ic with _ -> ()) ;
+          (try close_out_noerr oc with _ -> ()) ;
+          try close_in_noerr ec with _ -> ()))
+
 let append_debug_log line =
   try
     let oc =
@@ -152,6 +171,8 @@ let run_streaming_blocking ~on_log argv =
   append_debug_log ("RUN_STREAMING " ^ cmd_to_string argv) ;
   let cmd_str = cmd_to_string argv in
   let ic, oc, ec = Unix.open_process_full cmd_str (Unix.environment ()) in
+  Mutex.protect active_streaming_lock (fun () ->
+      active_streaming_process := Some (ic, oc, ec)) ;
   close_out oc ;
   let ic_fd = Unix.descr_of_in_channel ic in
   let ec_fd = Unix.descr_of_in_channel ec in
@@ -220,6 +241,8 @@ let run_streaming_blocking ~on_log argv =
   in
   flush_buf ic_buf ;
   flush_buf ec_buf ;
+  Mutex.protect active_streaming_lock (fun () ->
+      active_streaming_process := None) ;
   match Unix.close_process_full (ic, oc, ec) with
   | Unix.WEXITED 0 -> Ok ()
   | _status ->

--- a/lib/common/cmd_runner.mli
+++ b/lib/common/cmd_runner.mli
@@ -38,6 +38,11 @@ val set_run_streaming_hook :
   (on_log:(string -> unit) -> string list -> (unit, [`Msg of string]) result) ->
   unit
 
+(** Kill any active streaming subprocess. Safe to call when none is active.
+    Called during application shutdown to terminate the snapshot import process
+    so that [Fun.protect] finalizers can clean up temp files. *)
+val kill_active_streaming : unit -> unit
+
 (** {1 Command execution} *)
 
 (** Append a line to [/tmp/octez_manager_cmds.log] for debugging. *)

--- a/src/installer/snapshot.ml
+++ b/src/installer/snapshot.ml
@@ -307,6 +307,21 @@ let perform_snapshot_plan ?(quiet = false) ?on_log ?tmp_dir
             ~no_check
             ())
 
+let cleanup_stale_snapshot_files () =
+  let tmp_dir = Filename.get_temp_dir_name () in
+  try
+    let entries = Sys.readdir tmp_dir in
+    Array.iter
+      (fun name ->
+        if
+          String.starts_with ~prefix:"octez-manager.snapshot" name
+          && String.ends_with ~suffix:".snap" name
+        then
+          let path = Filename.concat tmp_dir name in
+          File_ops.remove_path path)
+      entries
+  with _ -> ()
+
 let perform_bootstrap ?(quiet = false) ?on_log ?tmp_dir ~plan
     ~(request : node_request) ~data_dir () =
   perform_snapshot_plan

--- a/src/installer/snapshot.mli
+++ b/src/installer/snapshot.mli
@@ -92,6 +92,11 @@ val perform_snapshot_plan :
   unit ->
   (unit, Rresult.R.msg) result
 
+(** Remove leftover temporary snapshot files from the system temp directory.
+    Safe to call at startup; cleans up files left by a previous run that was
+    interrupted while importing a snapshot. *)
+val cleanup_stale_snapshot_files : unit -> unit
+
 (** Perform bootstrap according to node request *)
 val perform_bootstrap :
   ?quiet:bool ->

--- a/src/ui/pages/manager_app.ml
+++ b/src/ui/pages/manager_app.ml
@@ -85,6 +85,7 @@ let register_and_init ?(log = false) ?logfile () =
   Runtime.initialize ~log ?logfile () ;
   register_global_keys () ;
   Binary_downloader.cleanup_stale_temp_dirs () ;
+  Snapshot.cleanup_stale_snapshot_files () ;
   Background_runner.enqueue (fun () ->
       match Version_checker.check_for_updates () with
       | Version_checker.UpdateAvailable
@@ -126,7 +127,8 @@ let shutdown () =
   Versions_scheduler.shutdown () ;
   Self_update_scheduler.stop () ;
   Domain_pool.shutdown () ;
-  Download.kill_active_download ()
+  Download.kill_active_download () ;
+  Cmd_runner.kill_active_streaming ()
 
 let run ?page ?(log = false) ?logfile ?theme ?local_indexer
     ?(indexer_network = "mainnet") ?(compare_indexers = false) () =


### PR DESCRIPTION
## Summary

- **Root cause**: When the user presses Esc during a snapshot import, the background domain running `octez-node snapshot import` is abandoned. `Fun.protect ~finally:` only runs when the OCaml domain returns normally, so the temporary `.snap` file is never deleted.
- **On shutdown** (`manager_app.ml`): `Cmd_runner.kill_active_streaming()` is now called alongside the existing `Download.kill_active_download()`. This closes the stdin/stdout/stderr channels of the active streaming subprocess, causing the `run_streaming_blocking` loop to exit and `Fun.protect` to fire its cleanup finalizer.
- **On startup** (`manager_app.ml`): `Snapshot.cleanup_stale_snapshot_files()` scans `/tmp` for any leftover `octez-manager.snapshot.*.snap` files from a previous run that was interrupted before the finalizer could fire.

## Test plan

- [ ] Start `octez-manager`, create a new mainnet node (rolling), wait for download to complete, then press Esc while the snapshot import is running — verify no `.snap` file remains in `/tmp` after exit
- [ ] Kill `octez-manager` with SIGTERM mid-import — verify cleanup on next startup
- [ ] `dune build && dune runtest` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)