### PR TITLE
fix(ci): add missing ppx_enforce pin to release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,6 +429,7 @@ jobs:
         if: steps.cache-opam.outputs.cache-hit != 'true'
         run: |
           opam pin add ppx_forbid "$PPX_FORBID_GIT_URL" --no-action
+          opam pin add ppx_enforce "$PPX_FORBID_GIT_URL" --no-action
           opam pin add miaou-core "$MIAOU_GIT_URL" --no-action
           opam pin add miaou-driver-term "$MIAOU_GIT_URL" --no-action
           opam pin add miaou-driver-matrix "$MIAOU_GIT_URL" --no-action


### PR DESCRIPTION
## Summary

- Adds `opam pin add ppx_enforce` to the Release job (was already in Build and Test)
- The install line references `ppx_enforce` but it was never pinned, causing `No package named ppx_enforce found`
- Second fix for the v1.0.0-rc1 release workflow