### PR TITLE
fix(ci): add missing miaou-registry pin and octez-index stub to CI Dockerfiles

### DIFF
--- a/Dockerfile.ci-debian
+++ b/Dockerfile.ci-debian
@@ -54,7 +54,8 @@ RUN eval $(opam env) && \
     opam pin add miaou-driver-matrix git+https://github.com/trilitech/miaou.git --no-action --yes && \
     opam pin add miaou-driver-web git+https://github.com/trilitech/miaou.git --no-action --yes && \
     opam pin add miaou-runner git+https://github.com/trilitech/miaou.git --no-action --yes && \
-    opam install -y miaou-core miaou-driver-term miaou-driver-matrix miaou-driver-web miaou-runner
+    opam pin add miaou-registry git+https://github.com/trilitech/miaou.git --no-action --yes && \
+    opam install -y miaou-core miaou-driver-term miaou-driver-matrix miaou-driver-web miaou-runner miaou-registry
 
 # Clean up opam cache
 RUN eval $(opam env) && opam clean -a -c -s --logs

--- a/test/integration/cli-tester/Dockerfile.coverage
+++ b/test/integration/cli-tester/Dockerfile.coverage
@@ -50,6 +50,10 @@ RUN echo "Downloading signatory ${SIGNATORY_VERSION}..." && \
     chmod +x /usr/local/bin/signatory && \
     rm -f /tmp/signatory.tar.gz
 
+# Create stub octez-index binary (no public releases yet)
+RUN printf '#!/bin/sh\necho "octez-index stub"\n' > /usr/local/bin/octez-index && \
+    chmod +x /usr/local/bin/octez-index
+
 # Download Zcash/Sapling parameters required for node operation
 ARG ZCASH_PARAMS_URL=https://download.z.cash/downloads
 RUN mkdir -p /usr/local/share/zcash-params && \


### PR DESCRIPTION
## Summary

- Add `miaou-registry` opam pin to `Dockerfile.ci-debian` (fixes **Build Debian CI Image** workflow)
- Add `octez-index` stub binary to `Dockerfile.coverage` (fixes **Coverage Report** workflow — golden path Step 9 and `index/01-install.sh`)

## Root Cause

Two independent issues causing CI red on main:

1. **Dockerfile.ci-debian**: Miaou added `miaou-registry` as a new package but it was never pinned in this Dockerfile, causing opam solver failure (`Missing dependency: miaou-registry`)

2. **Dockerfile.coverage**: When the `octez-index` stub was added to the regular cli-tester `Dockerfile` (commit 7fd0d589), the coverage variant was not updated. This meant `Paths.which "octez-index"` returned `None` inside the coverage container, causing `default_app_bin_dir` to fall back to `/usr/bin` where no binary exists. Both the golden path TUI test (Step 9: Install Index) and the CLI integration test (`index/01-install.sh`) failed as a result.

Coverage has been red since ~April 10 when the index golden path step was added.