### PR TITLE
fix(ui): apply themed background to Canvas rendering on Diagnostics, Topology, and Sandbox pages

### DIFF
--- a/src/ui/pages/diagnostics/diagnostics_page.ml
+++ b/src/ui/pages/diagnostics/diagnostics_page.ml
@@ -193,6 +193,12 @@ let resolve_bg ~fallback style =
   let resolved = Style.to_resolved style in
   if resolved.r_bg < 0 then fallback else resolved.r_bg
 
+(** Get themed default colors for Canvas rendering *)
+let themed_canvas_defaults () =
+  let bg_resolved = Style.to_resolved (Style_context.background ()) in
+  let fg_resolved = Style.to_resolved (Style_context.text ()) in
+  (fg_resolved.r_fg, bg_resolved.r_bg)
+
 let render_canvas_header ~width =
   let style_of fg = {C.default_style with fg} in
   let bold_of fg = {C.default_style with fg; bold = true} in
@@ -263,7 +269,8 @@ let render_canvas_header ~width =
       start_col
       indicators
   in
-  C.to_ansi c
+  let themed_fg, themed_bg = themed_canvas_defaults () in
+  C.to_ansi_with_defaults ~default_fg:themed_fg ~default_bg:themed_bg c
 
 let _footer = []
 
@@ -794,7 +801,7 @@ let handle_key ps key ~size =
 
 let has_modal _ = Miaou.Core.Modal_manager.has_active ()
 
-module Page : Miaou.Core.Tui_page.PAGE_SIG = struct
+module Page_Impl : Miaou.Core.Tui_page.PAGE_SIG = struct
   type nonrec state = state
 
   type nonrec msg = msg
@@ -851,6 +858,13 @@ module Page : Miaou.Core.Tui_page.PAGE_SIG = struct
 
   let has_modal = has_modal
 end
+
+module Page =
+  Themed_page.Make
+    (Page_Impl)
+    (struct
+      let page_name = name
+    end)
 
 let page : Miaou.Core.Registry.page =
   (module Page : Miaou.Core.Tui_page.PAGE_SIG)

--- a/src/ui/pages/sandbox_page.ml
+++ b/src/ui/pages/sandbox_page.ml
@@ -374,6 +374,14 @@ let canvas_status_char = function
   | Data.Service_state.Stopped -> "○"
   | Data.Service_state.Unknown _ -> "?"
 
+(** Get themed default colors for Canvas rendering *)
+let themed_canvas_defaults () =
+  let bg_resolved =
+    Miaou_style.Style.to_resolved (Style_context.background ())
+  in
+  let fg_resolved = Miaou_style.Style.to_resolved (Style_context.text ()) in
+  (fg_resolved.r_fg, bg_resolved.r_bg)
+
 (** Draw a compact service box [● Lbl] width=7, height=3. Returns center col. *)
 let draw_compact_box c ~row ~col ~label ~role ~st =
   let box_w = 7 in
@@ -585,7 +593,8 @@ let render_sandbox_canvas (sb : sandbox_info) ~width =
         done
       end)
     sb.accusers ;
-  C.to_ansi c
+  let themed_fg, themed_bg = themed_canvas_defaults () in
+  C.to_ansi_with_defaults ~default_fg:themed_fg ~default_bg:themed_bg c
 
 (** Match a configured --peer address to a node name by comparing P2P ports. *)
 let peer_to_node_name nodes peer_addr =

--- a/src/ui/pages/topology_page.ml
+++ b/src/ui/pages/topology_page.ml
@@ -146,6 +146,14 @@ let bold_of fg = {C.default_style with fg; bold = true}
 
 let dim_style = {C.default_style with dim = true}
 
+(** Get themed default colors for Canvas rendering *)
+let themed_canvas_defaults () =
+  let bg_resolved =
+    Miaou_style.Style.to_resolved (Style_context.background ())
+  in
+  let fg_resolved = Miaou_style.Style.to_resolved (Style_context.text ()) in
+  (fg_resolved.r_fg, bg_resolved.r_bg)
+
 (* Draw a service node box on a canvas *)
 let draw_node c ~node_w ~row ~col node =
   let canvas_w = C.cols c in
@@ -270,7 +278,8 @@ let render_wide ~width ~node_w trees =
       trees
       root_widths
   in
-  C.to_ansi c
+  let themed_fg, themed_bg = themed_canvas_defaults () in
+  C.to_ansi_with_defaults ~default_fg:themed_fg ~default_bg:themed_bg c
 
 (* Compact layout: vertical stack, each root with children indented below *)
 let render_compact ~width ~node_w trees =
@@ -322,7 +331,8 @@ let render_compact ~width ~node_w trees =
       0
       trees
   in
-  C.to_ansi c
+  let themed_fg, themed_bg = themed_canvas_defaults () in
+  C.to_ansi_with_defaults ~default_fg:themed_fg ~default_bg:themed_bg c
 
 (* Render the topology, choosing layout based on available width *)
 let render_topology ~width ~services =


### PR DESCRIPTION
## Summary

- Wrap Diagnostics page in `Themed_page.Make` (was missing, unlike all other pages)
- Use `C.to_ansi_with_defaults ~default_fg ~default_bg` instead of `C.to_ansi` in all Canvas-rendering pages (Diagnostics, Topology, Sandbox) so cells with unset bg inherit the theme background instead of terminal default
- Extracts themed colors via `Style_context.background()` and `Style_context.text()` at render time

Fixes #899