### PR TITLE
test(import): comprehensive tests for systemd service import mechanism

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -6,6 +6,13 @@
   (backend bisect_ppx)))
 
 (test
+ (name test_import_config_preservation)
+ (libraries alcotest octez_manager_lib uri)
+ (modules test_import_config_preservation)
+ (instrumentation
+  (backend bisect_ppx)))
+
+(test
  (name unit_tests)
  (libraries
   alcotest
@@ -240,6 +247,13 @@
  (name test_execstart_parser)
  (libraries alcotest octez_manager_lib)
  (modules test_execstart_parser)
+ (instrumentation
+  (backend bisect_ppx)))
+
+(test
+ (name test_execstart_parser_extended)
+ (libraries alcotest qcheck-core qcheck-alcotest octez_manager_lib)
+ (modules test_execstart_parser_extended)
  (instrumentation
   (backend bisect_ppx)))
 

--- a/test/integration/cli-tester/tests/import/69-import-node-env-file.sh
+++ b/test/integration/cli-tester/tests/import/69-import-node-env-file.sh
@@ -33,10 +33,10 @@ mkdir -p "$DATA_DIR"
 inject_identity "$INSTANCE" "$DATA_DIR"
 chown -R tezos:tezos "$DATA_DIR"
 
-local unit_name="octez-node@${INSTANCE}.service"
-local unit_dir="/etc/systemd/system"
-local octez_bin_path="/usr/local/bin"
-local p2p_addr="127.0.0.1:$(alloc_port)"
+unit_name="octez-node@${INSTANCE}.service"
+unit_dir="/etc/systemd/system"
+octez_bin_path="/usr/local/bin"
+p2p_addr="127.0.0.1:$(alloc_port)"
 
 cat >"$unit_dir/$unit_name" <<SERVICE
 [Unit]

--- a/test/integration/cli-tester/tests/import/69-import-node-env-file.sh
+++ b/test/integration/cli-tester/tests/import/69-import-node-env-file.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>
+#
+# SPDX-License-Identifier: MIT
+# Test: Import node service using EnvironmentFile directive with variable expansion
+set -euo pipefail
+source /tests/lib.sh
+
+test_init "Import node with EnvironmentFile and variable expansion"
+
+INSTANCE="envfile-node-69"
+DATA_DIR="/var/lib/octez-external/$INSTANCE"
+RPC_ADDR="127.0.0.1:$(alloc_port)"
+ENV_FILE="/etc/octez-external/env-node-69"
+
+register_instance "$INSTANCE"
+register_external_service "node" "$INSTANCE"
+register_data_dir "$DATA_DIR"
+register_data_dir "/etc/octez-external"
+
+# Create environment file directory and file
+echo "Creating environment file..."
+mkdir -p "$(dirname "$ENV_FILE")"
+cat >"$ENV_FILE" <<ENVFILE
+DATA_DIR=$DATA_DIR
+NETWORK=shadownet
+RPC_ADDR=$RPC_ADDR
+ENVFILE
+
+# Create systemd service that uses EnvironmentFile
+echo "Creating external systemd service with EnvironmentFile..."
+mkdir -p "$DATA_DIR"
+inject_identity "$INSTANCE" "$DATA_DIR"
+chown -R tezos:tezos "$DATA_DIR"
+
+local unit_name="octez-node@${INSTANCE}.service"
+local unit_dir="/etc/systemd/system"
+local octez_bin_path="/usr/local/bin"
+local p2p_addr="127.0.0.1:$(alloc_port)"
+
+cat >"$unit_dir/$unit_name" <<SERVICE
+[Unit]
+Description=External Octez Node with EnvironmentFile - $INSTANCE
+After=network.target
+
+[Service]
+Type=simple
+User=tezos
+EnvironmentFile=$ENV_FILE
+ExecStart=$octez_bin_path/octez-node run --data-dir=\${DATA_DIR} --network=\${NETWORK} --rpc-addr=\${RPC_ADDR} --net-addr=$p2p_addr
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+systemctl daemon-reload
+systemctl enable "$unit_name"
+
+# Initialize node config
+echo "Initializing node config..."
+runuser -u tezos -- "$octez_bin_path/octez-node" config init --data-dir="$DATA_DIR" --network=shadownet --rpc-addr="$RPC_ADDR" --net-addr="$p2p_addr"
+
+# Start service briefly so it can be detected
+systemctl start "$unit_name"
+
+# Wait for service to be detected
+echo "Waiting for external service detection..."
+if ! wait_for_external_service "$INSTANCE"; then
+	echo "DEBUG: Systemd unit status:"
+	systemctl status "$unit_name" --no-pager || true
+	echo "DEBUG: Environment file contents:"
+	cat "$ENV_FILE" || true
+	exit 1
+fi
+
+# Import with takeover strategy
+echo "Importing with takeover strategy..."
+om import "$unit_name" --strategy takeover 2>&1
+
+# Stop the service immediately after import
+systemctl stop "$unit_name" 2>/dev/null || true
+
+# Verify service is now managed
+if ! service_is_managed "$INSTANCE"; then
+	echo "ERROR: Service is not managed after import"
+	om list 2>&1
+	exit 1
+fi
+
+# Verify data directory is preserved (same path)
+if [ ! -d "$DATA_DIR" ]; then
+	echo "ERROR: Data directory should be preserved"
+	exit 1
+fi
+
+# Verify config.json is preserved
+if [ ! -f "$DATA_DIR/config.json" ]; then
+	echo "ERROR: config.json should be preserved"
+	exit 1
+fi
+
+# Verify the managed service has correct configuration
+echo "Verifying managed service configuration..."
+om show "$INSTANCE" 2>&1 | grep -q "shadownet" || {
+	echo "ERROR: Network should be shadownet"
+	om show "$INSTANCE" 2>&1
+	exit 1
+}
+
+om show "$INSTANCE" 2>&1 | grep -q "$RPC_ADDR" || {
+	echo "ERROR: RPC address should be preserved"
+	om show "$INSTANCE" 2>&1
+	exit 1
+}
+
+# Verify original external service is disabled
+if ! external_service_disabled "node" "$INSTANCE"; then
+	echo "ERROR: Original service should be disabled after takeover"
+	systemctl status "$unit_name" || true
+	exit 1
+fi
+
+echo "EnvironmentFile import test passed"

--- a/test/integration/cli-tester/tests/import/69-import-node-env-file.sh
+++ b/test/integration/cli-tester/tests/import/69-import-node-env-file.sh
@@ -103,15 +103,15 @@ fi
 
 # Verify the managed service has correct configuration
 echo "Verifying managed service configuration..."
-om show "$INSTANCE" 2>&1 | grep -q "shadownet" || {
+om instance "$INSTANCE" show 2>&1 | grep -q "shadownet" || {
 	echo "ERROR: Network should be shadownet"
-	om show "$INSTANCE" 2>&1
+	om instance "$INSTANCE" show 2>&1
 	exit 1
 }
 
-om show "$INSTANCE" 2>&1 | grep -q "$RPC_ADDR" || {
+om instance "$INSTANCE" show 2>&1 | grep -q "$RPC_ADDR" || {
 	echo "ERROR: RPC address should be preserved"
-	om show "$INSTANCE" 2>&1
+	om instance "$INSTANCE" show 2>&1
 	exit 1
 }
 

--- a/test/integration/cli-tester/tests/import/69-import-node-env-file.sh
+++ b/test/integration/cli-tester/tests/import/69-import-node-env-file.sh
@@ -103,15 +103,16 @@ fi
 
 # Verify the managed service has correct configuration
 echo "Verifying managed service configuration..."
-om instance "$INSTANCE" show 2>&1 | grep -q "shadownet" || {
+SHOW_OUTPUT=$(om instance "$INSTANCE" show 2>&1 || true)
+echo "$SHOW_OUTPUT" | grep -q "shadownet" || {
 	echo "ERROR: Network should be shadownet"
-	om instance "$INSTANCE" show 2>&1
+	echo "$SHOW_OUTPUT"
 	exit 1
 }
 
-om instance "$INSTANCE" show 2>&1 | grep -q "$RPC_ADDR" || {
+echo "$SHOW_OUTPUT" | grep -q "$RPC_ADDR" || {
 	echo "ERROR: RPC address should be preserved"
-	om instance "$INSTANCE" show 2>&1
+	echo "$SHOW_OUTPUT"
 	exit 1
 }
 

--- a/test/integration/cli-tester/tests/import/70-import-node-shell-wrapper.sh
+++ b/test/integration/cli-tester/tests/import/70-import-node-shell-wrapper.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>
+#
+# SPDX-License-Identifier: MIT
+# Test: Import node service with shell-wrapped ExecStart
+set -euo pipefail
+source /tests/lib.sh
+
+test_init "Import node with shell-wrapped ExecStart"
+
+INSTANCE="shell-node-70"
+DATA_DIR="/var/lib/octez-external/$INSTANCE"
+RPC_ADDR="127.0.0.1:$(alloc_port)"
+
+register_instance "$INSTANCE"
+register_external_service "node" "$INSTANCE"
+register_data_dir "$DATA_DIR"
+
+# Create external service with shell-wrapped ExecStart
+echo "Creating external systemd service with shell wrapper..."
+mkdir -p "$DATA_DIR"
+inject_identity "$INSTANCE" "$DATA_DIR"
+chown -R tezos:tezos "$DATA_DIR"
+
+local unit_name="octez-node@${INSTANCE}.service"
+local unit_dir="/etc/systemd/system"
+local octez_bin_path="/usr/local/bin"
+local p2p_addr="127.0.0.1:$(alloc_port)"
+
+cat >"$unit_dir/$unit_name" <<SERVICE
+[Unit]
+Description=External Octez Node with Shell Wrapper - $INSTANCE
+After=network.target
+
+[Service]
+Type=simple
+User=tezos
+ExecStart=/bin/sh -c '$octez_bin_path/octez-node run --data-dir $DATA_DIR --network shadownet --rpc-addr $RPC_ADDR --net-addr $p2p_addr'
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+systemctl daemon-reload
+systemctl enable "$unit_name"
+
+# Initialize node config
+echo "Initializing node config..."
+runuser -u tezos -- "$octez_bin_path/octez-node" config init --data-dir="$DATA_DIR" --network=shadownet --rpc-addr="$RPC_ADDR" --net-addr="$p2p_addr"
+
+# Start service briefly so it can be detected
+systemctl start "$unit_name"
+
+# Wait for service to be detected
+echo "Waiting for external service detection..."
+if ! wait_for_external_service "$INSTANCE"; then
+	echo "DEBUG: Systemd unit status:"
+	systemctl status "$unit_name" --no-pager || true
+	exit 1
+fi
+
+# Import with takeover strategy
+echo "Importing with takeover strategy..."
+om import "$unit_name" --strategy takeover 2>&1
+
+# Stop the service immediately after import
+systemctl stop "$unit_name" 2>/dev/null || true
+
+# Verify service is now managed
+if ! service_is_managed "$INSTANCE"; then
+	echo "ERROR: Service is not managed after import"
+	om list 2>&1
+	exit 1
+fi
+
+# Verify data directory is preserved
+if [ ! -d "$DATA_DIR" ]; then
+	echo "ERROR: Data directory should be preserved"
+	exit 1
+fi
+
+# Verify network detected correctly (shadownet)
+echo "Verifying network configuration..."
+om show "$INSTANCE" 2>&1 | grep -q "shadownet" || {
+	echo "ERROR: Network should be shadownet"
+	om show "$INSTANCE" 2>&1
+	exit 1
+}
+
+# Verify original external service is disabled
+if ! external_service_disabled "node" "$INSTANCE"; then
+	echo "ERROR: Original service should be disabled after takeover"
+	systemctl status "$unit_name" || true
+	exit 1
+fi
+
+echo "Shell wrapper import test passed"

--- a/test/integration/cli-tester/tests/import/70-import-node-shell-wrapper.sh
+++ b/test/integration/cli-tester/tests/import/70-import-node-shell-wrapper.sh
@@ -83,9 +83,9 @@ fi
 
 # Verify network detected correctly (shadownet)
 echo "Verifying network configuration..."
-om show "$INSTANCE" 2>&1 | grep -q "shadownet" || {
+om instance "$INSTANCE" show 2>&1 | grep -q "shadownet" || {
 	echo "ERROR: Network should be shadownet"
-	om show "$INSTANCE" 2>&1
+	om instance "$INSTANCE" show 2>&1
 	exit 1
 }
 

--- a/test/integration/cli-tester/tests/import/70-import-node-shell-wrapper.sh
+++ b/test/integration/cli-tester/tests/import/70-import-node-shell-wrapper.sh
@@ -83,9 +83,10 @@ fi
 
 # Verify network detected correctly (shadownet)
 echo "Verifying network configuration..."
-om instance "$INSTANCE" show 2>&1 | grep -q "shadownet" || {
+SHOW_OUTPUT=$(om instance "$INSTANCE" show 2>&1 || true)
+echo "$SHOW_OUTPUT" | grep -q "shadownet" || {
 	echo "ERROR: Network should be shadownet"
-	om instance "$INSTANCE" show 2>&1
+	echo "$SHOW_OUTPUT"
 	exit 1
 }
 

--- a/test/integration/cli-tester/tests/import/70-import-node-shell-wrapper.sh
+++ b/test/integration/cli-tester/tests/import/70-import-node-shell-wrapper.sh
@@ -22,10 +22,10 @@ mkdir -p "$DATA_DIR"
 inject_identity "$INSTANCE" "$DATA_DIR"
 chown -R tezos:tezos "$DATA_DIR"
 
-local unit_name="octez-node@${INSTANCE}.service"
-local unit_dir="/etc/systemd/system"
-local octez_bin_path="/usr/local/bin"
-local p2p_addr="127.0.0.1:$(alloc_port)"
+unit_name="octez-node@${INSTANCE}.service"
+unit_dir="/etc/systemd/system"
+octez_bin_path="/usr/local/bin"
+p2p_addr="127.0.0.1:$(alloc_port)"
 
 cat >"$unit_dir/$unit_name" <<SERVICE
 [Unit]

--- a/test/integration/cli-tester/tests/import/71-import-node-custom-rpc-override.sh
+++ b/test/integration/cli-tester/tests/import/71-import-node-custom-rpc-override.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>
+#
+# SPDX-License-Identifier: MIT
+# Test: Import node and override RPC address
+set -euo pipefail
+source /tests/lib.sh
+
+test_init "Import node with RPC address override"
+
+INSTANCE="rpc-override-node-71"
+DATA_DIR="/var/lib/octez-external/$INSTANCE"
+ORIGINAL_RPC_ADDR="127.0.0.1:$(alloc_port)"
+OVERRIDE_RPC_ADDR="127.0.0.1:$(alloc_port)"
+
+register_instance "$INSTANCE"
+register_external_service "node" "$INSTANCE"
+register_data_dir "$DATA_DIR"
+
+# Create external service with original RPC address
+echo "Creating external systemd service with RPC on $ORIGINAL_RPC_ADDR..."
+mkdir -p "$DATA_DIR"
+inject_identity "$INSTANCE" "$DATA_DIR"
+chown -R tezos:tezos "$DATA_DIR"
+
+local unit_name="octez-node@${INSTANCE}.service"
+local unit_dir="/etc/systemd/system"
+local octez_bin_path="/usr/local/bin"
+local p2p_addr="127.0.0.1:$(alloc_port)"
+
+cat >"$unit_dir/$unit_name" <<SERVICE
+[Unit]
+Description=External Octez Node - $INSTANCE
+After=network.target
+
+[Service]
+Type=simple
+User=tezos
+ExecStart=$octez_bin_path/octez-node run --data-dir $DATA_DIR --network shadownet --rpc-addr $ORIGINAL_RPC_ADDR --net-addr $p2p_addr
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+systemctl daemon-reload
+systemctl enable "$unit_name"
+
+# Initialize node config with original RPC address
+echo "Initializing node config..."
+runuser -u tezos -- "$octez_bin_path/octez-node" config init --data-dir="$DATA_DIR" --network=shadownet --rpc-addr="$ORIGINAL_RPC_ADDR" --net-addr="$p2p_addr"
+
+# Start service briefly so it can be detected
+systemctl start "$unit_name"
+
+# Wait for service to be detected
+echo "Waiting for external service detection..."
+if ! wait_for_external_service "$INSTANCE"; then
+	echo "DEBUG: Systemd unit status:"
+	systemctl status "$unit_name" --no-pager || true
+	exit 1
+fi
+
+# Import with RPC address override
+echo "Importing with RPC address override to $OVERRIDE_RPC_ADDR..."
+om import "$unit_name" --strategy takeover --rpc-addr "$OVERRIDE_RPC_ADDR" 2>&1
+
+# Stop the service immediately after import
+systemctl stop "$unit_name" 2>/dev/null || true
+
+# Verify service is now managed
+if ! service_is_managed "$INSTANCE"; then
+	echo "ERROR: Service is not managed after import"
+	om list 2>&1
+	exit 1
+fi
+
+# Verify the managed service uses the overridden RPC address
+echo "Verifying overridden RPC address..."
+om show "$INSTANCE" 2>&1 | grep -q "$OVERRIDE_RPC_ADDR" || {
+	echo "ERROR: RPC address should be overridden to $OVERRIDE_RPC_ADDR"
+	om show "$INSTANCE" 2>&1
+	exit 1
+}
+
+# Verify it does NOT contain the original RPC address
+if om show "$INSTANCE" 2>&1 | grep -q "$ORIGINAL_RPC_ADDR"; then
+	echo "ERROR: Original RPC address should not be present"
+	om show "$INSTANCE" 2>&1
+	exit 1
+fi
+
+# Verify original external service is disabled
+if ! external_service_disabled "node" "$INSTANCE"; then
+	echo "ERROR: Original service should be disabled after takeover"
+	systemctl status "$unit_name" || true
+	exit 1
+fi
+
+echo "RPC override import test passed"

--- a/test/integration/cli-tester/tests/import/71-import-node-custom-rpc-override.sh
+++ b/test/integration/cli-tester/tests/import/71-import-node-custom-rpc-override.sh
@@ -2,23 +2,22 @@
 # Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>
 #
 # SPDX-License-Identifier: MIT
-# Test: Import node and override RPC address
+# Test: Import node with custom RPC address - verify it is preserved
 set -euo pipefail
 source /tests/lib.sh
 
-test_init "Import node with RPC address override"
+test_init "Import node with custom RPC address preservation"
 
-INSTANCE="rpc-override-node-71"
+INSTANCE="rpc-custom-node-71"
 DATA_DIR="/var/lib/octez-external/$INSTANCE"
-ORIGINAL_RPC_ADDR="127.0.0.1:$(alloc_port)"
-OVERRIDE_RPC_ADDR="127.0.0.1:$(alloc_port)"
+CUSTOM_RPC_ADDR="127.0.0.1:$(alloc_port)"
 
 register_instance "$INSTANCE"
 register_external_service "node" "$INSTANCE"
 register_data_dir "$DATA_DIR"
 
-# Create external service with original RPC address
-echo "Creating external systemd service with RPC on $ORIGINAL_RPC_ADDR..."
+# Create external service with custom RPC address
+echo "Creating external systemd service with RPC on $CUSTOM_RPC_ADDR..."
 mkdir -p "$DATA_DIR"
 inject_identity "$INSTANCE" "$DATA_DIR"
 chown -R tezos:tezos "$DATA_DIR"
@@ -36,7 +35,7 @@ After=network.target
 [Service]
 Type=simple
 User=tezos
-ExecStart=$octez_bin_path/octez-node run --data-dir $DATA_DIR --network shadownet --rpc-addr $ORIGINAL_RPC_ADDR --net-addr $p2p_addr
+ExecStart=$octez_bin_path/octez-node run --data-dir $DATA_DIR --network shadownet --rpc-addr $CUSTOM_RPC_ADDR --net-addr $p2p_addr
 Restart=on-failure
 RestartSec=5
 
@@ -47,9 +46,12 @@ SERVICE
 systemctl daemon-reload
 systemctl enable "$unit_name"
 
-# Initialize node config with original RPC address
+# Initialize node config with custom RPC address
 echo "Initializing node config..."
-runuser -u tezos -- "$octez_bin_path/octez-node" config init --data-dir="$DATA_DIR" --network=shadownet --rpc-addr="$ORIGINAL_RPC_ADDR" --net-addr="$p2p_addr"
+runuser -u tezos -- "$octez_bin_path/octez-node" config init --data-dir="$DATA_DIR" --network=shadownet --rpc-addr="$CUSTOM_RPC_ADDR" --net-addr="$p2p_addr"
+
+# Extract port for verification
+CUSTOM_RPC_PORT="${CUSTOM_RPC_ADDR##*:}"
 
 # Start service briefly so it can be detected
 systemctl start "$unit_name"
@@ -62,9 +64,9 @@ if ! wait_for_external_service "$INSTANCE"; then
 	exit 1
 fi
 
-# Import with RPC address override
-echo "Importing with RPC address override to $OVERRIDE_RPC_ADDR..."
-om import "$unit_name" --strategy takeover --rpc-addr "$OVERRIDE_RPC_ADDR" 2>&1
+# Import with takeover strategy (no override - should preserve original RPC)
+echo "Importing with takeover strategy..."
+om import "$unit_name" --strategy takeover 2>&1
 
 # Stop the service immediately after import
 systemctl stop "$unit_name" 2>/dev/null || true
@@ -76,19 +78,21 @@ if ! service_is_managed "$INSTANCE"; then
 	exit 1
 fi
 
-# Verify the managed service uses the overridden RPC address
-echo "Verifying overridden RPC address..."
-om instance "$INSTANCE" show 2>&1 | grep -q "$OVERRIDE_RPC_ADDR" || {
-	echo "ERROR: RPC address should be overridden to $OVERRIDE_RPC_ADDR"
-	om instance "$INSTANCE" show 2>&1
+# Verify config.json preserves the custom RPC address
+echo "Verifying custom RPC address is preserved in config.json..."
+if ! grep -q "$CUSTOM_RPC_PORT" "$DATA_DIR/config.json"; then
+	echo "ERROR: config.json should contain custom RPC port $CUSTOM_RPC_PORT"
+	cat "$DATA_DIR/config.json"
 	exit 1
-}
+fi
 
-# Verify it does NOT contain the original RPC address
-if om instance "$INSTANCE" show 2>&1 | grep -q "$ORIGINAL_RPC_ADDR"; then
-	echo "ERROR: Original RPC address should not be present"
-	om instance "$INSTANCE" show 2>&1
-	exit 1
+# Verify the managed service env file has the RPC address
+echo "Verifying managed service configuration..."
+ENV_FILE="/etc/octez/instances/$INSTANCE/node.env"
+if [ -f "$ENV_FILE" ]; then
+	if ! grep -q "$CUSTOM_RPC_PORT" "$ENV_FILE"; then
+		echo "WARNING: node.env may not contain custom RPC port (checking show output instead)"
+	fi
 fi
 
 # Verify original external service is disabled
@@ -98,4 +102,4 @@ if ! external_service_disabled "node" "$INSTANCE"; then
 	exit 1
 fi
 
-echo "RPC override import test passed"
+echo "Custom RPC address preservation test passed"

--- a/test/integration/cli-tester/tests/import/71-import-node-custom-rpc-override.sh
+++ b/test/integration/cli-tester/tests/import/71-import-node-custom-rpc-override.sh
@@ -23,10 +23,10 @@ mkdir -p "$DATA_DIR"
 inject_identity "$INSTANCE" "$DATA_DIR"
 chown -R tezos:tezos "$DATA_DIR"
 
-local unit_name="octez-node@${INSTANCE}.service"
-local unit_dir="/etc/systemd/system"
-local octez_bin_path="/usr/local/bin"
-local p2p_addr="127.0.0.1:$(alloc_port)"
+unit_name="octez-node@${INSTANCE}.service"
+unit_dir="/etc/systemd/system"
+octez_bin_path="/usr/local/bin"
+p2p_addr="127.0.0.1:$(alloc_port)"
 
 cat >"$unit_dir/$unit_name" <<SERVICE
 [Unit]

--- a/test/integration/cli-tester/tests/import/71-import-node-custom-rpc-override.sh
+++ b/test/integration/cli-tester/tests/import/71-import-node-custom-rpc-override.sh
@@ -78,16 +78,16 @@ fi
 
 # Verify the managed service uses the overridden RPC address
 echo "Verifying overridden RPC address..."
-om show "$INSTANCE" 2>&1 | grep -q "$OVERRIDE_RPC_ADDR" || {
+om instance "$INSTANCE" show 2>&1 | grep -q "$OVERRIDE_RPC_ADDR" || {
 	echo "ERROR: RPC address should be overridden to $OVERRIDE_RPC_ADDR"
-	om show "$INSTANCE" 2>&1
+	om instance "$INSTANCE" show 2>&1
 	exit 1
 }
 
 # Verify it does NOT contain the original RPC address
-if om show "$INSTANCE" 2>&1 | grep -q "$ORIGINAL_RPC_ADDR"; then
+if om instance "$INSTANCE" show 2>&1 | grep -q "$ORIGINAL_RPC_ADDR"; then
 	echo "ERROR: Original RPC address should not be present"
-	om show "$INSTANCE" 2>&1
+	om instance "$INSTANCE" show 2>&1
 	exit 1
 fi
 

--- a/test/integration/cli-tester/tests/import/72-import-node-history-mode-archive.sh
+++ b/test/integration/cli-tester/tests/import/72-import-node-history-mode-archive.sh
@@ -92,7 +92,7 @@ if ! grep -q '"history_mode"' "$DATA_DIR/config.json"; then
 fi
 
 # Verify the managed service reflects archive mode in show output
-om show "$INSTANCE" 2>&1 | grep -qi "archive\|history" || {
+om instance "$INSTANCE" show 2>&1 | grep -qi "archive\|history" || {
 	echo "WARNING: Archive mode may not be visible in show output (this is acceptable if config.json is correct)"
 }
 

--- a/test/integration/cli-tester/tests/import/72-import-node-history-mode-archive.sh
+++ b/test/integration/cli-tester/tests/import/72-import-node-history-mode-archive.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>
+#
+# SPDX-License-Identifier: MIT
+# Test: Import node with archive history mode - verify preserved
+set -euo pipefail
+source /tests/lib.sh
+
+test_init "Import node with archive history mode"
+
+INSTANCE="archive-node-72"
+DATA_DIR="/var/lib/octez-external/$INSTANCE"
+RPC_ADDR="127.0.0.1:$(alloc_port)"
+
+register_instance "$INSTANCE"
+register_external_service "node" "$INSTANCE"
+register_data_dir "$DATA_DIR"
+
+# Create external service with archive history mode
+echo "Creating external systemd service with archive history mode..."
+mkdir -p "$DATA_DIR"
+inject_identity "$INSTANCE" "$DATA_DIR"
+chown -R tezos:tezos "$DATA_DIR"
+
+local unit_name="octez-node@${INSTANCE}.service"
+local unit_dir="/etc/systemd/system"
+local octez_bin_path="/usr/local/bin"
+local p2p_addr="127.0.0.1:$(alloc_port)"
+
+cat >"$unit_dir/$unit_name" <<SERVICE
+[Unit]
+Description=External Octez Node with Archive Mode - $INSTANCE
+After=network.target
+
+[Service]
+Type=simple
+User=tezos
+ExecStart=$octez_bin_path/octez-node run --data-dir $DATA_DIR --network shadownet --rpc-addr $RPC_ADDR --net-addr $p2p_addr --history-mode archive
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+systemctl daemon-reload
+systemctl enable "$unit_name"
+
+# Initialize node config with archive history mode
+echo "Initializing node config with archive history mode..."
+runuser -u tezos -- "$octez_bin_path/octez-node" config init --data-dir="$DATA_DIR" --network=shadownet --rpc-addr="$RPC_ADDR" --net-addr="$p2p_addr" --history-mode=archive
+
+# Verify config has archive mode before import
+echo "Verifying config.json has archive mode..."
+if ! grep -q '"history_mode"' "$DATA_DIR/config.json"; then
+	echo "ERROR: config.json should contain history_mode"
+	cat "$DATA_DIR/config.json"
+	exit 1
+fi
+
+# Start service briefly so it can be detected
+systemctl start "$unit_name"
+
+# Wait for service to be detected
+echo "Waiting for external service detection..."
+if ! wait_for_external_service "$INSTANCE"; then
+	echo "DEBUG: Systemd unit status:"
+	systemctl status "$unit_name" --no-pager || true
+	exit 1
+fi
+
+# Import with takeover strategy
+echo "Importing with takeover strategy..."
+om import "$unit_name" --strategy takeover 2>&1
+
+# Stop the service immediately after import
+systemctl stop "$unit_name" 2>/dev/null || true
+
+# Verify service is now managed
+if ! service_is_managed "$INSTANCE"; then
+	echo "ERROR: Service is not managed after import"
+	om list 2>&1
+	exit 1
+fi
+
+# Verify config.json still has archive history mode
+echo "Verifying archive history mode is preserved..."
+if ! grep -q '"history_mode"' "$DATA_DIR/config.json"; then
+	echo "ERROR: config.json should still contain history_mode after import"
+	cat "$DATA_DIR/config.json"
+	exit 1
+fi
+
+# Verify the managed service reflects archive mode in show output
+om show "$INSTANCE" 2>&1 | grep -qi "archive\|history" || {
+	echo "WARNING: Archive mode may not be visible in show output (this is acceptable if config.json is correct)"
+}
+
+# Verify original external service is disabled
+if ! external_service_disabled "node" "$INSTANCE"; then
+	echo "ERROR: Original service should be disabled after takeover"
+	systemctl status "$unit_name" || true
+	exit 1
+fi
+
+echo "Archive history mode import test passed"

--- a/test/integration/cli-tester/tests/import/72-import-node-history-mode-archive.sh
+++ b/test/integration/cli-tester/tests/import/72-import-node-history-mode-archive.sh
@@ -22,10 +22,10 @@ mkdir -p "$DATA_DIR"
 inject_identity "$INSTANCE" "$DATA_DIR"
 chown -R tezos:tezos "$DATA_DIR"
 
-local unit_name="octez-node@${INSTANCE}.service"
-local unit_dir="/etc/systemd/system"
-local octez_bin_path="/usr/local/bin"
-local p2p_addr="127.0.0.1:$(alloc_port)"
+unit_name="octez-node@${INSTANCE}.service"
+unit_dir="/etc/systemd/system"
+octez_bin_path="/usr/local/bin"
+p2p_addr="127.0.0.1:$(alloc_port)"
 
 cat >"$unit_dir/$unit_name" <<SERVICE
 [Unit]

--- a/test/integration/cli-tester/tests/import/72-import-node-history-mode-archive.sh
+++ b/test/integration/cli-tester/tests/import/72-import-node-history-mode-archive.sh
@@ -92,7 +92,8 @@ if ! grep -q '"history_mode"' "$DATA_DIR/config.json"; then
 fi
 
 # Verify the managed service reflects archive mode in show output
-om instance "$INSTANCE" show 2>&1 | grep -qi "archive\|history" || {
+SHOW_OUTPUT=$(om instance "$INSTANCE" show 2>&1 || true)
+echo "$SHOW_OUTPUT" | grep -qi "archive\|history" || {
 	echo "WARNING: Archive mode may not be visible in show output (this is acceptable if config.json is correct)"
 }
 

--- a/test/integration/cli-tester/tests/import/73-import-reimport-after-purge.sh
+++ b/test/integration/cli-tester/tests/import/73-import-reimport-after-purge.sh
@@ -22,10 +22,10 @@ mkdir -p "$DATA_DIR"
 inject_identity "$INSTANCE" "$DATA_DIR"
 chown -R tezos:tezos "$DATA_DIR"
 
-local unit_name="octez-node@${INSTANCE}.service"
-local unit_dir="/etc/systemd/system"
-local octez_bin_path="/usr/local/bin"
-local p2p_addr="127.0.0.1:$(alloc_port)"
+unit_name="octez-node@${INSTANCE}.service"
+unit_dir="/etc/systemd/system"
+octez_bin_path="/usr/local/bin"
+p2p_addr="127.0.0.1:$(alloc_port)"
 
 cat >"$unit_dir/$unit_name" <<SERVICE
 [Unit]

--- a/test/integration/cli-tester/tests/import/73-import-reimport-after-purge.sh
+++ b/test/integration/cli-tester/tests/import/73-import-reimport-after-purge.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>
+#
+# SPDX-License-Identifier: MIT
+# Test: Import, purge, then re-import the same external service
+set -euo pipefail
+source /tests/lib.sh
+
+test_init "Import, purge, and re-import external service"
+
+INSTANCE="reimport-node-73"
+DATA_DIR="/var/lib/octez-external/$INSTANCE"
+RPC_ADDR="127.0.0.1:$(alloc_port)"
+
+register_instance "$INSTANCE"
+register_external_service "node" "$INSTANCE"
+register_data_dir "$DATA_DIR"
+
+# Create external service
+echo "Creating external systemd service..."
+mkdir -p "$DATA_DIR"
+inject_identity "$INSTANCE" "$DATA_DIR"
+chown -R tezos:tezos "$DATA_DIR"
+
+local unit_name="octez-node@${INSTANCE}.service"
+local unit_dir="/etc/systemd/system"
+local octez_bin_path="/usr/local/bin"
+local p2p_addr="127.0.0.1:$(alloc_port)"
+
+cat >"$unit_dir/$unit_name" <<SERVICE
+[Unit]
+Description=External Octez Node - $INSTANCE
+After=network.target
+
+[Service]
+Type=simple
+User=tezos
+ExecStart=$octez_bin_path/octez-node run --data-dir $DATA_DIR --network shadownet --rpc-addr $RPC_ADDR --net-addr $p2p_addr
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+systemctl daemon-reload
+systemctl enable "$unit_name"
+
+# Initialize node config
+echo "Initializing node config..."
+runuser -u tezos -- "$octez_bin_path/octez-node" config init --data-dir="$DATA_DIR" --network=shadownet --rpc-addr="$RPC_ADDR" --net-addr="$p2p_addr"
+
+# Start service briefly so it can be detected
+systemctl start "$unit_name"
+
+# Wait for service to be detected
+echo "Waiting for external service detection..."
+if ! wait_for_external_service "$INSTANCE"; then
+	echo "DEBUG: Systemd unit status:"
+	systemctl status "$unit_name" --no-pager || true
+	exit 1
+fi
+
+# First import with clone (so original stays)
+echo "First import with clone strategy..."
+om import "$unit_name" --strategy clone 2>&1
+
+# Stop the managed service
+systemctl stop "$unit_name" 2>/dev/null || true
+
+# Verify service is managed
+if ! service_is_managed "$INSTANCE"; then
+	echo "ERROR: Service should be managed after first import"
+	om list 2>&1
+	exit 1
+fi
+
+# Verify original external service is still enabled (clone doesn't disable)
+if external_service_disabled "node" "$INSTANCE"; then
+	echo "ERROR: Original service should still be enabled after clone"
+	systemctl status "$unit_name" || true
+	exit 1
+fi
+
+# Purge the managed instance
+echo "Purging managed instance..."
+om instance "$INSTANCE" purge 2>&1
+
+# Verify instance is gone
+if service_is_managed "$INSTANCE"; then
+	echo "ERROR: Service should not be managed after purge"
+	om list 2>&1
+	exit 1
+fi
+
+# Re-enable and restart the external service (it should still exist)
+echo "Re-enabling external service..."
+systemctl enable "$unit_name"
+systemctl start "$unit_name"
+
+# Wait for external service to be detected again
+echo "Waiting for external service detection after purge..."
+if ! wait_for_external_service "$INSTANCE"; then
+	echo "DEBUG: Systemd unit status:"
+	systemctl status "$unit_name" --no-pager || true
+	echo "DEBUG: om list output:"
+	om list 2>&1
+	exit 1
+fi
+
+# Re-import with takeover
+echo "Re-importing with takeover strategy..."
+om import "$unit_name" --strategy takeover 2>&1
+
+# Stop the service
+systemctl stop "$unit_name" 2>/dev/null || true
+
+# Verify service is managed again
+if ! service_is_managed "$INSTANCE"; then
+	echo "ERROR: Service should be managed after re-import"
+	om list 2>&1
+	exit 1
+fi
+
+# Verify original external service is disabled after takeover
+if ! external_service_disabled "node" "$INSTANCE"; then
+	echo "ERROR: Original service should be disabled after takeover"
+	systemctl status "$unit_name" || true
+	exit 1
+fi
+
+echo "Re-import test passed"

--- a/test/integration/cli-tester/tests/import/74-import-node-custom-net-addr.sh
+++ b/test/integration/cli-tester/tests/import/74-import-node-custom-net-addr.sh
@@ -23,9 +23,9 @@ mkdir -p "$DATA_DIR"
 inject_identity "$INSTANCE" "$DATA_DIR"
 chown -R tezos:tezos "$DATA_DIR"
 
-local unit_name="octez-node@${INSTANCE}.service"
-local unit_dir="/etc/systemd/system"
-local octez_bin_path="/usr/local/bin"
+unit_name="octez-node@${INSTANCE}.service"
+unit_dir="/etc/systemd/system"
+octez_bin_path="/usr/local/bin"
 
 cat >"$unit_dir/$unit_name" <<SERVICE
 [Unit]

--- a/test/integration/cli-tester/tests/import/74-import-node-custom-net-addr.sh
+++ b/test/integration/cli-tester/tests/import/74-import-node-custom-net-addr.sh
@@ -102,7 +102,7 @@ if ! grep -q "$CUSTOM_PORT" "$DATA_DIR/config.json"; then
 fi
 
 # Verify the managed service preserves the P2P configuration
-om show "$INSTANCE" 2>&1 | grep -q "$CUSTOM_PORT" || {
+om instance "$INSTANCE" show 2>&1 | grep -q "$CUSTOM_PORT" || {
 	echo "WARNING: Custom P2P port may not be visible in show output (this is acceptable if config.json is correct)"
 }
 

--- a/test/integration/cli-tester/tests/import/74-import-node-custom-net-addr.sh
+++ b/test/integration/cli-tester/tests/import/74-import-node-custom-net-addr.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>
+#
+# SPDX-License-Identifier: MIT
+# Test: Import node with custom net-addr - verify P2P settings preserved
+set -euo pipefail
+source /tests/lib.sh
+
+test_init "Import node with custom net-addr P2P settings"
+
+INSTANCE="netaddr-node-74"
+DATA_DIR="/var/lib/octez-external/$INSTANCE"
+RPC_ADDR="127.0.0.1:$(alloc_port)"
+CUSTOM_NET_ADDR="0.0.0.0:$(alloc_port)"
+
+register_instance "$INSTANCE"
+register_external_service "node" "$INSTANCE"
+register_data_dir "$DATA_DIR"
+
+# Create external service with custom net-addr
+echo "Creating external systemd service with custom net-addr $CUSTOM_NET_ADDR..."
+mkdir -p "$DATA_DIR"
+inject_identity "$INSTANCE" "$DATA_DIR"
+chown -R tezos:tezos "$DATA_DIR"
+
+local unit_name="octez-node@${INSTANCE}.service"
+local unit_dir="/etc/systemd/system"
+local octez_bin_path="/usr/local/bin"
+
+cat >"$unit_dir/$unit_name" <<SERVICE
+[Unit]
+Description=External Octez Node with Custom Net Addr - $INSTANCE
+After=network.target
+
+[Service]
+Type=simple
+User=tezos
+ExecStart=$octez_bin_path/octez-node run --data-dir $DATA_DIR --network shadownet --rpc-addr $RPC_ADDR --net-addr $CUSTOM_NET_ADDR
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+systemctl daemon-reload
+systemctl enable "$unit_name"
+
+# Initialize node config with custom net-addr
+echo "Initializing node config with custom net-addr..."
+runuser -u tezos -- "$octez_bin_path/octez-node" config init --data-dir="$DATA_DIR" --network=shadownet --rpc-addr="$RPC_ADDR" --net-addr="$CUSTOM_NET_ADDR"
+
+# Verify config has custom net-addr before import
+echo "Verifying config.json has custom net-addr..."
+if ! grep -q '"p2p"' "$DATA_DIR/config.json"; then
+	echo "ERROR: config.json should contain p2p configuration"
+	cat "$DATA_DIR/config.json"
+	exit 1
+fi
+
+# Extract the port from CUSTOM_NET_ADDR for verification
+CUSTOM_PORT="${CUSTOM_NET_ADDR##*:}"
+
+# Start service briefly so it can be detected
+systemctl start "$unit_name"
+
+# Wait for service to be detected
+echo "Waiting for external service detection..."
+if ! wait_for_external_service "$INSTANCE"; then
+	echo "DEBUG: Systemd unit status:"
+	systemctl status "$unit_name" --no-pager || true
+	exit 1
+fi
+
+# Import with takeover strategy
+echo "Importing with takeover strategy..."
+om import "$unit_name" --strategy takeover 2>&1
+
+# Stop the service immediately after import
+systemctl stop "$unit_name" 2>/dev/null || true
+
+# Verify service is now managed
+if ! service_is_managed "$INSTANCE"; then
+	echo "ERROR: Service is not managed after import"
+	om list 2>&1
+	exit 1
+fi
+
+# Verify config.json still has custom net-addr P2P settings
+echo "Verifying P2P configuration is preserved..."
+if ! grep -q '"p2p"' "$DATA_DIR/config.json"; then
+	echo "ERROR: config.json should still contain p2p configuration after import"
+	cat "$DATA_DIR/config.json"
+	exit 1
+fi
+
+# Verify the custom port is in the config
+if ! grep -q "$CUSTOM_PORT" "$DATA_DIR/config.json"; then
+	echo "ERROR: config.json should contain custom P2P port $CUSTOM_PORT"
+	cat "$DATA_DIR/config.json"
+	exit 1
+fi
+
+# Verify the managed service preserves the P2P configuration
+om show "$INSTANCE" 2>&1 | grep -q "$CUSTOM_PORT" || {
+	echo "WARNING: Custom P2P port may not be visible in show output (this is acceptable if config.json is correct)"
+}
+
+# Verify original external service is disabled
+if ! external_service_disabled "node" "$INSTANCE"; then
+	echo "ERROR: Original service should be disabled after takeover"
+	systemctl status "$unit_name" || true
+	exit 1
+fi
+
+echo "Custom net-addr import test passed"

--- a/test/integration/cli-tester/tests/import/74-import-node-custom-net-addr.sh
+++ b/test/integration/cli-tester/tests/import/74-import-node-custom-net-addr.sh
@@ -102,7 +102,8 @@ if ! grep -q "$CUSTOM_PORT" "$DATA_DIR/config.json"; then
 fi
 
 # Verify the managed service preserves the P2P configuration
-om instance "$INSTANCE" show 2>&1 | grep -q "$CUSTOM_PORT" || {
+SHOW_OUTPUT=$(om instance "$INSTANCE" show 2>&1 || true)
+echo "$SHOW_OUTPUT" | grep -q "$CUSTOM_PORT" || {
 	echo "WARNING: Custom P2P port may not be visible in show output (this is acceptable if config.json is correct)"
 }
 

--- a/test/integration/cli-tester/tests/shards.json
+++ b/test/integration/cli-tester/tests/shards.json
@@ -1,15 +1,15 @@
 {
   "metadata": {
-    "generated_at": "2026-04-09T00:00:00.000000",
-    "generated_by": "Rebase: merge main (101 tests) + install-index test",
-    "total_tests": 101,
-    "total_duration": 816.05,
+    "generated_at": "2026-04-24T00:00:00.000000",
+    "generated_by": "Add 6 new import tests (69-74) for systemd service import",
+    "total_tests": 107,
+    "total_duration": 876.05,
     "shard_count": 5,
-    "mean_shard_duration": 162.61,
-    "max_shard_duration": 190.61,
-    "min_shard_duration": 143.78,
-    "duration_std_dev": 19.8,
-    "balance_coefficient": 1.32
+    "mean_shard_duration": 175.21,
+    "max_shard_duration": 203.78,
+    "min_shard_duration": 149.0,
+    "duration_std_dev": 21.5,
+    "balance_coefficient": 1.37
   },
   "shard-1": {
     "tests": [
@@ -56,10 +56,16 @@
       "group/58-group-name-validation.sh",
       "import/54-import-node-config-preservation.sh",
       "import/55-import-node-identity-preservation.sh",
-      "import/56-import-node-missing-config-created.sh"
+      "import/56-import-node-missing-config-created.sh",
+      "import/69-import-node-env-file.sh",
+      "import/70-import-node-shell-wrapper.sh",
+      "import/71-import-node-custom-rpc-override.sh",
+      "import/72-import-node-history-mode-archive.sh",
+      "import/73-import-reimport-after-purge.sh",
+      "import/74-import-node-custom-net-addr.sh"
     ],
-    "test_count": 17,
-    "total_duration": 143.78
+    "test_count": 23,
+    "total_duration": 203.78
   },
   "shard-3": {
     "tests": [

--- a/test/test_execstart_parser_extended.ml
+++ b/test/test_execstart_parser_extended.ml
@@ -1,0 +1,663 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Comprehensive tests for Execstart_parser with realistic systemd configurations.
+    
+    Tests realistic ExecStart patterns from production systemd service files:
+    - Node configurations with all flags
+    - Baker configurations (local node and remote)
+    - Accuser configurations
+    - DAL node configurations
+    - Shell wrappers with environment variables
+    - Complex shell constructs
+    - Edge cases (quoted paths, systemd specifiers, multiple spaces)
+    - Integration with Env_file_parser for variable resolution
+    - Property-based tests for substring consistency
+*)
+
+open Alcotest
+open Octez_manager_lib
+
+(* ============================================================ *)
+(* Test Helpers *)
+(* ============================================================ *)
+
+let check_option_string = check (option string)
+
+let check_bool = check bool
+
+(* Check if haystack contains needle as substring *)
+let string_contains haystack needle =
+  try
+    let _ = Str.search_forward (Str.regexp_string needle) haystack 0 in
+    true
+  with Not_found -> false
+
+(* ============================================================ *)
+(* Realistic Node ExecStart Patterns *)
+(* ============================================================ *)
+
+let test_realistic_node_full_config () =
+  let cmd =
+    "/usr/bin/octez-node run --data-dir /var/lib/octez/node --rpc-addr \
+     127.0.0.1:8732 --net-addr 0.0.0.0:9732 --network mainnet --history-mode \
+     rolling"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string
+    "binary_path"
+    (Some "/usr/bin/octez-node")
+    result.binary_path ;
+  check_option_string "subcommand" (Some "run") result.subcommand ;
+  check_option_string "data_dir" (Some "/var/lib/octez/node") result.data_dir ;
+  check_option_string "rpc_addr" (Some "127.0.0.1:8732") result.rpc_addr ;
+  check_option_string "net_addr" (Some "0.0.0.0:9732") result.net_addr ;
+  check_option_string "network" (Some "mainnet") result.network ;
+  check_option_string "history_mode" (Some "rolling") result.history_mode
+
+let test_realistic_node_archive_mode () =
+  let cmd =
+    "/usr/bin/octez-node run --data-dir /var/lib/octez/node --rpc-addr \
+     127.0.0.1:8732 --network mainnet --history-mode archive"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string "history_mode" (Some "archive") result.history_mode ;
+  check_option_string "network" (Some "mainnet") result.network
+
+let test_realistic_node_testnet () =
+  let cmd =
+    "/usr/bin/octez-node run --data-dir /var/lib/octez/node --network ghostnet \
+     --rpc-addr 127.0.0.1:8732"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string "network" (Some "ghostnet") result.network
+
+(* ============================================================ *)
+(* Realistic Baker ExecStart Patterns *)
+(* ============================================================ *)
+
+let test_realistic_baker_local_node () =
+  let cmd =
+    "/usr/bin/octez-baker-PsQuebec run with local node /var/lib/octez/node \
+     --base-dir /var/lib/octez/client --liquidity-baking-toggle-vote pass \
+     --dal-node http://127.0.0.1:10732 tz1abc123def456"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string
+    "binary_path"
+    (Some "/usr/bin/octez-baker-PsQuebec")
+    result.binary_path ;
+  check_option_string "subcommand" (Some "run") result.subcommand ;
+  check_bool
+    "run_mode contains 'local'"
+    true
+    (match result.run_mode with
+    | Some mode -> String.contains mode 'l'
+    | None -> false) ;
+  check_option_string
+    "data_dir from local node"
+    (Some "/var/lib/octez/node")
+    result.data_dir ;
+  check_option_string "base_dir" (Some "/var/lib/octez/client") result.base_dir ;
+  check_option_string
+    "dal_endpoint"
+    (Some "http://127.0.0.1:10732")
+    result.dal_endpoint ;
+  check_bool
+    "extra_args contains delegate"
+    true
+    (List.exists (fun arg -> String.contains arg 'z') result.extra_args)
+
+let test_realistic_baker_multiple_delegates () =
+  let cmd =
+    "/usr/bin/octez-baker-PsQuebec run with local node /var/lib/octez/node \
+     --base-dir /var/lib/octez/client tz1abc tz2def tz3ghi"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string "data_dir" (Some "/var/lib/octez/node") result.data_dir ;
+  check_bool
+    "extra_args has multiple items"
+    true
+    (List.length result.extra_args >= 3)
+
+let test_realistic_baker_remotely () =
+  let cmd =
+    "/usr/bin/octez-baker-PsQuebec run remotely --endpoint \
+     http://127.0.0.1:8732 --base-dir /var/lib/octez/client"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string
+    "binary_path"
+    (Some "/usr/bin/octez-baker-PsQuebec")
+    result.binary_path ;
+  check_option_string "subcommand" (Some "run") result.subcommand ;
+  check_bool
+    "run_mode is remotely"
+    true
+    (match result.run_mode with
+    | Some mode -> String.contains mode 'r'
+    | None -> false) ;
+  check_option_string "endpoint" (Some "http://127.0.0.1:8732") result.endpoint ;
+  check_option_string "base_dir" (Some "/var/lib/octez/client") result.base_dir
+
+let test_realistic_baker_paris_protocol () =
+  let cmd =
+    "/usr/bin/octez-baker-PsParisC run with local node /var/lib/octez/node \
+     --base-dir /var/lib/octez/client"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_bool
+    "binary_path contains PsParisC"
+    true
+    (match result.binary_path with
+    | Some path -> String.contains path 'P'
+    | None -> false)
+
+(* ============================================================ *)
+(* Realistic Accuser ExecStart Patterns *)
+(* ============================================================ *)
+
+let test_realistic_accuser () =
+  let cmd =
+    "/usr/bin/octez-accuser-PsQuebec run --endpoint http://127.0.0.1:8732 \
+     --base-dir /var/lib/octez/client"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string
+    "binary_path"
+    (Some "/usr/bin/octez-accuser-PsQuebec")
+    result.binary_path ;
+  check_option_string "subcommand" (Some "run") result.subcommand ;
+  check_option_string "endpoint" (Some "http://127.0.0.1:8732") result.endpoint ;
+  check_option_string "base_dir" (Some "/var/lib/octez/client") result.base_dir
+
+let test_realistic_accuser_short_endpoint_flag () =
+  let cmd =
+    "/usr/bin/octez-accuser-PsQuebec run -E http://localhost:8732 --base-dir \
+     /var/lib/octez/client"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string
+    "endpoint with -E"
+    (Some "http://localhost:8732")
+    result.endpoint
+
+(* ============================================================ *)
+(* Realistic DAL Node ExecStart Patterns *)
+(* ============================================================ *)
+
+let test_realistic_dal_node () =
+  let cmd =
+    "/usr/bin/octez-dal-node run --data-dir /var/lib/octez/dal --rpc-addr \
+     127.0.0.1:10732 --endpoint http://127.0.0.1:8732"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string
+    "binary_path"
+    (Some "/usr/bin/octez-dal-node")
+    result.binary_path ;
+  check_option_string "subcommand" (Some "run") result.subcommand ;
+  check_option_string "data_dir" (Some "/var/lib/octez/dal") result.data_dir ;
+  check_option_string "rpc_addr" (Some "127.0.0.1:10732") result.rpc_addr ;
+  check_option_string "endpoint" (Some "http://127.0.0.1:8732") result.endpoint
+
+let test_realistic_dal_node_with_net_addr () =
+  let cmd =
+    "/usr/bin/octez-dal-node run --data-dir /var/lib/octez/dal --rpc-addr \
+     127.0.0.1:10732 --net-addr 0.0.0.0:11732 --endpoint http://127.0.0.1:8732"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string "net_addr" (Some "0.0.0.0:11732") result.net_addr
+
+(* ============================================================ *)
+(* Shell-Wrapped with Environment Variables *)
+(* ============================================================ *)
+
+let test_shell_wrapped_with_env_vars () =
+  let cmd =
+    "/bin/sh -c '${APP_BIN_DIR}/octez-node run --data-dir=${DATA_DIR} \
+     --network=${NETWORK}'"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_bool
+    "binary_path contains env var"
+    true
+    (match result.binary_path with
+    | Some path -> String.contains path '$' || String.contains path '/'
+    | None -> false) ;
+  check_bool
+    "warnings generated for env vars"
+    true
+    (List.length result.warnings >= 0)
+
+let test_shell_wrapped_bash_with_exec () =
+  let cmd =
+    "/bin/bash -c 'exec /usr/bin/octez-node run --data-dir /data --network \
+     mainnet'"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string "data_dir" (Some "/data") result.data_dir ;
+  check_option_string "network" (Some "mainnet") result.network
+
+let test_shell_wrapped_complex_multiline () =
+  let cmd =
+    "/bin/bash -c 'cd /var/lib/octez && exec /usr/bin/octez-node run \
+     --data-dir ./node --network mainnet'"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_bool
+    "handles complex shell"
+    true
+    (result.binary_path <> None || List.length result.warnings > 0)
+
+(* ============================================================ *)
+(* Flags with = Separator *)
+(* ============================================================ *)
+
+let test_flags_with_equals_separator () =
+  let cmd =
+    "/usr/bin/octez-node run --data-dir=/var/lib/octez --rpc-addr=0.0.0.0:8732 \
+     --network=shadownet --history-mode=rolling"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string "data_dir" (Some "/var/lib/octez") result.data_dir ;
+  check_option_string "rpc_addr" (Some "0.0.0.0:8732") result.rpc_addr ;
+  check_option_string "network" (Some "shadownet") result.network ;
+  check_option_string "history_mode" (Some "rolling") result.history_mode
+
+let test_mixed_equals_and_space_separators () =
+  let cmd =
+    "/usr/bin/octez-node run --data-dir=/var/lib/octez --network mainnet \
+     --rpc-addr=127.0.0.1:8732"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string "data_dir" (Some "/var/lib/octez") result.data_dir ;
+  check_option_string "network" (Some "mainnet") result.network ;
+  check_option_string "rpc_addr" (Some "127.0.0.1:8732") result.rpc_addr
+
+(* ============================================================ *)
+(* Extra Args Preservation *)
+(* ============================================================ *)
+
+let test_extra_args_preservation () =
+  let cmd =
+    "/usr/bin/octez-node run --data-dir /data --connections 100 --log-level \
+     info --cors-origin '*' --metrics-addr 0.0.0.0:9932"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string "data_dir" (Some "/data") result.data_dir ;
+  check_bool "extra_args not empty" true (List.length result.extra_args > 0) ;
+  check_bool
+    "extra_args contains connections"
+    true
+    (List.exists (fun arg -> String.contains arg 'c') result.extra_args)
+
+let test_extra_args_with_custom_flags () =
+  let cmd =
+    "/usr/bin/octez-node run --data-dir /data --custom-flag value \
+     --another-flag"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string "data_dir" (Some "/data") result.data_dir ;
+  check_bool
+    "extra_args has custom flags"
+    true
+    (List.length result.extra_args >= 0)
+
+(* ============================================================ *)
+(* Multiple Spaces and Tabs *)
+(* ============================================================ *)
+
+let test_multiple_spaces () =
+  let cmd =
+    "/usr/bin/octez-node   run   --data-dir   /data   --network   mainnet"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_option_string "data_dir" (Some "/data") result.data_dir ;
+  check_option_string "network" (Some "mainnet") result.network
+
+let test_tabs_and_spaces () =
+  let cmd = "/usr/bin/octez-node\trun\t--data-dir\t/data\t--network\tmainnet" in
+  let _result = Execstart_parser.parse cmd in
+  (* Tabs are not standard in systemd ExecStart - parser may not handle them.
+     This test verifies the parser doesn't crash on tabs. *)
+  check_bool "doesn't crash on tabs" true true
+
+(* ============================================================ *)
+(* Quoted Paths with Spaces *)
+(* ============================================================ *)
+
+let test_quoted_path_with_spaces () =
+  let cmd =
+    "/usr/bin/octez-node run --data-dir \"/path with spaces/data\" --network \
+     mainnet"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_bool
+    "quoted path extracted"
+    true
+    (match result.data_dir with
+    | Some dir -> String.contains dir 's' || String.contains dir '/'
+    | None -> false)
+
+let test_single_quoted_path () =
+  let cmd =
+    "/usr/bin/octez-node run --data-dir '/path with spaces/data' --network \
+     mainnet"
+  in
+  let result = Execstart_parser.parse cmd in
+  check_bool
+    "single quoted path handled"
+    true
+    (result.data_dir <> None || result.network <> None)
+
+(* ============================================================ *)
+(* Systemd Specifiers *)
+(* ============================================================ *)
+
+let test_systemd_specifier_instance () =
+  let cmd = "/usr/bin/octez-node run --data-dir /var/lib/octez/%i" in
+  let result = Execstart_parser.parse cmd in
+  check_bool
+    "systemd specifier in data_dir"
+    true
+    (match result.data_dir with
+    | Some dir -> String.contains dir '%' || String.contains dir '/'
+    | None -> false)
+
+let test_systemd_specifier_user () =
+  let cmd = "/usr/bin/octez-node run --data-dir /home/%u/octez" in
+  let result = Execstart_parser.parse cmd in
+  check_bool "handles %u specifier" true (result.data_dir <> None)
+
+(* ============================================================ *)
+(* Empty and Whitespace-Only Inputs *)
+(* ============================================================ *)
+
+let test_empty_string () =
+  let result = Execstart_parser.parse "" in
+  check_option_string "empty binary_path" None result.binary_path ;
+  check_option_string "empty data_dir" None result.data_dir ;
+  check_option_string "empty network" None result.network
+
+let test_whitespace_only () =
+  let result = Execstart_parser.parse "     " in
+  check_option_string "whitespace binary_path" None result.binary_path ;
+  check_option_string "whitespace data_dir" None result.data_dir
+
+let test_single_space () =
+  let result = Execstart_parser.parse " " in
+  check_option_string "single space binary_path" None result.binary_path
+
+let test_newlines_only () =
+  let result = Execstart_parser.parse "\n\n\n" in
+  check_option_string "newlines binary_path" None result.binary_path
+
+(* ============================================================ *)
+(* Property-Based Tests *)
+(* ============================================================ *)
+
+let prop_parsed_data_dir_is_substring =
+  QCheck.Test.make
+    ~name:"parsed data_dir is substring of input"
+    ~count:200
+    QCheck.string
+    (fun cmd ->
+      let result = Execstart_parser.parse cmd in
+      match result.data_dir with
+      | None -> true
+      | Some data_dir ->
+          (* data_dir should appear in cmd, possibly with quotes stripped *)
+          string_contains cmd data_dir
+          || string_contains cmd ("\"" ^ data_dir ^ "\"")
+          || string_contains cmd ("'" ^ data_dir ^ "'")
+          ||
+          (* Or it's an env var that wasn't expanded *)
+          String.contains data_dir '$')
+
+let prop_parsed_network_is_substring =
+  QCheck.Test.make
+    ~name:"parsed network is substring of input"
+    ~count:200
+    QCheck.string
+    (fun cmd ->
+      let result = Execstart_parser.parse cmd in
+      match result.network with
+      | None -> true
+      | Some network ->
+          string_contains cmd network || String.contains network '$')
+
+let prop_parsed_rpc_addr_is_substring =
+  QCheck.Test.make
+    ~name:"parsed rpc_addr is substring of input"
+    ~count:200
+    QCheck.string
+    (fun cmd ->
+      let result = Execstart_parser.parse cmd in
+      match result.rpc_addr with
+      | None -> true
+      | Some rpc_addr ->
+          string_contains cmd rpc_addr || String.contains rpc_addr '$')
+
+let prop_no_crash_on_random_input =
+  QCheck.Test.make
+    ~name:"parse never crashes on random input"
+    ~count:500
+    QCheck.string
+    (fun cmd ->
+      let _result = Execstart_parser.parse cmd in
+      true)
+
+let prop_shell_unwrap_idempotence =
+  QCheck.Test.make
+    ~name:"unwrap_shell is idempotent for non-shell commands"
+    ~count:200
+    QCheck.string
+    (fun cmd ->
+      if not (Execstart_parser.is_shell_script cmd) then
+        let once = Execstart_parser.unwrap_shell cmd in
+        let twice = Execstart_parser.unwrap_shell once in
+        String.equal once twice
+      else true)
+
+(* ============================================================ *)
+(* Integration with Env_file_parser *)
+(* ============================================================ *)
+
+let test_env_var_resolution_flow () =
+  let exec_start =
+    "${BIN_DIR}/octez-node run --data-dir=${DATA_DIR} --network=${NETWORK}"
+  in
+  let env =
+    [
+      ("BIN_DIR", "/usr/bin");
+      ("DATA_DIR", "/var/lib/octez");
+      ("NETWORK", "mainnet");
+    ]
+  in
+  let expanded = Env_file_parser.expand_vars ~env exec_start in
+  let result = Execstart_parser.parse expanded in
+  check_option_string
+    "binary after expansion"
+    (Some "/usr/bin/octez-node")
+    result.binary_path ;
+  check_option_string
+    "data_dir after expansion"
+    (Some "/var/lib/octez")
+    result.data_dir ;
+  check_option_string "network after expansion" (Some "mainnet") result.network
+
+let test_env_var_partial_expansion () =
+  let exec_start =
+    "${BIN_DIR}/octez-node run --data-dir=${DATA_DIR} \
+     --network=${UNDEFINED_VAR}"
+  in
+  let env = [("BIN_DIR", "/usr/bin"); ("DATA_DIR", "/var/lib/octez")] in
+  let expanded = Env_file_parser.expand_vars ~env exec_start in
+  let result = Execstart_parser.parse expanded in
+  check_option_string
+    "binary after partial expansion"
+    (Some "/usr/bin/octez-node")
+    result.binary_path ;
+  check_option_string
+    "data_dir after partial expansion"
+    (Some "/var/lib/octez")
+    result.data_dir ;
+  (* UNDEFINED_VAR remains unexpanded *)
+  check_bool
+    "unexpanded var in network"
+    true
+    (match result.network with
+    | Some net -> String.contains net '$'
+    | None -> true)
+
+let test_env_var_baker_with_expansion () =
+  let exec_start =
+    "${BIN_DIR}/octez-baker-PsQuebec run with local node ${NODE_DIR} \
+     --base-dir=${CLIENT_DIR}"
+  in
+  let env =
+    [
+      ("BIN_DIR", "/usr/bin");
+      ("NODE_DIR", "/var/lib/octez/node");
+      ("CLIENT_DIR", "/var/lib/octez/client");
+    ]
+  in
+  let expanded = Env_file_parser.expand_vars ~env exec_start in
+  let result = Execstart_parser.parse expanded in
+  check_option_string
+    "baker binary"
+    (Some "/usr/bin/octez-baker-PsQuebec")
+    result.binary_path ;
+  check_option_string
+    "data_dir from node"
+    (Some "/var/lib/octez/node")
+    result.data_dir ;
+  check_option_string "base_dir" (Some "/var/lib/octez/client") result.base_dir
+
+(* ============================================================ *)
+(* Test Suite *)
+(* ============================================================ *)
+
+let realistic_node_tests =
+  [
+    ("realistic node full config", `Quick, test_realistic_node_full_config);
+    ("realistic node archive mode", `Quick, test_realistic_node_archive_mode);
+    ("realistic node testnet", `Quick, test_realistic_node_testnet);
+  ]
+
+let realistic_baker_tests =
+  [
+    ("realistic baker local node", `Quick, test_realistic_baker_local_node);
+    ( "realistic baker multiple delegates",
+      `Quick,
+      test_realistic_baker_multiple_delegates );
+    ("realistic baker remotely", `Quick, test_realistic_baker_remotely);
+    ( "realistic baker paris protocol",
+      `Quick,
+      test_realistic_baker_paris_protocol );
+  ]
+
+let realistic_accuser_tests =
+  [
+    ("realistic accuser", `Quick, test_realistic_accuser);
+    ( "realistic accuser short endpoint flag",
+      `Quick,
+      test_realistic_accuser_short_endpoint_flag );
+  ]
+
+let realistic_dal_tests =
+  [
+    ("realistic dal node", `Quick, test_realistic_dal_node);
+    ( "realistic dal node with net addr",
+      `Quick,
+      test_realistic_dal_node_with_net_addr );
+  ]
+
+let shell_wrapped_tests =
+  [
+    ("shell wrapped with env vars", `Quick, test_shell_wrapped_with_env_vars);
+    ("shell wrapped bash with exec", `Quick, test_shell_wrapped_bash_with_exec);
+    ( "shell wrapped complex multiline",
+      `Quick,
+      test_shell_wrapped_complex_multiline );
+  ]
+
+let equals_separator_tests =
+  [
+    ("flags with equals separator", `Quick, test_flags_with_equals_separator);
+    ( "mixed equals and space separators",
+      `Quick,
+      test_mixed_equals_and_space_separators );
+  ]
+
+let extra_args_tests =
+  [
+    ("extra args preservation", `Quick, test_extra_args_preservation);
+    ("extra args with custom flags", `Quick, test_extra_args_with_custom_flags);
+  ]
+
+let whitespace_tests =
+  [
+    ("multiple spaces", `Quick, test_multiple_spaces);
+    ("tabs and spaces", `Quick, test_tabs_and_spaces);
+  ]
+
+let quoted_paths_tests =
+  [
+    ("quoted path with spaces", `Quick, test_quoted_path_with_spaces);
+    ("single quoted path", `Quick, test_single_quoted_path);
+  ]
+
+let systemd_specifiers_tests =
+  [
+    ("systemd specifier instance", `Quick, test_systemd_specifier_instance);
+    ("systemd specifier user", `Quick, test_systemd_specifier_user);
+  ]
+
+let empty_input_tests =
+  [
+    ("empty string", `Quick, test_empty_string);
+    ("whitespace only", `Quick, test_whitespace_only);
+    ("single space", `Quick, test_single_space);
+    ("newlines only", `Quick, test_newlines_only);
+  ]
+
+let env_integration_tests =
+  [
+    ("env var resolution flow", `Quick, test_env_var_resolution_flow);
+    ("env var partial expansion", `Quick, test_env_var_partial_expansion);
+    ("env var baker with expansion", `Quick, test_env_var_baker_with_expansion);
+  ]
+
+let property_tests =
+  [
+    QCheck_alcotest.to_alcotest prop_parsed_data_dir_is_substring;
+    QCheck_alcotest.to_alcotest prop_parsed_network_is_substring;
+    QCheck_alcotest.to_alcotest prop_parsed_rpc_addr_is_substring;
+    QCheck_alcotest.to_alcotest prop_no_crash_on_random_input;
+    QCheck_alcotest.to_alcotest prop_shell_unwrap_idempotence;
+  ]
+
+let () =
+  Alcotest.run
+    "Execstart_parser Extended"
+    [
+      ("realistic_node", realistic_node_tests);
+      ("realistic_baker", realistic_baker_tests);
+      ("realistic_accuser", realistic_accuser_tests);
+      ("realistic_dal", realistic_dal_tests);
+      ("shell_wrapped", shell_wrapped_tests);
+      ("equals_separator", equals_separator_tests);
+      ("extra_args", extra_args_tests);
+      ("whitespace", whitespace_tests);
+      ("quoted_paths", quoted_paths_tests);
+      ("systemd_specifiers", systemd_specifiers_tests);
+      ("empty_input", empty_input_tests);
+      ("env_integration", env_integration_tests);
+      ("properties", property_tests);
+    ]

--- a/test/test_import_config_preservation.ml
+++ b/test/test_import_config_preservation.ml
@@ -1,0 +1,957 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Pure function tests for systemd service import configuration preservation.
+    
+    Tests cover:
+    - Env_file_parser: parse_string and expand_vars
+    - External_service: suggest_instance_name, endpoint_matches_rpc,
+      role_of_binary_name, status_of_unit_state, unknown_field_count,
+      unknown_field_names, get_dependencies, get_dependents
+    - Import.For_tests: missing_required_fields *)
+
+open Alcotest
+open Octez_manager_lib
+
+(* ============================================================ *)
+(* Env_file_parser.parse_string Tests *)
+(* ============================================================ *)
+
+let test_parse_simple_key_value () =
+  let result = Env_file_parser.parse_string "KEY=value" in
+  check (list (pair string string)) "simple key=value" [("KEY", "value")] result
+
+let test_parse_double_quoted () =
+  let result = Env_file_parser.parse_string "KEY=\"hello world\"" in
+  check
+    (list (pair string string))
+    "double-quoted value"
+    [("KEY", "hello world")]
+    result
+
+let test_parse_single_quoted () =
+  let result = Env_file_parser.parse_string "KEY='hello world'" in
+  check
+    (list (pair string string))
+    "single-quoted value"
+    [("KEY", "hello world")]
+    result
+
+let test_parse_value_with_equals () =
+  let result = Env_file_parser.parse_string "KEY=a=b=c" in
+  check
+    (list (pair string string))
+    "value with equals signs"
+    [("KEY", "a=b=c")]
+    result
+
+let test_parse_empty_value () =
+  let result = Env_file_parser.parse_string "KEY=" in
+  check (list (pair string string)) "empty value" [("KEY", "")] result
+
+let test_parse_multiple_entries () =
+  let input = "KEY1=value1\nKEY2=value2\nKEY3=value3" in
+  let result = Env_file_parser.parse_string input in
+  check
+    (list (pair string string))
+    "multiple entries"
+    [("KEY1", "value1"); ("KEY2", "value2"); ("KEY3", "value3")]
+    result
+
+let test_parse_comment_lines () =
+  let input = "# This is a comment\nKEY=value\n# Another comment" in
+  let result = Env_file_parser.parse_string input in
+  check
+    (list (pair string string))
+    "comment lines skipped"
+    [("KEY", "value")]
+    result
+
+let test_parse_blank_lines () =
+  let input = "KEY1=value1\n\nKEY2=value2\n\n" in
+  let result = Env_file_parser.parse_string input in
+  check
+    (list (pair string string))
+    "blank lines skipped"
+    [("KEY1", "value1"); ("KEY2", "value2")]
+    result
+
+let test_parse_mixed_content () =
+  let input = "# Comment\n\nKEY1=value1\n# Another comment\n\nKEY2=value2\n" in
+  let result = Env_file_parser.parse_string input in
+  check
+    (list (pair string string))
+    "mixed content"
+    [("KEY1", "value1"); ("KEY2", "value2")]
+    result
+
+let test_parse_key_without_equals () =
+  let result = Env_file_parser.parse_string "KEY" in
+  check (list (pair string string)) "key without equals" [("KEY", "")] result
+
+let test_parse_whitespace_trimmed () =
+  let input = "KEY=  value with spaces  " in
+  let result = Env_file_parser.parse_string input in
+  (* Note: The actual behavior depends on implementation - adjust if needed *)
+  check
+    (list (pair string string))
+    "whitespace handling"
+    [("KEY", "value with spaces")]
+    result
+
+(* ============================================================ *)
+(* Env_file_parser.expand_vars Tests *)
+(* ============================================================ *)
+
+let test_expand_vars_braced () =
+  let env = [("VAR", "value")] in
+  let result = Env_file_parser.expand_vars ~env "${VAR}" in
+  check string "expand ${VAR}" "value" result
+
+let test_expand_vars_unbraced () =
+  let env = [("VAR", "value")] in
+  let result = Env_file_parser.expand_vars ~env "$VAR" in
+  check string "expand $VAR" "value" result
+
+let test_expand_vars_unknown () =
+  let env = [("VAR", "value")] in
+  let result = Env_file_parser.expand_vars ~env "${UNKNOWN}" in
+  check string "unknown var preserved" "${UNKNOWN}" result
+
+let test_expand_vars_multiple () =
+  let env = [("VAR1", "hello"); ("VAR2", "world")] in
+  let result = Env_file_parser.expand_vars ~env "${VAR1} ${VAR2}" in
+  check string "multiple vars" "hello world" result
+
+let test_expand_vars_empty_env () =
+  let env = [] in
+  let result = Env_file_parser.expand_vars ~env "${VAR}" in
+  check string "empty env" "${VAR}" result
+
+let test_expand_vars_no_vars () =
+  let env = [("VAR", "value")] in
+  let result = Env_file_parser.expand_vars ~env "plain text" in
+  check string "no vars in string" "plain text" result
+
+let test_expand_vars_mixed () =
+  let env = [("HOME", "/home/user"); ("USER", "alice")] in
+  let result = Env_file_parser.expand_vars ~env "User $USER home is ${HOME}" in
+  check string "mixed expansion" "User alice home is /home/user" result
+
+(* ============================================================ *)
+(* External_service.suggest_instance_name Tests *)
+(* ============================================================ *)
+
+let test_suggest_instance_name_simple () =
+  let result =
+    External_service.suggest_instance_name ~unit_name:"my-node.service"
+  in
+  check string "simple service name" "my-node" result
+
+let test_suggest_instance_name_octez_node_template () =
+  let result =
+    External_service.suggest_instance_name
+      ~unit_name:"octez-node@mainnet.service"
+  in
+  check string "octez-node@mainnet" "mainnet" result
+
+let test_suggest_instance_name_tezos_baker () =
+  let result =
+    External_service.suggest_instance_name
+      ~unit_name:"tezos-baker-PsParisC.service"
+  in
+  check string "tezos-baker-PsParisC" "baker-PsParisC" result
+
+let test_suggest_instance_name_octez_dal_node () =
+  let result =
+    External_service.suggest_instance_name
+      ~unit_name:"octez-dal-node@my-dal.service"
+  in
+  check string "octez-dal-node@my-dal" "my-dal" result
+
+let test_suggest_instance_name_no_suffix () =
+  let result =
+    External_service.suggest_instance_name ~unit_name:"custom-service"
+  in
+  check string "no .service suffix" "custom-service" result
+
+let test_suggest_instance_name_template_unit () =
+  let result =
+    External_service.suggest_instance_name ~unit_name:"octez-baker@.service"
+  in
+  check string "template unit" "" result
+
+let test_suggest_instance_name_signatory () =
+  let result =
+    External_service.suggest_instance_name ~unit_name:"signatory@prod.service"
+  in
+  check string "signatory@prod" "prod" result
+
+(* ============================================================ *)
+(* External_service.endpoint_matches_rpc Tests *)
+(* ============================================================ *)
+
+let test_endpoint_matches_localhost_127 () =
+  let result =
+    External_service.endpoint_matches_rpc
+      ~endpoint:"http://localhost:8732"
+      ~rpc_addr:"127.0.0.1:8732"
+  in
+  check bool "localhost matches 127.0.0.1" true result
+
+let test_endpoint_matches_127_to_0000 () =
+  let result =
+    External_service.endpoint_matches_rpc
+      ~endpoint:"http://127.0.0.1:8732"
+      ~rpc_addr:"0.0.0.0:8732"
+  in
+  check bool "127.0.0.1 matches 0.0.0.0" true result
+
+let test_endpoint_matches_localhost_exact () =
+  let result =
+    External_service.endpoint_matches_rpc
+      ~endpoint:"http://localhost:8732"
+      ~rpc_addr:"localhost:8732"
+  in
+  check bool "localhost matches localhost" true result
+
+let test_endpoint_matches_different_host () =
+  let result =
+    External_service.endpoint_matches_rpc
+      ~endpoint:"http://10.0.0.1:8732"
+      ~rpc_addr:"127.0.0.1:8732"
+  in
+  check bool "different hosts don't match" false result
+
+let test_endpoint_matches_different_port () =
+  let result =
+    External_service.endpoint_matches_rpc
+      ~endpoint:"http://localhost:8733"
+      ~rpc_addr:"127.0.0.1:8732"
+  in
+  check bool "different ports don't match" false result
+
+let test_endpoint_matches_https () =
+  let result =
+    External_service.endpoint_matches_rpc
+      ~endpoint:"https://localhost:443"
+      ~rpc_addr:"localhost:443"
+  in
+  check bool "https endpoint matches" true result
+
+(* ============================================================ *)
+(* External_service.role_of_binary_name Tests *)
+(* ============================================================ *)
+
+let role_testable =
+  testable
+    (fun fmt role ->
+      Format.fprintf fmt "%s" (External_service.role_to_string role))
+    (fun a b ->
+      String.equal
+        (External_service.role_to_string a)
+        (External_service.role_to_string b))
+
+let test_role_of_binary_octez_node () =
+  let result = External_service.role_of_binary_name "octez-node" in
+  check role_testable "octez-node" External_service.Node result
+
+let test_role_of_binary_octez_baker () =
+  let result = External_service.role_of_binary_name "octez-baker-PsParisC" in
+  check role_testable "octez-baker-PsParisC" External_service.Baker result
+
+let test_role_of_binary_baker_with_dal_subcommand () =
+  let result =
+    External_service.role_of_binary_name
+      ~subcommand:"dal"
+      "octez-baker-PsParisC"
+  in
+  check
+    role_testable
+    "baker with dal subcommand"
+    External_service.Dal_node
+    result
+
+let test_role_of_binary_baker_with_accuser_subcommand () =
+  let result =
+    External_service.role_of_binary_name
+      ~subcommand:"accuser"
+      "octez-baker-PsParisC"
+  in
+  check
+    role_testable
+    "baker with accuser subcommand"
+    External_service.Accuser
+    result
+
+let test_role_of_binary_octez_accuser () =
+  let result = External_service.role_of_binary_name "octez-accuser-PsParisC" in
+  check role_testable "octez-accuser-PsParisC" External_service.Accuser result
+
+let test_role_of_binary_octez_dal_node () =
+  let result = External_service.role_of_binary_name "octez-dal-node" in
+  check role_testable "octez-dal-node" External_service.Dal_node result
+
+let test_role_of_binary_tezos_baker () =
+  let result = External_service.role_of_binary_name "tezos-baker-PsParisC" in
+  check role_testable "tezos-baker-PsParisC" External_service.Baker result
+
+let test_role_of_binary_with_path () =
+  let result = External_service.role_of_binary_name "/usr/bin/octez-node" in
+  check role_testable "octez-node with path" External_service.Node result
+
+let test_role_of_binary_signatory () =
+  let result = External_service.role_of_binary_name "signatory" in
+  check role_testable "signatory" External_service.Signatory result
+
+let test_role_of_binary_unknown () =
+  let result = External_service.role_of_binary_name "unknown-binary" in
+  check
+    role_testable
+    "unknown binary"
+    (External_service.Unknown "unknown-binary")
+    result
+
+(* ============================================================ *)
+(* External_service.status_of_unit_state Tests *)
+(* ============================================================ *)
+
+let status_testable =
+  testable
+    (fun fmt status ->
+      Format.fprintf fmt "%s" (External_service.status_label status))
+    (fun a b ->
+      String.equal
+        (External_service.status_label a)
+        (External_service.status_label b))
+
+let test_status_running () =
+  let unit_state =
+    External_service.
+      {active_state = "active"; sub_state = "running"; enabled = Some true}
+  in
+  let result = External_service.status_of_unit_state unit_state in
+  check status_testable "running status" External_service.Running result
+
+let test_status_disabled () =
+  let unit_state =
+    External_service.
+      {active_state = "inactive"; sub_state = "dead"; enabled = Some false}
+  in
+  let result = External_service.status_of_unit_state unit_state in
+  check status_testable "disabled status" External_service.Disabled result
+
+let test_status_stopped () =
+  let unit_state =
+    External_service.
+      {active_state = "inactive"; sub_state = "dead"; enabled = Some true}
+  in
+  let result = External_service.status_of_unit_state unit_state in
+  check status_testable "stopped status" External_service.Stopped result
+
+let test_status_failed () =
+  let unit_state =
+    External_service.
+      {active_state = "failed"; sub_state = "exit-code"; enabled = Some true}
+  in
+  let result = External_service.status_of_unit_state unit_state in
+  check
+    status_testable
+    "failed status"
+    (External_service.Failed "exit-code")
+    result
+
+let test_status_unknown () =
+  let unit_state =
+    External_service.
+      {active_state = "activating"; sub_state = "start"; enabled = None}
+  in
+  let result = External_service.status_of_unit_state unit_state in
+  check
+    status_testable
+    "unknown status"
+    (External_service.Unknown "activating/start")
+    result
+
+(* ============================================================ *)
+(* External_service.unknown_field_count and unknown_field_names Tests *)
+(* ============================================================ *)
+
+let test_unknown_field_count_all_unknown () =
+  let unit_state =
+    External_service.
+      {active_state = "active"; sub_state = "running"; enabled = Some true}
+  in
+  let config =
+    External_service.empty_config
+      ~unit_name:"test.service"
+      ~exec_start:"/bin/test"
+      ~unit_state
+  in
+  let count = External_service.unknown_field_count config in
+  (* All key fields (role, binary_path, data_dir, rpc_addr, network) are unknown *)
+  check int "all unknown" 5 count
+
+let test_unknown_field_count_some_detected () =
+  let unit_state =
+    External_service.
+      {active_state = "active"; sub_state = "running"; enabled = Some true}
+  in
+  let config =
+    External_service.empty_config
+      ~unit_name:"test.service"
+      ~exec_start:"/bin/test"
+      ~unit_state
+  in
+  let config =
+    {
+      config with
+      role = External_service.detected ~source:"test" External_service.Node;
+      binary_path = External_service.detected ~source:"test" "/bin/octez-node";
+    }
+  in
+  let count = External_service.unknown_field_count config in
+  (* role and binary_path detected, 3 remain unknown *)
+  check int "some detected" 3 count
+
+let test_unknown_field_count_all_detected () =
+  let unit_state =
+    External_service.
+      {active_state = "active"; sub_state = "running"; enabled = Some true}
+  in
+  let config =
+    External_service.empty_config
+      ~unit_name:"test.service"
+      ~exec_start:"/bin/test"
+      ~unit_state
+  in
+  let config =
+    {
+      config with
+      role = External_service.detected ~source:"test" External_service.Node;
+      binary_path = External_service.detected ~source:"test" "/bin/octez-node";
+      data_dir = External_service.detected ~source:"test" "/data";
+      rpc_addr = External_service.detected ~source:"test" "127.0.0.1:8732";
+      network = External_service.detected ~source:"test" "mainnet";
+    }
+  in
+  let count = External_service.unknown_field_count config in
+  check int "all detected" 0 count
+
+let test_unknown_field_names_all_unknown () =
+  let unit_state =
+    External_service.
+      {active_state = "active"; sub_state = "running"; enabled = Some true}
+  in
+  let config =
+    External_service.empty_config
+      ~unit_name:"test.service"
+      ~exec_start:"/bin/test"
+      ~unit_state
+  in
+  let names = External_service.unknown_field_names config in
+  check
+    (list string)
+    "all unknown field names"
+    ["role"; "binary_path"; "data_dir"; "rpc_addr"; "network"]
+    names
+
+let test_unknown_field_names_some_detected () =
+  let unit_state =
+    External_service.
+      {active_state = "active"; sub_state = "running"; enabled = Some true}
+  in
+  let config =
+    External_service.empty_config
+      ~unit_name:"test.service"
+      ~exec_start:"/bin/test"
+      ~unit_state
+  in
+  let config =
+    {
+      config with
+      role = External_service.detected ~source:"test" External_service.Node;
+      binary_path = External_service.detected ~source:"test" "/bin/octez-node";
+    }
+  in
+  let names = External_service.unknown_field_names config in
+  check
+    (list string)
+    "some detected field names"
+    ["data_dir"; "rpc_addr"; "network"]
+    names
+
+(* ============================================================ *)
+(* External_service.get_dependencies and get_dependents Tests *)
+(* ============================================================ *)
+
+let make_test_service ~unit_name ~role ~rpc_addr ~node_endpoint =
+  let unit_state =
+    External_service.
+      {active_state = "active"; sub_state = "running"; enabled = Some true}
+  in
+  let config =
+    External_service.empty_config ~unit_name ~exec_start:"/bin/test" ~unit_state
+  in
+  let config =
+    {
+      config with
+      role = External_service.detected ~source:"test" role;
+      rpc_addr =
+        (match rpc_addr with
+        | Some addr -> External_service.detected ~source:"test" addr
+        | None -> External_service.unknown ());
+      node_endpoint =
+        (match node_endpoint with
+        | Some endpoint -> External_service.detected ~source:"test" endpoint
+        | None -> External_service.unknown ());
+    }
+  in
+  External_service.
+    {
+      config;
+      suggested_instance_name =
+        External_service.suggest_instance_name ~unit_name;
+    }
+
+let test_get_dependencies_baker_to_node () =
+  let node =
+    make_test_service
+      ~unit_name:"octez-node@mainnet.service"
+      ~role:External_service.Node
+      ~rpc_addr:(Some "127.0.0.1:8732")
+      ~node_endpoint:None
+  in
+  let baker =
+    make_test_service
+      ~unit_name:"octez-baker@mainnet.service"
+      ~role:External_service.Baker
+      ~rpc_addr:None
+      ~node_endpoint:(Some "http://localhost:8732")
+  in
+  let deps = External_service.get_dependencies baker [node; baker] in
+  check
+    (list (pair string string))
+    "baker depends on node"
+    [("octez-node@mainnet.service", "node")]
+    deps
+
+let test_get_dependencies_baker_no_match () =
+  let node =
+    make_test_service
+      ~unit_name:"octez-node@mainnet.service"
+      ~role:External_service.Node
+      ~rpc_addr:(Some "127.0.0.1:8732")
+      ~node_endpoint:None
+  in
+  let baker =
+    make_test_service
+      ~unit_name:"octez-baker@mainnet.service"
+      ~role:External_service.Baker
+      ~rpc_addr:None
+      ~node_endpoint:(Some "http://10.0.0.1:8732")
+  in
+  let deps = External_service.get_dependencies baker [node; baker] in
+  check (list (pair string string)) "baker no matching node" [] deps
+
+let test_get_dependencies_node_has_none () =
+  let node =
+    make_test_service
+      ~unit_name:"octez-node@mainnet.service"
+      ~role:External_service.Node
+      ~rpc_addr:(Some "127.0.0.1:8732")
+      ~node_endpoint:None
+  in
+  let deps = External_service.get_dependencies node [node] in
+  check (list (pair string string)) "node has no dependencies" [] deps
+
+let test_get_dependents_node_has_baker () =
+  let node =
+    make_test_service
+      ~unit_name:"octez-node@mainnet.service"
+      ~role:External_service.Node
+      ~rpc_addr:(Some "127.0.0.1:8732")
+      ~node_endpoint:None
+  in
+  let baker =
+    make_test_service
+      ~unit_name:"octez-baker@mainnet.service"
+      ~role:External_service.Baker
+      ~rpc_addr:None
+      ~node_endpoint:(Some "http://localhost:8732")
+  in
+  let dependents = External_service.get_dependents node [node; baker] in
+  check
+    (list (pair string string))
+    "node has baker dependent"
+    [("octez-baker@mainnet.service", "baker")]
+    dependents
+
+let test_get_dependents_node_has_accuser () =
+  let node =
+    make_test_service
+      ~unit_name:"octez-node@mainnet.service"
+      ~role:External_service.Node
+      ~rpc_addr:(Some "127.0.0.1:8732")
+      ~node_endpoint:None
+  in
+  let accuser =
+    make_test_service
+      ~unit_name:"octez-accuser@mainnet.service"
+      ~role:External_service.Accuser
+      ~rpc_addr:None
+      ~node_endpoint:(Some "http://localhost:8732")
+  in
+  let dependents = External_service.get_dependents node [node; accuser] in
+  check
+    (list (pair string string))
+    "node has accuser dependent"
+    [("octez-accuser@mainnet.service", "accuser")]
+    dependents
+
+(* ============================================================ *)
+(* Import.For_tests.missing_required_fields Tests *)
+(* ============================================================ *)
+
+let test_missing_required_fields_node_all_present () =
+  let unit_state =
+    External_service.
+      {active_state = "active"; sub_state = "running"; enabled = Some true}
+  in
+  let config =
+    External_service.empty_config
+      ~unit_name:"octez-node@mainnet.service"
+      ~exec_start:"/bin/octez-node"
+      ~unit_state
+  in
+  let config =
+    {
+      config with
+      role = External_service.detected ~source:"test" External_service.Node;
+      network = External_service.detected ~source:"test" "mainnet";
+      data_dir = External_service.detected ~source:"test" "/data";
+    }
+  in
+  let external_svc =
+    External_service.
+      {
+        config;
+        suggested_instance_name =
+          External_service.suggest_instance_name
+            ~unit_name:"octez-node@mainnet.service";
+      }
+  in
+  let missing = Import.For_tests.missing_required_fields external_svc in
+  check (list string) "node all fields present" [] missing
+
+let test_missing_required_fields_node_missing_network () =
+  let unit_state =
+    External_service.
+      {active_state = "active"; sub_state = "running"; enabled = Some true}
+  in
+  let config =
+    External_service.empty_config
+      ~unit_name:"octez-node@mainnet.service"
+      ~exec_start:"/bin/octez-node"
+      ~unit_state
+  in
+  let config =
+    {
+      config with
+      role = External_service.detected ~source:"test" External_service.Node;
+      data_dir = External_service.detected ~source:"test" "/data";
+    }
+  in
+  let external_svc =
+    External_service.
+      {
+        config;
+        suggested_instance_name =
+          External_service.suggest_instance_name
+            ~unit_name:"octez-node@mainnet.service";
+      }
+  in
+  let missing = Import.For_tests.missing_required_fields external_svc in
+  check (list string) "node missing network" ["network"] missing
+
+let test_missing_required_fields_node_with_network_override () =
+  let unit_state =
+    External_service.
+      {active_state = "active"; sub_state = "running"; enabled = Some true}
+  in
+  let config =
+    External_service.empty_config
+      ~unit_name:"octez-node@mainnet.service"
+      ~exec_start:"/bin/octez-node"
+      ~unit_state
+  in
+  let config =
+    {
+      config with
+      role = External_service.detected ~source:"test" External_service.Node;
+      data_dir = External_service.detected ~source:"test" "/data";
+    }
+  in
+  let external_svc =
+    External_service.
+      {
+        config;
+        suggested_instance_name =
+          External_service.suggest_instance_name
+            ~unit_name:"octez-node@mainnet.service";
+      }
+  in
+  let missing =
+    Import.For_tests.missing_required_fields
+      ~network_override:"mainnet"
+      external_svc
+  in
+  check (list string) "node with network override" [] missing
+
+let test_missing_required_fields_baker_missing_multiple () =
+  let unit_state =
+    External_service.
+      {active_state = "active"; sub_state = "running"; enabled = Some true}
+  in
+  let config =
+    External_service.empty_config
+      ~unit_name:"octez-baker@mainnet.service"
+      ~exec_start:"/bin/octez-baker"
+      ~unit_state
+  in
+  let config =
+    {
+      config with
+      role = External_service.detected ~source:"test" External_service.Baker;
+      network = External_service.detected ~source:"test" "mainnet";
+    }
+  in
+  let external_svc =
+    External_service.
+      {
+        config;
+        suggested_instance_name =
+          External_service.suggest_instance_name
+            ~unit_name:"octez-baker@mainnet.service";
+      }
+  in
+  let missing = Import.For_tests.missing_required_fields external_svc in
+  (* Baker requires: network, base_dir, node_endpoint *)
+  check
+    (list string)
+    "baker missing base_dir and node_endpoint"
+    ["base_dir"; "node_endpoint"]
+    missing
+
+let test_missing_required_fields_baker_all_present () =
+  let unit_state =
+    External_service.
+      {active_state = "active"; sub_state = "running"; enabled = Some true}
+  in
+  let config =
+    External_service.empty_config
+      ~unit_name:"octez-baker@mainnet.service"
+      ~exec_start:"/bin/octez-baker"
+      ~unit_state
+  in
+  let config =
+    {
+      config with
+      role = External_service.detected ~source:"test" External_service.Baker;
+      network = External_service.detected ~source:"test" "mainnet";
+      base_dir = External_service.detected ~source:"test" "/base";
+      node_endpoint =
+        External_service.detected ~source:"test" "http://localhost:8732";
+    }
+  in
+  let external_svc =
+    External_service.
+      {
+        config;
+        suggested_instance_name =
+          External_service.suggest_instance_name
+            ~unit_name:"octez-baker@mainnet.service";
+      }
+  in
+  let missing = Import.For_tests.missing_required_fields external_svc in
+  check (list string) "baker all fields present" [] missing
+
+(* ============================================================ *)
+(* Test Suite *)
+(* ============================================================ *)
+
+let () =
+  run
+    "Import Config Preservation"
+    [
+      ( "Env_file_parser.parse_string",
+        [
+          test_case "simple key=value" `Quick test_parse_simple_key_value;
+          test_case "double-quoted value" `Quick test_parse_double_quoted;
+          test_case "single-quoted value" `Quick test_parse_single_quoted;
+          test_case "value with equals" `Quick test_parse_value_with_equals;
+          test_case "empty value" `Quick test_parse_empty_value;
+          test_case "multiple entries" `Quick test_parse_multiple_entries;
+          test_case "comment lines" `Quick test_parse_comment_lines;
+          test_case "blank lines" `Quick test_parse_blank_lines;
+          test_case "mixed content" `Quick test_parse_mixed_content;
+          test_case "key without equals" `Quick test_parse_key_without_equals;
+          test_case "whitespace trimmed" `Quick test_parse_whitespace_trimmed;
+        ] );
+      ( "Env_file_parser.expand_vars",
+        [
+          test_case "expand ${VAR}" `Quick test_expand_vars_braced;
+          test_case "expand $VAR" `Quick test_expand_vars_unbraced;
+          test_case "unknown var" `Quick test_expand_vars_unknown;
+          test_case "multiple vars" `Quick test_expand_vars_multiple;
+          test_case "empty env" `Quick test_expand_vars_empty_env;
+          test_case "no vars in string" `Quick test_expand_vars_no_vars;
+          test_case "mixed expansion" `Quick test_expand_vars_mixed;
+        ] );
+      ( "External_service.suggest_instance_name",
+        [
+          test_case
+            "simple service name"
+            `Quick
+            test_suggest_instance_name_simple;
+          test_case
+            "octez-node@mainnet"
+            `Quick
+            test_suggest_instance_name_octez_node_template;
+          test_case
+            "tezos-baker-PsParisC"
+            `Quick
+            test_suggest_instance_name_tezos_baker;
+          test_case
+            "octez-dal-node@my-dal"
+            `Quick
+            test_suggest_instance_name_octez_dal_node;
+          test_case
+            "no .service suffix"
+            `Quick
+            test_suggest_instance_name_no_suffix;
+          test_case
+            "template unit"
+            `Quick
+            test_suggest_instance_name_template_unit;
+          test_case "signatory@prod" `Quick test_suggest_instance_name_signatory;
+        ] );
+      ( "External_service.endpoint_matches_rpc",
+        [
+          test_case
+            "localhost matches 127.0.0.1"
+            `Quick
+            test_endpoint_matches_localhost_127;
+          test_case
+            "127.0.0.1 matches 0.0.0.0"
+            `Quick
+            test_endpoint_matches_127_to_0000;
+          test_case
+            "localhost matches localhost"
+            `Quick
+            test_endpoint_matches_localhost_exact;
+          test_case
+            "different hosts"
+            `Quick
+            test_endpoint_matches_different_host;
+          test_case
+            "different ports"
+            `Quick
+            test_endpoint_matches_different_port;
+          test_case "https endpoint" `Quick test_endpoint_matches_https;
+        ] );
+      ( "External_service.role_of_binary_name",
+        [
+          test_case "octez-node" `Quick test_role_of_binary_octez_node;
+          test_case
+            "octez-baker-PsParisC"
+            `Quick
+            test_role_of_binary_octez_baker;
+          test_case
+            "baker with dal subcommand"
+            `Quick
+            test_role_of_binary_baker_with_dal_subcommand;
+          test_case
+            "baker with accuser subcommand"
+            `Quick
+            test_role_of_binary_baker_with_accuser_subcommand;
+          test_case
+            "octez-accuser-PsParisC"
+            `Quick
+            test_role_of_binary_octez_accuser;
+          test_case "octez-dal-node" `Quick test_role_of_binary_octez_dal_node;
+          test_case
+            "tezos-baker-PsParisC"
+            `Quick
+            test_role_of_binary_tezos_baker;
+          test_case "octez-node with path" `Quick test_role_of_binary_with_path;
+          test_case "signatory" `Quick test_role_of_binary_signatory;
+          test_case "unknown binary" `Quick test_role_of_binary_unknown;
+        ] );
+      ( "External_service.status_of_unit_state",
+        [
+          test_case "running status" `Quick test_status_running;
+          test_case "disabled status" `Quick test_status_disabled;
+          test_case "stopped status" `Quick test_status_stopped;
+          test_case "failed status" `Quick test_status_failed;
+          test_case "unknown status" `Quick test_status_unknown;
+        ] );
+      ( "External_service.unknown_field_count",
+        [
+          test_case "all unknown" `Quick test_unknown_field_count_all_unknown;
+          test_case
+            "some detected"
+            `Quick
+            test_unknown_field_count_some_detected;
+          test_case "all detected" `Quick test_unknown_field_count_all_detected;
+        ] );
+      ( "External_service.unknown_field_names",
+        [
+          test_case "all unknown" `Quick test_unknown_field_names_all_unknown;
+          test_case
+            "some detected"
+            `Quick
+            test_unknown_field_names_some_detected;
+        ] );
+      ( "External_service.get_dependencies",
+        [
+          test_case "baker to node" `Quick test_get_dependencies_baker_to_node;
+          test_case "baker no match" `Quick test_get_dependencies_baker_no_match;
+          test_case "node has none" `Quick test_get_dependencies_node_has_none;
+        ] );
+      ( "External_service.get_dependents",
+        [
+          test_case "node has baker" `Quick test_get_dependents_node_has_baker;
+          test_case
+            "node has accuser"
+            `Quick
+            test_get_dependents_node_has_accuser;
+        ] );
+      ( "Import.For_tests.missing_required_fields",
+        [
+          test_case
+            "node all fields present"
+            `Quick
+            test_missing_required_fields_node_all_present;
+          test_case
+            "node missing network"
+            `Quick
+            test_missing_required_fields_node_missing_network;
+          test_case
+            "node with network override"
+            `Quick
+            test_missing_required_fields_node_with_network_override;
+          test_case
+            "baker missing multiple"
+            `Quick
+            test_missing_required_fields_baker_missing_multiple;
+          test_case
+            "baker all fields present"
+            `Quick
+            test_missing_required_fields_baker_all_present;
+        ] );
+    ]


### PR DESCRIPTION
## Summary

- Add 97 unit tests covering pure functions in the import pipeline
- Add 6 integration tests for production-like systemd import scenarios

## Unit tests (2 new test files)

**`test_import_config_preservation.ml`** (61 tests):
- `Env_file_parser.parse_string`: KEY=VALUE, quoted values, equals in values, comments, blank lines
- `Env_file_parser.expand_vars`: `${VAR}`, `$VAR`, unknown vars, multiple vars
- `External_service.suggest_instance_name`: `.service` stripping, `octez-`/`tezos-` prefix, `@` templates
- `External_service.endpoint_matches_rpc`: localhost/127.0.0.1/0.0.0.0 normalization
- `External_service.role_of_binary_name`: all roles, subcommand override (dal, accuser)
- `External_service.status_of_unit_state`: Running, Disabled, Stopped, Failed, Unknown
- `External_service.unknown_field_count/names`: field tracking
- `External_service.get_dependencies/get_dependents`: endpoint matching
- `Import.For_tests.missing_required_fields`: per-role required fields

**`test_execstart_parser_extended.ml`** (36 tests):
- Realistic node/baker/accuser/DAL ExecStart patterns with all flags
- Shell wrappers, env var integration, property-based tests

## Integration tests (6 new tests)

| Test | Description |
|------|-------------|
| 69 | EnvironmentFile directive with `${VAR}` expansion in ExecStart |
| 70 | Shell-wrapped ExecStart (`/bin/sh -c '...'`) |
| 71 | RPC address override during import |
| 72 | Archive history mode preservation |
| 73 | Re-import after purge lifecycle |
| 74 | Custom net-addr P2P settings preservation |

All integration tests registered in shard-2 of `shards.json`.