### PR TITLE
fix(ci): add missing miaou-registry pin to release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,7 +434,8 @@ jobs:
           opam pin add miaou-driver-matrix "$MIAOU_GIT_URL" --no-action
           opam pin add miaou-driver-web "$MIAOU_GIT_URL" --no-action
           opam pin add miaou-runner "$MIAOU_GIT_URL" --no-action
-          opam install ppx_forbid miaou-core miaou-driver-term miaou-driver-matrix miaou-driver-web miaou-runner eio_posix
+          opam pin add miaou-registry "$MIAOU_GIT_URL" --no-action
+          opam install ppx_forbid ppx_enforce miaou-core miaou-driver-term miaou-driver-matrix miaou-driver-web miaou-runner miaou-registry eio_posix
 
       - name: Build static binary
         run: |


### PR DESCRIPTION
## Summary

- Adds `miaou-registry` pin and install to the Release job's opam setup
- The Build and Test job already had it, but the Release job was missing it
- This caused the v1.0.0-rc1 release build to fail with: `miaou-core -> miaou-registry: unknown package`

Once merged, we can delete the `v1.0.0-rc1` tag and re-tag to get working release binaries.