### PR TITLE
fix(wallets): improve balance fetching, network picker, and operation reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Network names shown as URLs in wallet actions**: Network picker for transfer/stake/delegate actions now shows clean network names (e.g., "shadownet") instead of raw URLs (e.g., "https://teztnets.com/shadownet") for locally running nodes.
 - **Wallet balances not fetched on page load**: Wallet balances are now fetched proactively when the application starts and refreshed periodically every 30 seconds. Previously, balances only appeared after user interaction (moving cursor to a key or pressing `r` to refresh), making the page appear unresponsive on first visit.
 - **Extra args help explorer showing debug info**: Removed debug leftovers from the extra-args flag browser modal (used in node, baker, accuser, DAL, and index forms). The modal title bar was displaying the last key pressed, scroll offset, and cursor position.
 - **Baker form delegates reset on base dir change**: When creating a baker, changing the Baker Base Dir or changing the Instance Name in a way that updates the base dir now clears the previously selected delegates. This prevents stale delegate selections from a different base directory being carried over.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Network names shown as URLs in wallet actions**: Network picker for transfer/stake/delegate actions now shows clean network names (e.g., "shadownet") instead of raw URLs (e.g., "https://teztnets.com/shadownet") for locally running nodes.
 - **Wallet balances not fetched on page load**: Wallet balances are now fetched proactively when the application starts and refreshed periodically every 30 seconds. Previously, balances only appeared after user interaction (moving cursor to a key or pressing `r` to refresh), making the page appear unresponsive on first visit.
+- **Wallet operations hanging on non-bootstrapped nodes**: Transfer, stake, and delegate operations now pass `--wait none` to octez-client, preventing the command from blocking indefinitely at "Waiting for the node to be bootstrapped..." when the target node is still syncing.
 - **Extra args help explorer showing debug info**: Removed debug leftovers from the extra-args flag browser modal (used in node, baker, accuser, DAL, and index forms). The modal title bar was displaying the last key pressed, scroll offset, and cursor position.
 - **Baker form delegates reset on base dir change**: When creating a baker, changing the Baker Base Dir or changing the Instance Name in a way that updates the base dir now clears the previously selected delegates. This prevents stale delegate selections from a different base directory being carried over.
 - **DAL node data dir not tracking instance name**: When installing a DAL node, the data directory was always initialised to `dal-node-dal` regardless of the chosen instance name or selected node. The data dir now stays in sync with the instance name in all three cases: manual name edits, initial node selection (autoname), and node switches after autoname.
@@ -28,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - **Wallet operations show both local and public endpoints**: When a network has both a local running node and public RPC endpoints, the network picker now shows separate entries for each, letting you choose which endpoint to use for transfers, staking, and other operations.
+- **Syncing endpoints greyed out in wallet network picker**: Local nodes that are not yet fully bootstrapped are now visually dimmed with a "(syncing..)" indicator in the network picker. The cursor skips over them during navigation and they cannot be selected, preventing accidental submission to non-bootstrapped endpoints.
 - **Log export now runs in the background with progress feedback**: Exporting instance logs no longer freezes the UI. A progress bar is shown during the export and a green success toast displays the archive path on completion.
 - Simplified help modal (`?`) keymaps across all pages: removed verbose descriptions in favor of concise action names (e.g., "Toggle view" instead of "Group/Role view", "Back" instead of "Back / Previous")
 - Simplified instances page help hint: removed verbose view mode descriptions ("By Role", "By Group", "Toggle view") in favor of concise key combinations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Wallet balances not fetched on page load**: Wallet balances are now fetched proactively when the application starts and refreshed periodically every 30 seconds. Previously, balances only appeared after user interaction (moving cursor to a key or pressing `r` to refresh), making the page appear unresponsive on first visit.
 - **Extra args help explorer showing debug info**: Removed debug leftovers from the extra-args flag browser modal (used in node, baker, accuser, DAL, and index forms). The modal title bar was displaying the last key pressed, scroll offset, and cursor position.
 - **Baker form delegates reset on base dir change**: When creating a baker, changing the Baker Base Dir or changing the Instance Name in a way that updates the base dir now clears the previously selected delegates. This prevents stale delegate selections from a different base directory being carried over.
 - **DAL node data dir not tracking instance name**: When installing a DAL node, the data directory was always initialised to `dal-node-dal` regardless of the chosen instance name or selected node. The data dir now stays in sync with the instance name in all three cases: manual name edits, initial node selection (autoname), and node switches after autoname.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Wallet operations show both local and public endpoints**: When a network has both a local running node and public RPC endpoints, the network picker now shows separate entries for each, letting you choose which endpoint to use for transfers, staking, and other operations.
 - **Log export now runs in the background with progress feedback**: Exporting instance logs no longer freezes the UI. A progress bar is shown during the export and a green success toast displays the archive path on completion.
 - Simplified help modal (`?`) keymaps across all pages: removed verbose descriptions in favor of concise action names (e.g., "Toggle view" instead of "Group/Role view", "Back" instead of "Back / Previous")
 - Simplified instances page help hint: removed verbose view mode descriptions ("By Role", "By Group", "Toggle view") in favor of concise key combinations

--- a/src/ui/baker_ops.ml
+++ b/src/ui/baker_ops.ml
@@ -40,7 +40,7 @@ let build_command ~octez_client_bin ~endpoint ~base_dir ~password_file ~alias
     @ (match password_file with
       | Some f -> ["--password-filename"; f]
       | None -> [])
-    @ ["--endpoint"; endpoint]
+    @ ["--endpoint"; endpoint; "--wait"; "none"]
   in
   let cmd =
     match op with

--- a/src/ui/keys_scheduler.ml
+++ b/src/ui/keys_scheduler.ml
@@ -320,11 +320,24 @@ let refresh_tzkt_aliases () =
       if Tzkt_aliases.needs_refresh ~network then Tzkt_aliases.refresh ~network)
     networks
 
+(** Queue balance fetches for all tracked keys. Uses [request_fetch] so
+    fresh data is not re-fetched and duplicate pending requests are dropped. *)
+let fetch_all_tracked_keys () =
+  let keys = Mutex.protect keys_lock (fun () -> !tracked_keys) in
+  List.iter
+    (fun (_base_dir, pkhs) -> List.iter (fun pkh -> request_fetch ~pkh) pkhs)
+    keys
+
 let scheduler_loop () =
   Worker_queue.start worker ;
   Eio_unix.sleep 3.0 ;
+  (* Initial fetch: queue balance requests for all tracked keys so that
+     data is available as soon as the user opens the Wallets page. *)
+  fetch_all_tracked_keys () ;
   while not (Atomic.get stop_flag) do
     (try refresh_tzkt_aliases () with _ -> ()) ;
+    (* Periodic refresh: re-queue stale keys *)
+    fetch_all_tracked_keys () ;
     Eio_unix.sleep poll_interval
   done ;
   Worker_queue.stop worker
@@ -343,3 +356,11 @@ let get_endpoints_for_network ~network =
   get_node_endpoints ()
   |> List.filter_map (fun (net, endpoint) ->
       if String.equal net network then Some endpoint else None)
+
+module Internal_for_tests = struct
+  let fetch_all_tracked_keys = fetch_all_tracked_keys
+
+  let get_tracked_pkhs () =
+    let keys = Mutex.protect keys_lock (fun () -> !tracked_keys) in
+    List.concat_map (fun (_base_dir, pkhs) -> pkhs) keys
+end

--- a/src/ui/keys_scheduler.mli
+++ b/src/ui/keys_scheduler.mli
@@ -61,3 +61,15 @@ val stop : unit -> unit
 (** Get running node endpoints for a specific network.
     Returns a list of endpoint URLs. Fast, reads from service state cache. *)
 val get_endpoints_for_network : network:string -> string list
+
+(**/**)
+
+module Internal_for_tests : sig
+  (** Queue balance fetches for all tracked keys. *)
+  val fetch_all_tracked_keys : unit -> unit
+
+  (** Get the list of all currently tracked PKHs (flattened from all base_dirs). *)
+  val get_tracked_pkhs : unit -> string list
+end
+
+(**/**)

--- a/src/ui/modal_helpers.ml
+++ b/src/ui/modal_helpers.ml
@@ -130,7 +130,12 @@ let open_text_modal ~title ~lines =
     ~on_close:(fun _ _ -> ())
 
 let open_choice_modal (type choice) ~title ~(items : choice list) ~to_string
-    ?on_tick ~on_select () =
+    ?on_tick ?is_enabled ~on_select () =
+  let is_enabled = Option.value ~default:(fun _ -> true) is_enabled in
+  let wrapped_to_string item =
+    let s = to_string item in
+    if is_enabled item then s else Widgets.themed_muted s
+  in
   let module Modal = struct
     type state = choice Select_widget.t
 
@@ -186,15 +191,46 @@ let open_choice_modal (type choice) ~title ~(items : choice list) ~to_string
             "Esc"
         | _ -> key
       in
+      (* Helper to skip over disabled items in a given direction *)
+      let skip_disabled_in_direction s direction =
+        let max_steps = List.length items in
+        let rec loop s steps =
+          if steps >= max_steps then s
+          else
+            match Select_widget.get_selection s with
+            | Some item when not (is_enabled item) ->
+                loop (Select_widget.handle_key s ~key:direction) (steps + 1)
+            | _ -> s
+        in
+        loop s 0
+      in
       if key = "Enter" then (
-        Miaou.Core.Modal_manager.set_consume_next_key () ;
-        Miaou.Core.Modal_manager.close_top `Commit ;
-        ps)
+        match Select_widget.get_selection s with
+        | Some item when not (is_enabled item) ->
+            (* Ignore Enter on disabled item *)
+            ps
+        | _ ->
+            Miaou.Core.Modal_manager.set_consume_next_key () ;
+            Miaou.Core.Modal_manager.close_top `Commit ;
+            ps)
       else if key = "Esc" then (
         Miaou.Core.Modal_manager.set_consume_next_key () ;
         Miaou.Core.Modal_manager.close_top `Cancel ;
         ps)
-      else Navigation.update (fun _ -> Select_widget.handle_key s ~key) ps
+      else
+        (* Handle navigation keys and skip disabled items *)
+        let s' = Select_widget.handle_key s ~key in
+        let s'' =
+          match key with
+          | "Up" -> skip_disabled_in_direction s' "Up"
+          | "Down" -> skip_disabled_in_direction s' "Down"
+          | "PageUp" -> skip_disabled_in_direction s' "Up"
+          | "PageDown" -> skip_disabled_in_direction s' "Down"
+          | "Home" -> skip_disabled_in_direction s' "Down"
+          | "End" -> skip_disabled_in_direction s' "Up"
+          | _ -> s'
+        in
+        Navigation.update (fun _ -> s'') ps
 
     let handle_key = handle_modal_key
 
@@ -210,7 +246,23 @@ let open_choice_modal (type choice) ~title ~(items : choice list) ~to_string
 
     let has_modal _ = true
   end in
-  let widget = Select_widget.open_centered ~title:"" ~items ~to_string () in
+  let widget =
+    Select_widget.open_centered ~title:"" ~items ~to_string:wrapped_to_string ()
+  in
+  (* Skip to first enabled item if initial selection is disabled *)
+  let skip_to_enabled s =
+    let max_steps = List.length items in
+    let rec loop s steps =
+      if steps >= max_steps then s
+      else
+        match Select_widget.get_selection s with
+        | Some item when not (is_enabled item) ->
+            loop (Select_widget.handle_key s ~key:"Down") (steps + 1)
+        | _ -> s
+    in
+    loop s 0
+  in
+  let widget = skip_to_enabled widget in
   let ui : Miaou.Core.Modal_manager.ui =
     {
       title;

--- a/src/ui/modal_helpers.mli
+++ b/src/ui/modal_helpers.mli
@@ -12,12 +12,14 @@ val open_text_modal : title:string -> lines:string list -> unit
     @param items Choices to display.
     @param to_string Render each item as a string.
     @param on_tick Optional callback invoked on each render tick (e.g. to refresh items).
+    @param is_enabled Optional predicate to determine if an item is selectable. Disabled items are greyed out and skipped during navigation. Defaults to all items enabled.
     @param on_select Called when the user picks an item. *)
 val open_choice_modal :
   title:string ->
   items:'a list ->
   to_string:('a -> string) ->
   ?on_tick:(unit -> unit) ->
+  ?is_enabled:('a -> bool) ->
   on_select:('a -> unit) ->
   unit ->
   unit

--- a/src/ui/pages/wallets_page.ml
+++ b/src/ui/pages/wallets_page.ml
@@ -1628,7 +1628,8 @@ let run_onchain_operation ~base_dir ~description ~args ~network ?(endpoint = "")
       offer_download_or_error ~action_label:"perform operation"
   | Some client ->
       let full_args =
-        (client :: "--base-dir" :: base_dir :: args) @ ["--burn-cap"; "1"]
+        (client :: "--base-dir" :: base_dir :: "--wait" :: "none" :: args)
+        @ ["--burn-cap"; "1"]
       in
       let endpoint_opt =
         if String.length endpoint > 0 then Some endpoint

--- a/src/ui/pages/wallets_page.ml
+++ b/src/ui/pages/wallets_page.ml
@@ -1618,8 +1618,9 @@ let extract_client_error raw_err =
     Shows a real-time checklist (submitting → included → confirmed → finalized).
     Adds [--burn-cap 1] automatically.
     @param network Network name for explorer links in tracking modal.
+    @param endpoint Optional specific endpoint to use. If empty, resolves from network.
     @param on_done Optional cleanup callback invoked regardless of outcome. *)
-let run_onchain_operation ~base_dir ~description ~args ~network
+let run_onchain_operation ~base_dir ~description ~args ~network ?(endpoint = "")
     ?(on_done = fun () -> ()) ~on_success () =
   match find_octez_client ~base_dir with
   | None ->
@@ -1629,9 +1630,11 @@ let run_onchain_operation ~base_dir ~description ~args ~network
       let full_args =
         (client :: "--base-dir" :: base_dir :: args) @ ["--burn-cap"; "1"]
       in
-      let endpoint =
-        let endpoints = Keys_scheduler.get_endpoints_for_network ~network in
-        match endpoints with ep :: _ -> Some ep | [] -> None
+      let endpoint_opt =
+        if String.length endpoint > 0 then Some endpoint
+        else
+          let endpoints = Keys_scheduler.get_endpoints_for_network ~network in
+          match endpoints with ep :: _ -> Some ep | [] -> None
       in
       let step_ref = Atomic.make Instances_wallet.Submitting in
       Instances_wallet.open_tracking_modal ~title:description ~network ~step_ref ;
@@ -1648,7 +1651,7 @@ let run_onchain_operation ~base_dir ~description ~args ~network
                   Atomic.set step_ref (Instances_wallet.Submitted {op_hash}) ;
                   Context.toast_success (description ^ ": operation submitted") ;
                   on_success () ;
-                  (match endpoint with
+                  (match endpoint_opt with
                   | Some ep ->
                       Instances_wallet.poll_operation
                         ~endpoint:ep
@@ -1678,7 +1681,7 @@ let styled_network network =
   if String.equal network "mainnet" then Widgets.themed_warning network
   else network
 
-let confirm_and_run ~base_dir ~title ~message ~args ~network
+let confirm_and_run ~base_dir ~title ~message ~args ~network ~endpoint
     ?(on_done = fun () -> ()) ~on_success () =
   let full_message =
     Printf.sprintf "%s\nNetwork: %s" message (styled_network network)
@@ -1693,6 +1696,7 @@ let confirm_and_run ~base_dir ~title ~message ~args ~network
           ~description:title
           ~args
           ~network
+          ~endpoint
           ~on_done
           ~on_success
           ()
@@ -1720,7 +1724,8 @@ let with_password_if_needed ~base_dir (key : Keys_reader.key_metadata) ~action =
 
 (** Transfer action: pick destination from known addresses, then amount.
     Uses dry-run to estimate fees before executing. *)
-let action_transfer ~base_dir ~network (key : Keys_reader.key_metadata) =
+let action_transfer ~base_dir ~network ~endpoint
+    (key : Keys_reader.key_metadata) =
   pick_address
     ~title:"Transfer: Destination"
     ~exclude_pkh:key.pkh
@@ -1750,12 +1755,8 @@ let action_transfer ~base_dir ~network (key : Keys_reader.key_metadata) =
                       (display_alias ~base_dir key)
                   in
                   let endpoint_args =
-                    let endpoints =
-                      Keys_scheduler.get_endpoints_for_network ~network
-                    in
-                    match endpoints with
-                    | ep :: _ -> ["--endpoint"; ep]
-                    | [] -> []
+                    if String.length endpoint > 0 then ["--endpoint"; endpoint]
+                    else []
                   in
                   let op_args =
                     extra_args @ endpoint_args
@@ -1774,6 +1775,7 @@ let action_transfer ~base_dir ~network (key : Keys_reader.key_metadata) =
                          amount_str)
                     ~args:op_args
                     ~network
+                    ~endpoint
                     ~on_done:cleanup
                     ~on_success:(fun () ->
                       Transfer_mru.add ~pkh:dest_pkh () ;
@@ -1782,8 +1784,8 @@ let action_transfer ~base_dir ~network (key : Keys_reader.key_metadata) =
         ())
 
 (** Register as delegate action. *)
-let action_register_delegate ~base_dir ~network (key : Keys_reader.key_metadata)
-    =
+let action_register_delegate ~base_dir ~network ~endpoint
+    (key : Keys_reader.key_metadata) =
   Modal_helpers.confirm_modal
     ~title:
       (Printf.sprintf
@@ -1805,10 +1807,8 @@ let action_register_delegate ~base_dir ~network (key : Keys_reader.key_metadata)
                 (display_alias ~base_dir key)
             in
             let endpoint_args =
-              let endpoints =
-                Keys_scheduler.get_endpoints_for_network ~network
-              in
-              match endpoints with ep :: _ -> ["--endpoint"; ep] | [] -> []
+              if String.length endpoint > 0 then ["--endpoint"; endpoint]
+              else []
             in
             run_onchain_operation
               ~base_dir
@@ -1817,13 +1817,15 @@ let action_register_delegate ~base_dir ~network (key : Keys_reader.key_metadata)
                 (extra_args @ endpoint_args
                 @ ["register"; "key"; key.alias; "as"; "delegate"])
               ~network
+              ~endpoint
               ~on_done:cleanup
               ~on_success:(fun () -> Keys_scheduler.force_refresh ~pkh:key.pkh)
               ()))
     ()
 
 (** Delegate to another baker. *)
-let action_delegate_to ~base_dir ~network (key : Keys_reader.key_metadata) =
+let action_delegate_to ~base_dir ~network ~endpoint
+    (key : Keys_reader.key_metadata) =
   pick_address
     ~title:"Delegate to"
     ~exclude_pkh:key.pkh
@@ -1837,8 +1839,7 @@ let action_delegate_to ~base_dir ~network (key : Keys_reader.key_metadata) =
               baker_pkh
           in
           let endpoint_args =
-            let endpoints = Keys_scheduler.get_endpoints_for_network ~network in
-            match endpoints with ep :: _ -> ["--endpoint"; ep] | [] -> []
+            if String.length endpoint > 0 then ["--endpoint"; endpoint] else []
           in
           run_onchain_operation
             ~base_dir
@@ -1847,12 +1848,14 @@ let action_delegate_to ~base_dir ~network (key : Keys_reader.key_metadata) =
               (extra_args @ endpoint_args
               @ ["set"; "delegate"; "for"; key.alias; "to"; baker_pkh])
             ~network
+            ~endpoint
             ~on_done:cleanup
             ~on_success:(fun () -> Keys_scheduler.force_refresh ~pkh:key.pkh)
             ()))
 
 (** Undelegate action. *)
-let action_undelegate ~base_dir ~network (key : Keys_reader.key_metadata) =
+let action_undelegate ~base_dir ~network ~endpoint
+    (key : Keys_reader.key_metadata) =
   Modal_helpers.confirm_modal
     ~title:(Printf.sprintf "Undelegate '%s'?" (display_alias ~base_dir key))
     ~message:
@@ -1869,10 +1872,8 @@ let action_undelegate ~base_dir ~network (key : Keys_reader.key_metadata) =
               Printf.sprintf "Undelegate '%s'" (display_alias ~base_dir key)
             in
             let endpoint_args =
-              let endpoints =
-                Keys_scheduler.get_endpoints_for_network ~network
-              in
-              match endpoints with ep :: _ -> ["--endpoint"; ep] | [] -> []
+              if String.length endpoint > 0 then ["--endpoint"; endpoint]
+              else []
             in
             run_onchain_operation
               ~base_dir
@@ -1881,13 +1882,14 @@ let action_undelegate ~base_dir ~network (key : Keys_reader.key_metadata) =
                 (extra_args @ endpoint_args
                 @ ["withdraw"; "delegate"; "from"; key.alias])
               ~network
+              ~endpoint
               ~on_done:cleanup
               ~on_success:(fun () -> Keys_scheduler.force_refresh ~pkh:key.pkh)
               ()))
     ()
 
 (** Stake action: stake tez for a key with dry-run confirmation. *)
-let action_stake ~base_dir ~network (key : Keys_reader.key_metadata) =
+let action_stake ~base_dir ~network ~endpoint (key : Keys_reader.key_metadata) =
   Modal_helpers.prompt_text_modal
     ~title:"Stake: Amount (tez)"
     ~width:30
@@ -1912,10 +1914,8 @@ let action_stake ~base_dir ~network (key : Keys_reader.key_metadata) =
                   (display_alias ~base_dir key)
               in
               let endpoint_args =
-                let endpoints =
-                  Keys_scheduler.get_endpoints_for_network ~network
-                in
-                match endpoints with ep :: _ -> ["--endpoint"; ep] | [] -> []
+                if String.length endpoint > 0 then ["--endpoint"; endpoint]
+                else []
               in
               let op_args =
                 extra_args @ endpoint_args
@@ -1931,6 +1931,7 @@ let action_stake ~base_dir ~network (key : Keys_reader.key_metadata) =
                      amount_str)
                 ~args:op_args
                 ~network
+                ~endpoint
                 ~on_done:cleanup
                 ~on_success:(fun () ->
                   Keys_scheduler.force_refresh ~pkh:key.pkh)
@@ -1938,7 +1939,8 @@ let action_stake ~base_dir ~network (key : Keys_reader.key_metadata) =
     ()
 
 (** Unstake action: unstake tez for a key with dry-run confirmation. *)
-let action_unstake ~base_dir ~network (key : Keys_reader.key_metadata) =
+let action_unstake ~base_dir ~network ~endpoint (key : Keys_reader.key_metadata)
+    =
   Modal_helpers.prompt_text_modal
     ~title:"Unstake: Amount (tez)"
     ~width:30
@@ -1963,10 +1965,8 @@ let action_unstake ~base_dir ~network (key : Keys_reader.key_metadata) =
                   (display_alias ~base_dir key)
               in
               let endpoint_args =
-                let endpoints =
-                  Keys_scheduler.get_endpoints_for_network ~network
-                in
-                match endpoints with ep :: _ -> ["--endpoint"; ep] | [] -> []
+                if String.length endpoint > 0 then ["--endpoint"; endpoint]
+                else []
               in
               let op_args =
                 extra_args @ endpoint_args
@@ -1982,6 +1982,7 @@ let action_unstake ~base_dir ~network (key : Keys_reader.key_metadata) =
                      amount_str)
                 ~args:op_args
                 ~network
+                ~endpoint
                 ~on_done:cleanup
                 ~on_success:(fun () ->
                   Keys_scheduler.force_refresh ~pkh:key.pkh)
@@ -2102,56 +2103,90 @@ let open_create_import_modal ~base_dir =
       | `Import -> action_import_key ~base_dir)
     ()
 
+(** Represents a network endpoint choice: network, endpoint, and source. *)
+type network_choice = {
+  network : string;
+  endpoint : string;
+  source : string; (* "local" or "public" *)
+}
+
 (** Prompt for network if a key has access to multiple networks.
     Lists all networks with available endpoints (local instances or public
     nodes), annotated with balance if known. Skips the picker if only one.
     For sandbox wallet groups, always uses the sandbox's own network without
-    prompting — sandbox keys must not be used on other networks. *)
+    prompting — sandbox keys must not be used on other networks.
+    When a network has both local and public endpoints, shows both as separate
+    choices, allowing the user to select which endpoint to use. *)
 let with_network (key : Keys_reader.key_metadata) ~(group : enriched_group)
     ~action =
   match group.sandbox_name with
   | Some _ ->
       let network = match group.networks with n :: _ -> n | [] -> "mainnet" in
-      action ~network
+      (* For sandbox, find the local endpoint *)
+      let endpoint =
+        let endpoints = Keys_scheduler.get_endpoints_for_network ~network in
+        match endpoints with ep :: _ -> ep | [] -> ""
+      in
+      action ~network ~endpoint
   | None -> (
       let wallet_data = Keys_scheduler.get_wallet_data ~pkh:key.pkh in
-      (* All networks with running local nodes *)
-      let local_networks =
+      (* Collect (network, endpoint, source) from local running nodes *)
+      let local_choices =
         Data.load_service_states ()
         |> List.filter (fun (st : Data.Service_state.t) ->
             String.equal st.service.role "node"
             && match st.status with Running -> true | _ -> false)
         |> List.map (fun (st : Data.Service_state.t) ->
-            Network_name.normalize st.service.network)
-        |> List.sort_uniq String.compare
+            {
+              network = Network_name.normalize st.service.network;
+              endpoint = Rpc_addr.to_endpoint st.service.rpc_addr;
+              source = "local";
+            })
       in
-      (* All networks with public nodes *)
-      let public_networks =
+      (* Collect from public nodes *)
+      let public_choices =
         Public_nodes_cache.get_nodes ()
-        |> List.filter_map (fun (n : Public_nodes_cache.node_info) -> n.network)
-        |> List.sort_uniq String.compare
+        |> List.filter_map (fun (n : Public_nodes_cache.node_info) ->
+            match n.network with
+            | Some net ->
+                Some {network = net; endpoint = n.rpc_addr; source = "public"}
+            | None -> None)
       in
-      let all_networks =
-        List.sort_uniq String.compare (local_networks @ public_networks)
+      (* Deduplicate by (network, source) — keep one entry per network per source *)
+      let all_choices = local_choices @ public_choices in
+      let seen = Hashtbl.create 16 in
+      let choices =
+        List.filter
+          (fun c ->
+            let key = (c.network, c.source) in
+            if Hashtbl.mem seen key then false
+            else (
+              Hashtbl.replace seen key true ;
+              true))
+          all_choices
       in
-      (* Fallback to group networks if nothing else *)
-      let networks =
-        if all_networks = [] then List.sort_uniq String.compare group.networks
-        else all_networks
+      (* Sort: local first within each network, then alphabetical *)
+      let choices =
+        List.sort
+          (fun a b ->
+            let cmp_net = String.compare a.network b.network in
+            if cmp_net <> 0 then cmp_net
+            else String.compare a.source b.source (* "local" < "public" *))
+          choices
       in
-      match networks with
-      | [] -> action ~network:"mainnet"
-      | [single] -> action ~network:single
+      match choices with
+      | [] -> action ~network:"mainnet" ~endpoint:""
+      | [single] -> action ~network:single.network ~endpoint:single.endpoint
       | multiple ->
           Modal_helpers.open_choice_modal
             ~title:"Select network"
             ~items:multiple
-            ~to_string:(fun net ->
+            ~to_string:(fun c ->
               let balance_str =
                 match
                   List.find_opt
                     (fun (wd : Keys_scheduler.wallet_data) ->
-                      String.equal wd.network net)
+                      String.equal wd.network c.network)
                     wallet_data
                 with
                 | Some wd ->
@@ -2160,14 +2195,13 @@ let with_network (key : Keys_reader.key_metadata) ~(group : enriched_group)
                       (Baker_wallet_data.format_tez wd.spendable_balance)
                 | None -> ""
               in
-              let source =
-                if List.exists (String.equal net) local_networks then "local"
-                else "public"
+              let label =
+                Printf.sprintf "%s  (%s)%s" c.network c.source balance_str
               in
-              let label = Printf.sprintf "%s  (%s)%s" net source balance_str in
-              if String.equal net "mainnet" then Widgets.themed_warning label
+              if String.equal c.network "mainnet" then
+                Widgets.themed_warning label
               else label)
-            ~on_select:(fun net -> action ~network:net)
+            ~on_select:(fun c -> action ~network:c.network ~endpoint:c.endpoint)
             ())
 
 (** Show the action modal for a selected key. *)
@@ -2219,23 +2253,23 @@ let open_key_action_modal ~(group : enriched_group)
     ~on_select:(function
       | `Copy -> copy_to_clipboard key.pkh
       | `Transfer ->
-          with_network key ~group ~action:(fun ~network ->
-              action_transfer ~base_dir ~network key)
+          with_network key ~group ~action:(fun ~network ~endpoint ->
+              action_transfer ~base_dir ~network ~endpoint key)
       | `Stake ->
-          with_network key ~group ~action:(fun ~network ->
-              action_stake ~base_dir ~network key)
+          with_network key ~group ~action:(fun ~network ~endpoint ->
+              action_stake ~base_dir ~network ~endpoint key)
       | `Unstake ->
-          with_network key ~group ~action:(fun ~network ->
-              action_unstake ~base_dir ~network key)
+          with_network key ~group ~action:(fun ~network ~endpoint ->
+              action_unstake ~base_dir ~network ~endpoint key)
       | `Register ->
-          with_network key ~group ~action:(fun ~network ->
-              action_register_delegate ~base_dir ~network key)
+          with_network key ~group ~action:(fun ~network ~endpoint ->
+              action_register_delegate ~base_dir ~network ~endpoint key)
       | `Delegate_to ->
-          with_network key ~group ~action:(fun ~network ->
-              action_delegate_to ~base_dir ~network key)
+          with_network key ~group ~action:(fun ~network ~endpoint ->
+              action_delegate_to ~base_dir ~network ~endpoint key)
       | `Undelegate ->
-          with_network key ~group ~action:(fun ~network ->
-              action_undelegate ~base_dir ~network key)
+          with_network key ~group ~action:(fun ~network ~endpoint ->
+              action_undelegate ~base_dir ~network ~endpoint key)
       | `Rename -> action_rename ~base_dir key
       | `Forget -> action_forget ~base_dir key)
     ()
@@ -2391,7 +2425,17 @@ let open_batch_modal ps =
                 let network =
                   match group.networks with n :: _ -> n | [] -> "mainnet"
                 in
-                action_register_delegate ~base_dir:group.base_dir ~network key)
+                let endpoint =
+                  let endpoints =
+                    Keys_scheduler.get_endpoints_for_network ~network
+                  in
+                  match endpoints with ep :: _ -> ep | [] -> ""
+                in
+                action_register_delegate
+                  ~base_dir:group.base_dir
+                  ~network
+                  ~endpoint
+                  key)
               selected_keys
         | `Batch_delegate ->
             (* Pick a single baker address, then delegate all selected keys *)
@@ -2419,13 +2463,16 @@ let open_batch_modal ps =
                       ~base_dir:group.base_dir
                       key
                       ~action:(fun ~extra_args ~cleanup ->
-                        let endpoint_args =
+                        let endpoint =
                           let endpoints =
                             Keys_scheduler.get_endpoints_for_network ~network
                           in
-                          match endpoints with
-                          | ep :: _ -> ["--endpoint"; ep]
-                          | [] -> []
+                          match endpoints with ep :: _ -> ep | [] -> ""
+                        in
+                        let endpoint_args =
+                          if String.length endpoint > 0 then
+                            ["--endpoint"; endpoint]
+                          else []
                         in
                         run_onchain_operation
                           ~base_dir:group.base_dir
@@ -2445,6 +2492,7 @@ let open_batch_modal ps =
                                 baker_pkh;
                               ])
                           ~network
+                          ~endpoint
                           ~on_done:cleanup
                           ~on_success:(fun () ->
                             Keys_scheduler.force_refresh ~pkh:key.pkh)

--- a/src/ui/pages/wallets_page.ml
+++ b/src/ui/pages/wallets_page.ml
@@ -2111,6 +2111,7 @@ type network_choice = {
   label : string;
       (* e.g. "node-shadownet (shadownet)" or "shadownet (public)" *)
   is_local : bool;
+  syncing : bool; (* true when node is not fully bootstrapped *)
 }
 
 (** Prompt for network if a key has access to multiple networks.
@@ -2141,11 +2142,17 @@ let with_network (key : Keys_reader.key_metadata) ~(group : enriched_group)
             && match st.status with Running -> true | _ -> false)
         |> List.map (fun (st : Data.Service_state.t) ->
             let net = Network_name.normalize st.service.network in
+            let syncing =
+              match Rpc_metrics.get ~instance:st.service.instance with
+              | Some m -> not (m.bootstrapped = Some true)
+              | None -> true (* unknown status = assume syncing *)
+            in
             {
               network = net;
               endpoint = Rpc_addr.to_endpoint st.service.rpc_addr;
               label = Printf.sprintf "%s (%s)" st.service.instance net;
               is_local = true;
+              syncing;
             })
       in
       (* Collect from public nodes *)
@@ -2160,6 +2167,7 @@ let with_network (key : Keys_reader.key_metadata) ~(group : enriched_group)
                     endpoint = n.rpc_addr;
                     label = Printf.sprintf "%s (public)" net;
                     is_local = false;
+                    syncing = false;
                   }
             | None -> None)
       in
@@ -2198,7 +2206,13 @@ let with_network (key : Keys_reader.key_metadata) ~(group : enriched_group)
       in
       match choices with
       | [] -> action ~network:"mainnet" ~endpoint:""
-      | [single] -> action ~network:single.network ~endpoint:single.endpoint
+      | [single] ->
+          if single.syncing then
+            Context.toast_error
+              (Printf.sprintf
+                 "%s is still syncing — cannot submit operations"
+                 single.label)
+          else action ~network:single.network ~endpoint:single.endpoint
       | multiple ->
           Modal_helpers.open_choice_modal
             ~title:"Select network"
@@ -2217,10 +2231,14 @@ let with_network (key : Keys_reader.key_metadata) ~(group : enriched_group)
                       (Baker_wallet_data.format_tez wd.spendable_balance)
                 | None -> ""
               in
-              let label = Printf.sprintf "%s%s" c.label balance_str in
+              let sync_str = if c.syncing then "  (syncing..)" else "" in
+              let label =
+                Printf.sprintf "%s%s%s" c.label balance_str sync_str
+              in
               if String.equal c.network "mainnet" then
                 Widgets.themed_warning label
               else label)
+            ~is_enabled:(fun c -> not c.syncing)
             ~on_select:(fun c -> action ~network:c.network ~endpoint:c.endpoint)
             ())
 

--- a/src/ui/pages/wallets_page.ml
+++ b/src/ui/pages/wallets_page.ml
@@ -2121,7 +2121,8 @@ let with_network (key : Keys_reader.key_metadata) ~(group : enriched_group)
         |> List.filter (fun (st : Data.Service_state.t) ->
             String.equal st.service.role "node"
             && match st.status with Running -> true | _ -> false)
-        |> List.map (fun (st : Data.Service_state.t) -> st.service.network)
+        |> List.map (fun (st : Data.Service_state.t) ->
+            Network_name.normalize st.service.network)
         |> List.sort_uniq String.compare
       in
       (* All networks with public nodes *)

--- a/src/ui/pages/wallets_page.ml
+++ b/src/ui/pages/wallets_page.ml
@@ -2103,11 +2103,13 @@ let open_create_import_modal ~base_dir =
       | `Import -> action_import_key ~base_dir)
     ()
 
-(** Represents a network endpoint choice: network, endpoint, and source. *)
+(** Represents a network endpoint choice: network, endpoint, and display label. *)
 type network_choice = {
   network : string;
   endpoint : string;
-  source : string; (* "local" or "public" *)
+  label : string;
+      (* e.g. "node-shadownet (shadownet)" or "shadownet (public)" *)
+  is_local : bool;
 }
 
 (** Prompt for network if a key has access to multiple networks.
@@ -2130,17 +2132,19 @@ let with_network (key : Keys_reader.key_metadata) ~(group : enriched_group)
       action ~network ~endpoint
   | None -> (
       let wallet_data = Keys_scheduler.get_wallet_data ~pkh:key.pkh in
-      (* Collect (network, endpoint, source) from local running nodes *)
+      (* Collect (network, endpoint, label) from local running nodes *)
       let local_choices =
         Data.load_service_states ()
         |> List.filter (fun (st : Data.Service_state.t) ->
             String.equal st.service.role "node"
             && match st.status with Running -> true | _ -> false)
         |> List.map (fun (st : Data.Service_state.t) ->
+            let net = Network_name.normalize st.service.network in
             {
-              network = Network_name.normalize st.service.network;
+              network = net;
               endpoint = Rpc_addr.to_endpoint st.service.rpc_addr;
-              source = "local";
+              label = Printf.sprintf "%s (%s)" st.service.instance net;
+              is_local = true;
             })
       in
       (* Collect from public nodes *)
@@ -2149,29 +2153,46 @@ let with_network (key : Keys_reader.key_metadata) ~(group : enriched_group)
         |> List.filter_map (fun (n : Public_nodes_cache.node_info) ->
             match n.network with
             | Some net ->
-                Some {network = net; endpoint = n.rpc_addr; source = "public"}
+                Some
+                  {
+                    network = net;
+                    endpoint = n.rpc_addr;
+                    label = Printf.sprintf "%s (public)" net;
+                    is_local = false;
+                  }
             | None -> None)
       in
-      (* Deduplicate by (network, source) — keep one entry per network per source *)
-      let all_choices = local_choices @ public_choices in
-      let seen = Hashtbl.create 16 in
-      let choices =
+      (* Deduplicate: local by endpoint (keep each instance), public by
+         network (one entry per network — multiple providers share one slot). *)
+      let seen_ep = Hashtbl.create 16 in
+      let local_deduped =
         List.filter
           (fun c ->
-            let key = (c.network, c.source) in
-            if Hashtbl.mem seen key then false
+            if Hashtbl.mem seen_ep c.endpoint then false
             else (
-              Hashtbl.replace seen key true ;
+              Hashtbl.replace seen_ep c.endpoint true ;
               true))
-          all_choices
+          local_choices
       in
-      (* Sort: local first within each network, then alphabetical *)
+      let seen_net = Hashtbl.create 16 in
+      let public_deduped =
+        List.filter
+          (fun c ->
+            if Hashtbl.mem seen_net c.network then false
+            else (
+              Hashtbl.replace seen_net c.network true ;
+              true))
+          public_choices
+      in
+      let choices = local_deduped @ public_deduped in
+      (* Sort: local instances first, then public, alphabetical within each *)
       let choices =
         List.sort
           (fun a b ->
-            let cmp_net = String.compare a.network b.network in
-            if cmp_net <> 0 then cmp_net
-            else String.compare a.source b.source (* "local" < "public" *))
+            match (a.is_local, b.is_local) with
+            | true, false -> -1
+            | false, true -> 1
+            | _ -> String.compare a.label b.label)
           choices
       in
       match choices with
@@ -2195,9 +2216,7 @@ let with_network (key : Keys_reader.key_metadata) ~(group : enriched_group)
                       (Baker_wallet_data.format_tez wd.spendable_balance)
                 | None -> ""
               in
-              let label =
-                Printf.sprintf "%s  (%s)%s" c.network c.source balance_str
-              in
+              let label = Printf.sprintf "%s%s" c.label balance_str in
               if String.equal c.network "mainnet" then
                 Widgets.themed_warning label
               else label)

--- a/test/test_baker_ops.ml
+++ b/test/test_baker_ops.ml
@@ -39,6 +39,8 @@ let test_build_register () =
       bin;
       "--endpoint";
       endpoint;
+      "--wait";
+      "none";
       "register";
       "key";
       alias;
@@ -66,6 +68,8 @@ let test_build_stake () =
       bin;
       "--endpoint";
       endpoint;
+      "--wait";
+      "none";
       "stake";
       "1000";
       "for";
@@ -92,6 +96,8 @@ let test_build_unstake () =
       bin;
       "--endpoint";
       endpoint;
+      "--wait";
+      "none";
       "unstake";
       "500";
       "for";
@@ -118,6 +124,8 @@ let test_build_finalize_unstake () =
       bin;
       "--endpoint";
       endpoint;
+      "--wait";
+      "none";
       "finalize";
       "unstake";
       "for";
@@ -144,6 +152,8 @@ let test_build_transfer () =
       bin;
       "--endpoint";
       endpoint;
+      "--wait";
+      "none";
       "transfer";
       "100";
       "from";
@@ -172,6 +182,8 @@ let test_build_set_delegate_params () =
       bin;
       "--endpoint";
       endpoint;
+      "--wait";
+      "none";
       "set";
       "delegate";
       "parameters";
@@ -203,6 +215,8 @@ let test_build_update_consensus_key () =
       bin;
       "--endpoint";
       endpoint;
+      "--wait";
+      "none";
       "update";
       "consensus";
       "key";
@@ -232,6 +246,8 @@ let test_build_submit_proposals () =
       bin;
       "--endpoint";
       endpoint;
+      "--wait";
+      "none";
       "submit";
       "proposals";
       "for";
@@ -260,6 +276,8 @@ let test_build_submit_ballot () =
       bin;
       "--endpoint";
       endpoint;
+      "--wait";
+      "none";
       "submit";
       "ballot";
       "for";
@@ -304,6 +322,8 @@ let test_build_with_base_dir () =
       "/home/tezos/.tezos-client";
       "--endpoint";
       endpoint;
+      "--wait";
+      "none";
       "register";
       "key";
       alias;
@@ -333,6 +353,8 @@ let test_build_with_password_file () =
       "/home/mathias/passwd";
       "--endpoint";
       endpoint;
+      "--wait";
+      "none";
       "register";
       "key";
       alias;
@@ -364,6 +386,8 @@ let test_build_with_base_dir_and_password_file () =
       "/home/mathias/passwd";
       "--endpoint";
       endpoint;
+      "--wait";
+      "none";
       "stake";
       "500";
       "for";

--- a/test/test_wallets_page.ml
+++ b/test/test_wallets_page.ml
@@ -14,6 +14,7 @@
 open Alcotest
 open Octez_manager_lib
 module Keys_page = Octez_manager_ui.Wallets_page
+module Keys_scheduler = Octez_manager_ui.Keys_scheduler
 module Main_shell = Octez_manager_ui.Main_shell
 module HD = Lib_miaou_internal.Headless_driver
 module TH = Tui_test_helpers_lib.Tui_test_helpers
@@ -414,6 +415,65 @@ let fold_tests =
       test_tab_toggles_fold_via_main_shell );
   ]
 
+(* ============================================================ *)
+(* Scheduler Initial Fetch Tests *)
+(* ============================================================ *)
+
+(** Regression test for bug: wallet balances not fetched on page load.
+    
+    Root cause: The scheduler_loop never proactively fetches balances for
+    tracked keys. It only:
+    1. Starts the worker queue
+    2. Sleeps 3 seconds
+    3. Loops every 30s refreshing only tzkt aliases
+    
+    The only way balances get fetched is via service_cycle (which has a 
+    2-second debounce and only works when cursor is on a KeyItem) or via 
+    force_refresh called after user actions.
+    
+    Fix: Extract a helper function fetch_all_tracked_keys and call it in
+    scheduler_loop both initially (after sleep) and in the periodic loop.
+    
+    This test verifies the fix by:
+    1. Setting tracked keys via set_keys
+    2. Verifying they can be retrieved via get_tracked_pkhs
+    3. Verifying fetch_all_tracked_keys doesn't crash
+    
+    This validates the data flow from set_keys → tracked_keys → iteration
+    logic that the scheduler loop uses.
+*)
+let test_scheduler_proactive_fetch () =
+  (* Set some test keys *)
+  Keys_scheduler.set_keys
+    [
+      ("/home/test/.tezos-client", ["tz1abc"; "tz1def"]);
+      ("/home/test/.local/share/octez/baker1", ["tz1ghi"]);
+    ] ;
+
+  (* Verify tracked PKHs are retrievable *)
+  let tracked = Keys_scheduler.Internal_for_tests.get_tracked_pkhs () in
+  check (list string) "all PKHs tracked" ["tz1abc"; "tz1def"; "tz1ghi"] tracked ;
+
+  (* Call fetch_all_tracked_keys - should not crash *)
+  (* This will call request_fetch for each PKH, which submits to the worker
+     queue. Since the worker isn't started in tests, requests are just queued. *)
+  Keys_scheduler.Internal_for_tests.fetch_all_tracked_keys () ;
+
+  (* Verify wallet data is still empty (worker not running, so no fetches complete) *)
+  let data_abc = Keys_scheduler.get_wallet_data ~pkh:"tz1abc" in
+  check int "no data fetched (worker not running)" 0 (List.length data_abc) ;
+
+  (* Success: fetch_all_tracked_keys executed without raising exceptions,
+     proving the iteration logic and mutex access work correctly. *)
+  check bool "test completed" true true
+
+let scheduler_tests =
+  [
+    ( "scheduler fetches balances proactively on startup",
+      `Quick,
+      test_scheduler_proactive_fetch );
+  ]
+
 let () =
   Alcotest.run
     "Wallets_page"
@@ -421,4 +481,5 @@ let () =
       ("base_dir_deduplication", base_dir_tests);
       ("fold_unfold", fold_tests);
       ("refresh_on_dirty_flag", refresh_tests);
+      ("scheduler_initial_fetch", scheduler_tests);
     ]


### PR DESCRIPTION
## Summary

A batch of wallet page improvements addressing several UX issues:

- **Proactive balance fetching**: Balances are now fetched on scheduler startup and every 30s cycle, instead of only when the user interacts with a specific key
- **Network name normalization**: Network picker shows clean names (e.g. "shadownet") instead of raw URLs
- **Local + public endpoint choice**: When both local nodes and public endpoints are available, the picker shows separate entries for each, with instance names for local entries
- **`--wait none` for operations**: Prevents octez-client from hanging at "Waiting for the node to be bootstrapped..." on non-synced nodes (applied to both wallet and baker operations)
- **Syncing endpoint indicator**: Non-bootstrapped local nodes are greyed out with "(syncing..)" label, cursor skips over them, and Enter is blocked — preventing accidental submission to syncing nodes

### New `~is_enabled` parameter for `open_choice_modal`

Added a generic `?is_enabled:('a -> bool)` predicate to `modal_helpers.ml`. Disabled items are rendered with `themed_muted`, the cursor auto-skips them on navigation, and Enter is ignored. This is reusable for any future modal that needs disabled items.

## Commits

| Commit | Description |
|--------|-------------|
| `fa984b0d` | Fetch balances proactively on scheduler startup + regression test |
| `df84ed7b` | Normalize network names in wallet action network picker |
| `070fdb30` | Allow choosing between local and public endpoints for operations |
| `8f6d3a71` | Show instance names for local endpoints in network picker |
| `c22a2708` | Add `--wait none` to prevent operations hanging on non-bootstrapped nodes |
| `608a105e` | Grey out and skip syncing endpoints in network picker |
| `439ba1d8` | Changelog entries |

## Testing

- Unit test added for proactive balance fetch (`test_wallets_page.ml`)
- Baker ops tests updated for `--wait none` placement (`test_baker_ops.ml`)
- All commits compile independently (`git rebase --exec 'dune build' main` passes)
- Visually verified in tmux: syncing endpoints display "(syncing..)" text, cursor skips them on Up/Down, and they cannot be selected