### PR TITLE
fix(wallet): strip URL prefix from network before building tzkt links

### DIFF
--- a/src/ui/pages/instances/instances_wallet.ml
+++ b/src/ui/pages/instances/instances_wallet.ml
@@ -194,8 +194,11 @@ let baker_password_file (svc : Service.t) =
           | Some global_str -> find (String.split_on_char ' ' global_str)))
 
 let tzkt_base_url ~network =
-  if String.equal network "mainnet" then "https://tzkt.io"
-  else Printf.sprintf "https://%s.tzkt.io" network
+  let name =
+    match Snapshots.slug_of_network network with Some s -> s | None -> network
+  in
+  if String.equal name "mainnet" then "https://tzkt.io"
+  else Printf.sprintf "https://%s.tzkt.io" name
 
 (* ── Operation tracking ──────────────────────────────────── *)
 

--- a/src/ui/pages/wallets_page.ml
+++ b/src/ui/pages/wallets_page.ml
@@ -2074,7 +2074,12 @@ let action_receive ~base_dir (key : Keys_reader.key_metadata) =
   let explorer_url =
     match network with
     | Some net ->
-        let subdomain = if String.equal net "mainnet" then "" else net ^ "." in
+        let name =
+          match Snapshots.slug_of_network net with Some s -> s | None -> net
+        in
+        let subdomain =
+          if String.equal name "mainnet" then "" else name ^ "."
+        in
         Printf.sprintf "https://%stzkt.io/%s" subdomain key.pkh
     | None -> Printf.sprintf "https://tzkt.io/%s" key.pkh
   in

--- a/test/unit_tests.ml
+++ b/test/unit_tests.ml
@@ -1325,6 +1325,33 @@ let snapshots_sanitize_kind () =
         (Snapshots.sanitize_kind_input input))
     cases
 
+let tzkt_url_construction () =
+  (* Test that tzkt URLs are constructed correctly by extracting network slug from URLs.
+     This verifies the fix for #906 where URL-style networks caused double https:// prefix. *)
+  let build_tzkt_url network =
+    let name =
+      match Snapshots.slug_of_network network with
+      | Some s -> s
+      | None -> network
+    in
+    if String.equal name "mainnet" then "https://tzkt.io"
+    else Printf.sprintf "https://%s.tzkt.io" name
+  in
+  let cases =
+    [
+      ("mainnet", "https://tzkt.io");
+      ("ghostnet", "https://ghostnet.tzkt.io");
+      ("https://teztnets.com/tallinnnet", "https://tallinnnet.tzkt.io");
+      ("https://teztnets.com/weeklynet-2026-02-04", "https://weeklynet.tzkt.io");
+      ( "https://snapshots.tzinit.org/networks/Seoulnet.json",
+        "https://seoulnet.tzkt.io" );
+    ]
+  in
+  List.iter
+    (fun (input, expected) ->
+      Alcotest.(check string) "tzkt URL" expected (build_tzkt_url input))
+    cases
+
 let sh_quote_tests () =
   Alcotest.(check string)
     "needs quoting"
@@ -6276,6 +6303,10 @@ let () =
         [
           Alcotest.test_case "slug_of_network" `Quick snapshots_slug_of_network;
           Alcotest.test_case "sanitize" `Quick snapshots_sanitize_kind;
+          Alcotest.test_case
+            "tzkt_url_construction"
+            `Quick
+            tzkt_url_construction;
         ] );
       ( "snapshots.fetch",
         [


### PR DESCRIPTION
## Summary

- Fix double `https://` prefix in wallet operation explorer links when network is a URL (e.g., `https://teztnets.com/tallinnnet`)
- Apply `Snapshots.slug_of_network` to extract the network name before constructing tzkt URLs in both `instances_wallet.ml` and `wallets_page.ml`
- Add unit test verifying correct URL construction for plain names and URL-style networks

Fixes #906