### PR TITLE
feat(ui): add cascade import support to import wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Cascade import in TUI**: Import wizard now supports cascade import mode, allowing users to import services with all their dependencies or dependents in the correct order. Toggle with 'c' in the configure step. (fixes #886)
+
 ## [1.0.0] - 2026-04-16
 
 ### Added

--- a/src/ui/pages/import_wizard.ml
+++ b/src/ui/pages/import_wizard.ml
@@ -26,6 +26,9 @@ type state = {
   custom_name : string option;
   network_override : string option;
   error : string option;
+  cascade : bool;
+  cascade_chain : External_service.t list;
+  cascade_analysis : Import_cascade.dependency_analysis option;
 }
 
 type msg = unit
@@ -44,6 +47,9 @@ let init () =
       custom_name = None;
       network_override = None;
       error = None;
+      cascade = false;
+      cascade_chain = [];
+      cascade_analysis = None;
     }
 
 let update ps _ =
@@ -233,54 +239,74 @@ and start_import ps =
         (fun s -> {s with error = Some "No service selected"})
         ps
   | Some external_svc ->
-      let import_task ~append_log () =
-        let overrides : Import.field_overrides =
-          {
-            network = s.network_override;
-            data_dir = None;
-            base_dir = None;
-            rpc_addr = None;
-            net_addr = None;
-            delegates = None;
-          }
-        in
-        let options : Import.import_options =
-          {
-            strategy = s.strategy;
-            new_instance_name = s.custom_name;
-            overrides;
-            dry_run = false;
-            interactive = false;
-            preserve_data = true;
-            quiet = false;
-          }
-        in
-        match
-          Import.import_service
-            ~on_log:append_log
-            ~all_external_services:s.external_services
-            ~options
-            ~external_svc
-            ()
-        with
-        | Ok _result -> Ok ()
-        | Error e -> Error e
+      (* Shared options construction *)
+      let overrides : Import.field_overrides =
+        {
+          network = s.network_override;
+          data_dir = None;
+          base_dir = None;
+          rpc_addr = None;
+          net_addr = None;
+          delegates = None;
+        }
       in
-      Job_manager.submit
-        ~on_complete:(fun status ->
-          match status with
-          | Job_manager.Succeeded ->
-              Cache.invalidate_all () ;
-              Context.mark_instances_dirty () ;
-              Context.toast_success "Service imported successfully!" ;
-              Context.set_pending_tab Context.Tab_instances ;
-              Context.navigate_back ()
-          | Job_manager.Failed msg ->
-              Context.toast_error (Printf.sprintf "Import failed: %s" msg)
-          | Job_manager.Pending | Job_manager.Running -> ())
-        ~timeout:None
-        ~description:"Import external service"
-        import_task ;
+      let options : Import.import_options =
+        {
+          strategy = s.strategy;
+          new_instance_name = s.custom_name;
+          overrides;
+          dry_run = false;
+          interactive = false;
+          preserve_data = true;
+          quiet = false;
+        }
+      in
+      (* Shared completion callback *)
+      let on_complete status =
+        match status with
+        | Job_manager.Succeeded ->
+            Cache.invalidate_all () ;
+            Context.mark_instances_dirty () ;
+            let msg =
+              if s.cascade then "Cascade import successful!"
+              else "Service imported successfully!"
+            in
+            Context.toast_success msg ;
+            Context.set_pending_tab Context.Tab_instances ;
+            Context.navigate_back ()
+        | Job_manager.Failed msg ->
+            Context.toast_error (Printf.sprintf "Import failed: %s" msg)
+        | Job_manager.Pending | Job_manager.Running -> ()
+      in
+      (* Import task differs based on cascade mode *)
+      let import_task ~append_log () =
+        if s.cascade then
+          match
+            Import.import_cascade
+              ~on_log:append_log
+              ~options
+              ~external_svc
+              ~all_services:s.external_services
+              ()
+          with
+          | Ok _results -> Ok ()
+          | Error e -> Error e
+        else
+          match
+            Import.import_service
+              ~on_log:append_log
+              ~all_external_services:s.external_services
+              ~options
+              ~external_svc
+              ()
+          with
+          | Ok _result -> Ok ()
+          | Error e -> Error e
+      in
+      let description =
+        if s.cascade then "Import cascade" else "Import external service"
+      in
+      Job_manager.submit ~on_complete ~timeout:None ~description import_task ;
       Navigation.update (fun s -> {s with step = Importing; error = None}) ps
 
 let handled_keys () = Miaou.Core.Keys.[Escape; Enter; Up; Down; Tab]
@@ -302,6 +328,29 @@ let move_selection ps delta =
         {s with selected_idx})
     ps
 
+let compute_cascade_chain s =
+  (* Compute cascade chain based on strategy and selected service *)
+  match s.selected_service with
+  | None -> ([], None)
+  | Some svc ->
+      let chain =
+        match s.strategy with
+        | Import.Takeover ->
+            Import_cascade.get_full_cascade
+              ~service:svc
+              ~all_services:s.external_services
+        | Import.Clone ->
+            Import_cascade.get_dependency_chain
+              ~service:svc
+              ~all_services:s.external_services
+      in
+      let analysis =
+        Import_cascade.analyze_dependencies
+          ~services:s.external_services
+          ~target_services:chain
+      in
+      (chain, Some analysis)
+
 let toggle_strategy ps =
   Navigation.update
     (fun s ->
@@ -310,8 +359,33 @@ let toggle_strategy ps =
         | Import.Takeover -> Import.Clone
         | Import.Clone -> Import.Takeover
       in
-      {s with strategy})
+      (* If cascade is enabled, recompute with new strategy *)
+      if s.cascade then
+        let cascade_chain, cascade_analysis = compute_cascade_chain s in
+        {s with strategy; cascade_chain; cascade_analysis}
+      else {s with strategy; cascade_chain = []; cascade_analysis = None})
     ps
+
+let toggle_cascade ps =
+  let s = ps.Navigation.s in
+  let new_cascade = not s.cascade in
+  if new_cascade then
+    (* Cascade enabled: compute the chain *)
+    let cascade_chain, cascade_analysis = compute_cascade_chain s in
+    Navigation.update
+      (fun s -> {s with cascade = new_cascade; cascade_chain; cascade_analysis})
+      ps
+  else
+    (* Cascade disabled: clear the chain *)
+    Navigation.update
+      (fun s ->
+        {
+          s with
+          cascade = new_cascade;
+          cascade_chain = [];
+          cascade_analysis = None;
+        })
+      ps
 
 let header s =
   let step_text =
@@ -401,6 +475,7 @@ let view ps ~focus:_ ~size =
               | Import.Takeover -> "Takeover (disable original)"
               | Import.Clone -> "Clone (keep original)"
             in
+            let cascade_text = if s.cascade then "Yes" else "No" in
             [
               "";
               Printf.sprintf
@@ -417,6 +492,7 @@ let view ps ~focus:_ ~size =
                      (External_service.value_or
                         ~default:"(auto-detect)"
                         svc.config.network));
+              Printf.sprintf "  Cascade:       %s" cascade_text;
               "";
             ]
             @ (let missing =
@@ -432,7 +508,42 @@ let view ps ~focus:_ ~size =
                    "";
                  ]
                else [])
-            @ [""; "Space: Toggle strategy  Enter: Next  Esc: Back"])
+            @ (if s.cascade then
+                 match s.cascade_analysis with
+                 | None ->
+                     [""; Widgets.themed_muted "  Computing cascade..."; ""]
+                 | Some analysis ->
+                     let chain_count = List.length s.cascade_chain in
+                     let order_str =
+                       String.concat
+                         " → "
+                         (List.map
+                            (fun unit_name ->
+                              match
+                                List.find_opt
+                                  (fun (svc : External_service.t) ->
+                                    String.equal svc.config.unit_name unit_name)
+                                  s.external_services
+                              with
+                              | Some svc -> svc.suggested_instance_name
+                              | None -> unit_name)
+                            analysis.import_order)
+                     in
+                     [
+                       "";
+                       Widgets.themed_emphasis
+                         (Printf.sprintf
+                            "Cascade import: %d services"
+                            chain_count);
+                       Widgets.themed_muted (Printf.sprintf "  %s" order_str);
+                       "";
+                     ]
+               else [])
+            @ [
+                "";
+                "Space: Toggle strategy  c: Toggle cascade  Enter: Next  Esc: \
+                 Back";
+              ])
     | ReviewImport -> (
         match s.selected_service with
         | None -> ["Error: No service selected"]
@@ -440,38 +551,87 @@ let view ps ~focus:_ ~size =
             let final_name =
               Option.value s.custom_name ~default:svc.suggested_instance_name
             in
-            [
-              "";
-              Widgets.themed_success "Ready to import:";
-              "";
-              Printf.sprintf "  Original unit: %s" svc.config.unit_name;
-              Printf.sprintf
-                "  New instance:  %s"
-                (Widgets.themed_emphasis final_name);
-              Printf.sprintf
-                "  Strategy:      %s"
-                (match s.strategy with
+            if s.cascade then
+              (* Cascade import review *)
+              let chain_count = List.length s.cascade_chain in
+              [
+                "";
+                Widgets.themed_success "Ready to cascade import:";
+                "";
+                Printf.sprintf
+                  "  Target service: %s"
+                  (Widgets.themed_emphasis svc.suggested_instance_name);
+                Printf.sprintf "  Services to import: %d" chain_count;
+                Printf.sprintf
+                  "  Strategy:       %s"
+                  (match s.strategy with
+                  | Import.Takeover ->
+                      Widgets.themed_warning "Takeover (will disable originals)"
+                  | Import.Clone ->
+                      Widgets.themed_success "Clone (keep originals)");
+                "";
+                "Import order:";
+              ]
+              @ (match s.cascade_analysis with
+                | None -> ["  (analysis not available)"]
+                | Some analysis ->
+                    List.mapi
+                      (fun i unit_name ->
+                        match
+                          List.find_opt
+                            (fun (svc : External_service.t) ->
+                              String.equal svc.config.unit_name unit_name)
+                            s.external_services
+                        with
+                        | Some svc ->
+                            let role_str =
+                              match svc.config.role.value with
+                              | Some r -> External_service.role_to_string r
+                              | None -> "unknown"
+                            in
+                            Printf.sprintf
+                              "  %d. %s (%s)"
+                              (i + 1)
+                              svc.suggested_instance_name
+                              role_str
+                        | None -> Printf.sprintf "  %d. %s" (i + 1) unit_name)
+                      analysis.import_order)
+              @ [""; "Enter: Confirm  Esc: Back"]
+            else
+              (* Single service import review *)
+              [
+                "";
+                Widgets.themed_success "Ready to import:";
+                "";
+                Printf.sprintf "  Original unit: %s" svc.config.unit_name;
+                Printf.sprintf
+                  "  New instance:  %s"
+                  (Widgets.themed_emphasis final_name);
+                Printf.sprintf
+                  "  Strategy:      %s"
+                  (match s.strategy with
+                  | Import.Takeover ->
+                      Widgets.themed_warning "Takeover (will disable original)"
+                  | Import.Clone ->
+                      Widgets.themed_success "Clone (keep original)");
+                "";
+                "What will happen:";
+              ]
+              @ (match s.strategy with
                 | Import.Takeover ->
-                    Widgets.themed_warning "Takeover (will disable original)"
-                | Import.Clone -> Widgets.themed_success "Clone (keep original)");
-              "";
-              "What will happen:";
-            ]
-            @ (match s.strategy with
-              | Import.Takeover ->
-                  [
-                    "  1. Stop external service";
-                    "  2. Create managed service";
-                    "  3. Disable original systemd unit";
-                    "  4. Start managed service";
-                  ]
-              | Import.Clone ->
-                  [
-                    "  1. Create managed service (copy config)";
-                    "  2. Keep original service running";
-                    "  3. Start managed service";
-                  ])
-            @ [""; "Enter: Confirm  Esc: Back"])
+                    [
+                      "  1. Stop external service";
+                      "  2. Create managed service";
+                      "  3. Disable original systemd unit";
+                      "  4. Start managed service";
+                    ]
+                | Import.Clone ->
+                    [
+                      "  1. Create managed service (copy config)";
+                      "  2. Keep original service running";
+                      "  3. Start managed service";
+                    ])
+              @ [""; "Enter: Confirm  Esc: Back"])
     | Importing -> (
         (* Show live progress from Job_manager *)
         let all_jobs = Job_manager.list () in
@@ -567,6 +727,7 @@ let handle_key ps key ~size:_ =
     | SelectService, Some Keys.Enter -> next_step ps
     | SelectService, Some Keys.Escape -> Navigation.back ps
     | ConfigureImport, Some (Keys.Char " ") -> toggle_strategy ps
+    | ConfigureImport, Some (Keys.Char "c") -> toggle_cascade ps
     | ConfigureImport, Some Keys.Enter -> next_step ps
     | ConfigureImport, Some Keys.Escape -> back ps
     | ReviewImport, Some Keys.Enter -> next_step ps

--- a/src/ui/pages/import_wizard.mli
+++ b/src/ui/pages/import_wizard.mli
@@ -30,6 +30,11 @@ type state = {
   custom_name : string option;  (** Optional custom instance name override. *)
   network_override : string option;  (** Optional network name override. *)
   error : string option;  (** Error message from the last operation. *)
+  cascade : bool;  (** Whether to import dependencies/dependents. *)
+  cascade_chain : External_service.t list;
+      (** Services to import when cascade is enabled. *)
+  cascade_analysis : Import_cascade.dependency_analysis option;
+      (** Dependency analysis for cascade import preview. *)
 }
 
 (** Navigation-wrapped state. *)
@@ -52,6 +57,9 @@ val move_selection : pstate -> int -> pstate
 
 (** Toggle the import strategy between [Takeover] and [Clone]. *)
 val toggle_strategy : pstate -> pstate
+
+(** Toggle cascade import on/off and recompute dependency chain. *)
+val toggle_cascade : pstate -> pstate
 
 (** Return the header lines for the current wizard step. *)
 val header : state -> string list

--- a/test/test_import_wizard_pure.ml
+++ b/test/test_import_wizard_pure.ml
@@ -15,7 +15,8 @@ module Navigation = Miaou.Core.Navigation
 
 let make_state ?(step = Import_wizard.SelectService) ?(external_services = [])
     ?(selected_idx = 0) ?selected_service ?(strategy = Import.Takeover)
-    ?custom_name ?network_override ?error () : Import_wizard.state =
+    ?custom_name ?network_override ?error ?(cascade = false)
+    ?(cascade_chain = []) ?cascade_analysis () : Import_wizard.state =
   {
     step;
     external_services;
@@ -25,6 +26,9 @@ let make_state ?(step = Import_wizard.SelectService) ?(external_services = [])
     custom_name;
     network_override;
     error;
+    cascade;
+    cascade_chain;
+    cascade_analysis;
   }
 
 let wrap_state = Navigation.make
@@ -216,6 +220,62 @@ let test_keymap_has_enter () =
   Alcotest.(check bool) "has Enter" true (List.mem "Enter" keys)
 
 (* ============================================================ *)
+(* toggle_cascade Tests                                         *)
+(* ============================================================ *)
+
+let test_toggle_cascade_off_to_on () =
+  let svc = make_ext_svc "test-node" in
+  let ps =
+    wrap_state
+      (make_state
+         ~external_services:[svc]
+         ~selected_service:svc
+         ~cascade:false
+         ())
+  in
+  let ps' = Import_wizard.toggle_cascade ps in
+  Alcotest.(check bool) "cascade enabled" true ps'.Navigation.s.cascade
+
+let test_toggle_cascade_on_to_off () =
+  let svc = make_ext_svc "test-node" in
+  let ps =
+    wrap_state
+      (make_state
+         ~external_services:[svc]
+         ~selected_service:svc
+         ~cascade:true
+         ())
+  in
+  let ps' = Import_wizard.toggle_cascade ps in
+  Alcotest.(check bool) "cascade disabled" false ps'.Navigation.s.cascade
+
+let test_toggle_cascade_clears_chain_when_disabled () =
+  let svc = make_ext_svc "test-node" in
+  let ps =
+    wrap_state
+      (make_state
+         ~external_services:[svc]
+         ~selected_service:svc
+         ~cascade:true
+         ~cascade_chain:[svc]
+         ())
+  in
+  let ps' = Import_wizard.toggle_cascade ps in
+  Alcotest.(check int)
+    "cascade chain cleared"
+    0
+    (List.length ps'.Navigation.s.cascade_chain)
+
+let test_toggle_cascade_no_selected_service () =
+  let ps = wrap_state (make_state ~cascade:false ()) in
+  let ps' = Import_wizard.toggle_cascade ps in
+  Alcotest.(check bool) "cascade enabled" true ps'.Navigation.s.cascade ;
+  Alcotest.(check int)
+    "no chain computed"
+    0
+    (List.length ps'.Navigation.s.cascade_chain)
+
+(* ============================================================ *)
 (* Test Runner                                                   *)
 (* ============================================================ *)
 
@@ -243,6 +303,19 @@ let () =
             `Quick
             test_toggle_clone_to_takeover;
           Alcotest.test_case "round trip" `Quick test_toggle_round_trip;
+        ] );
+      ( "toggle_cascade",
+        [
+          Alcotest.test_case "off to on" `Quick test_toggle_cascade_off_to_on;
+          Alcotest.test_case "on to off" `Quick test_toggle_cascade_on_to_off;
+          Alcotest.test_case
+            "clears chain when disabled"
+            `Quick
+            test_toggle_cascade_clears_chain_when_disabled;
+          Alcotest.test_case
+            "no selected service"
+            `Quick
+            test_toggle_cascade_no_selected_service;
         ] );
       ( "header",
         [


### PR DESCRIPTION
## Summary

- Adds cascade import toggle ('c' key) to the TUI import wizard's ConfigureImport step, matching the CLI's `--cascade` flag
- Shows cascade chain preview with import order (dependencies → dependents) before confirming
- Wires up `Import.import_cascade` for multi-service import execution via Job_manager

## Details

### New wizard state fields
- `cascade : bool` — toggle for cascade mode
- `cascade_chain : External_service.t list` — computed services to import
- `cascade_analysis : Import_cascade.dependency_analysis option` — for preview

### UI flow
1. **ConfigureImport**: Press 'c' to toggle cascade. Shows preview of services in import order.
2. **ReviewImport**: Shows full cascade chain with service count and roles.
3. **Importing**: Uses `Import.import_cascade` instead of `Import.import_service`.

### Strategy-aware cascade
- **Takeover**: `get_full_cascade` (dependencies + dependents)
- **Clone**: `get_dependency_chain` (dependencies only)
- Cascade chain recomputes automatically when strategy is toggled

### Tests
- 4 new pure state machine tests for cascade toggle behavior

Fixes #886