### PR TITLE
feat(rewards): improve first-run UX and indexer configurability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **Cascade import in TUI**: Import wizard now supports cascade import mode, allowing users to import services with all their dependencies or dependents in the correct order. Toggle with 'c' in the configure step. (fixes #886)
+- **Rewards first-run guidance**: When no payout configuration exists for the selected baker, the Rewards Overview shows a "Set up rewards" panel pointing to the Configuration tab; the Configuration tab shows a `[c: create]` status line until the first save. Action shortcuts that require config (`g`/`p`/`d`/`t`) are hidden on the Overview until then.
+- **Indexer URL configuration in TUI**: New "Indexer URL" field in the Rewards Configuration tab. Editing it opens a picker listing local octez-index services for the baker's network, the network-appropriate TzKT URL, and a "Custom URL..." entry for free-form input.
 
 ### Changed
 

--- a/src/rewards/payout_config.ml
+++ b/src/rewards/payout_config.ml
@@ -449,6 +449,8 @@ let rec mkdir_p path =
     mkdir_p (Filename.dirname path) ;
     try Unix.mkdir path 0o755 with Unix.Unix_error (Unix.EEXIST, _, _) -> ())
 
+let exists ~instance = Sys.file_exists (config_path ~instance)
+
 let load ~instance =
   let path = config_path ~instance in
   if not (Sys.file_exists path) then

--- a/src/rewards/payout_config.mli
+++ b/src/rewards/payout_config.mli
@@ -70,6 +70,9 @@ val rewards_dir : instance:string -> string
 (** Load configuration from disk for a given baker instance. *)
 val load : instance:string -> (t, string) result
 
+(** Whether a saved configuration file exists for [instance]. *)
+val exists : instance:string -> bool
+
 (** Save configuration to disk for a given baker instance. *)
 val save : instance:string -> t -> (unit, string) result
 

--- a/src/ui/pages/rewards/rewards_config_tab.ml
+++ b/src/ui/pages/rewards/rewards_config_tab.ml
@@ -259,12 +259,10 @@ let edit_field ?network (config : Payout_config.t) field =
   | IndexerUrl ->
       let indexers = local_indexers_for_network ~network in
       let tzkt_choice =
-        let url =
-          match Option.bind network network_slug with
-          | Some slug -> Payout_config.tzkt_base_url_for_network slug
-          | None -> "https://api.tzkt.io"
+        let slug =
+          Option.bind network network_slug |> Option.value ~default:"mainnet"
         in
-        Tzkt_default url
+        Tzkt_default (Payout_config.tzkt_base_url_for_network slug)
       in
       let choices =
         List.map

--- a/src/ui/pages/rewards/rewards_config_tab.ml
+++ b/src/ui/pages/rewards/rewards_config_tab.ml
@@ -40,6 +40,7 @@ type field_id =
   | BakerFee
   | PayoutMode
   | PayoutKeyAlias
+  | IndexerUrl
   | MinPayout
   | MinBalance
   | BelowMinDest
@@ -56,6 +57,7 @@ let all_fields =
     BakerFee;
     PayoutMode;
     PayoutKeyAlias;
+    IndexerUrl;
     MinPayout;
     MinBalance;
     BelowMinDest;
@@ -74,6 +76,7 @@ let field_label = function
   | BakerFee -> "Baker Fee"
   | PayoutMode -> "Payout Mode"
   | PayoutKeyAlias -> "Payout Key"
+  | IndexerUrl -> "Indexer URL"
   | MinPayout -> "Min Payout"
   | MinBalance -> "Min Balance"
   | BelowMinDest -> "Below Min Dest"
@@ -92,6 +95,10 @@ let field_hint = function
       "Actual: pay based on real rewards received. Ideal: pay based on \
        expected rewards regardless of missed blocks."
   | PayoutKeyAlias -> "octez-client key alias used to sign payout transactions."
+  | IndexerUrl ->
+      "Base URL of the indexer used to fetch cycle rewards and delegator data. \
+       Accepts a public TzKT instance (e.g. https://api.tzkt.io) or a \
+       self-hosted TzKT-compatible indexer such as octez-index."
   | MinPayout ->
       "Delegators whose reward is below this threshold will not receive a \
        payout."
@@ -128,6 +135,7 @@ let field_value (config : Payout_config.t) = function
       | Rewards.Actual -> "Actual"
       | Rewards.Ideal -> "Ideal")
   | PayoutKeyAlias -> config.payout_key_alias
+  | IndexerUrl -> config.tzkt_url
   | MinPayout ->
       Rewards.format_tez config.min_payout ^ " " ^ tez_symbol ^ " (mutez)"
   | MinBalance ->
@@ -154,7 +162,65 @@ let field_value (config : Payout_config.t) = function
 
 (* {1 Field editing} *)
 
-let edit_field (config : Payout_config.t) field =
+type indexer_choice =
+  | Local_indexer of {instance : string; endpoint : string}
+  | Tzkt_default of string
+  | Custom_url
+
+let prompt_custom_indexer_url config =
+  Modal_helpers.prompt_validated_text_modal
+    ~title:"Indexer URL (TzKT or octez-index)"
+    ~initial:config.Payout_config.tzkt_url
+    ~validator:(fun s ->
+      let s = String.trim s in
+      if String.length s = 0 then Error "URL must not be empty"
+      else if
+        (not (String.starts_with ~prefix:"http://" s))
+        && not (String.starts_with ~prefix:"https://" s)
+      then Error "URL must start with http:// or https://"
+      else Ok ())
+    ~on_submit:(fun s ->
+      let url = String.trim s in
+      let url =
+        if String.length url > 0 && url.[String.length url - 1] = '/' then
+          String.sub url 0 (String.length url - 1)
+        else url
+      in
+      pending_config := Some {config with tzkt_url = url})
+    ()
+
+(** Extract a network slug from values like ["https://teztnets.com/bakingnet"]
+    or ["bakingnet"]. Returns [None] if the value does not look like a usable
+    slug (e.g. an unrecognised URL with extra path components). *)
+let network_slug network =
+  let n = Network_name.normalize network in
+  let looks_like_slug s =
+    String.length s > 0
+    && (not (String.contains s '/'))
+    && not (String.contains s ':')
+  in
+  if looks_like_slug n then Some n
+  else
+    match String.rindex_opt n '/' with
+    | Some i when i + 1 < String.length n ->
+        let tail = String.sub n (i + 1) (String.length n - i - 1) in
+        if looks_like_slug tail then Some tail else None
+    | _ -> None
+
+let local_indexers_for_network ~network =
+  match Octez_manager_lib.Service_registry.list () with
+  | Error _ -> []
+  | Ok svcs ->
+      List.filter
+        (fun (svc : Octez_manager_lib.Service.t) ->
+          String.equal svc.role "index"
+          &&
+          match network with
+          | None -> true
+          | Some n -> String.equal svc.network n)
+        svcs
+
+let edit_field ?network (config : Payout_config.t) field =
   match field with
   | BakerFee ->
       Modal_helpers.prompt_validated_text_modal
@@ -189,6 +255,43 @@ let edit_field (config : Payout_config.t) field =
         ~initial:config.payout_key_alias
         ~on_submit:(fun s ->
           pending_config := Some {config with payout_key_alias = s})
+        ()
+  | IndexerUrl ->
+      let indexers = local_indexers_for_network ~network in
+      let tzkt_choice =
+        let url =
+          match Option.bind network network_slug with
+          | Some slug -> Payout_config.tzkt_base_url_for_network slug
+          | None -> "https://api.tzkt.io"
+        in
+        Tzkt_default url
+      in
+      let choices =
+        List.map
+          (fun (svc : Octez_manager_lib.Service.t) ->
+            Local_indexer
+              {
+                instance = svc.instance;
+                endpoint = Octez_manager_lib.Rpc_addr.to_endpoint svc.rpc_addr;
+              })
+          indexers
+        @ [tzkt_choice; Custom_url]
+      in
+      Modal_helpers.open_choice_modal
+        ~title:"Indexer URL"
+        ~items:choices
+        ~to_string:(function
+          | Local_indexer {instance; endpoint} ->
+              Printf.sprintf "%s  (%s)" instance endpoint
+          | Tzkt_default url -> Printf.sprintf "TzKT  (%s)" url
+          | Custom_url -> "Custom URL...")
+        ~on_select:(fun choice ->
+          match choice with
+          | Local_indexer {endpoint; _} ->
+              pending_config := Some {config with tzkt_url = endpoint}
+          | Tzkt_default url ->
+              pending_config := Some {config with tzkt_url = url}
+          | Custom_url -> prompt_custom_indexer_url config)
         ()
   | MinPayout ->
       Modal_helpers.prompt_validated_text_modal
@@ -608,9 +711,12 @@ let render ~(state : Rewards_state.state) ~cols ~_rows =
             let style = if is_selected then Box.Double else Box.Rounded in
             Box.render ~title ~style ~width:box_width content
       in
-      (* Dirty indicator *)
-      let dirty_indicator =
-        if state.config_dirty then
+      (* Status indicator: create (never saved) takes priority over dirty *)
+      let status_indicator =
+        if not state.config_exists then
+          Widgets.themed_warning "  * Not yet saved"
+          ^ Widgets.themed_muted "  [c: create]"
+        else if state.config_dirty then
           Widgets.themed_warning "  * Unsaved changes"
           ^ Widgets.themed_muted "  [s: save]"
         else ""
@@ -622,6 +728,6 @@ let render ~(state : Rewards_state.state) ~cols ~_rows =
         else parts
       in
       let parts =
-        if dirty_indicator <> "" then parts @ [dirty_indicator] else parts
+        if status_indicator <> "" then parts @ [status_indicator] else parts
       in
       String.concat "\n" parts

--- a/src/ui/pages/rewards/rewards_config_tab.mli
+++ b/src/ui/pages/rewards/rewards_config_tab.mli
@@ -12,6 +12,7 @@ type field_id =
   | BakerFee
   | PayoutMode
   | PayoutKeyAlias
+  | IndexerUrl
   | MinPayout
   | MinBalance
   | BelowMinDest
@@ -44,8 +45,11 @@ val set_pending_config_clean : Octez_manager_rewards.Payout_config.t -> unit
 val consume_pending_config_clean :
   unit -> Octez_manager_rewards.Payout_config.t option
 
-(** Open a modal to edit a configuration field. *)
-val edit_field : Octez_manager_rewards.Payout_config.t -> field_id -> unit
+(** Open a modal to edit a configuration field. [network] is used by
+    [IndexerUrl] to filter local octez-index services to those matching the
+    baker's network. *)
+val edit_field :
+  ?network:string -> Octez_manager_rewards.Payout_config.t -> field_id -> unit
 
 (** Save the configuration to disk. *)
 val save_config :

--- a/src/ui/pages/rewards/rewards_overview.ml
+++ b/src/ui/pages/rewards/rewards_overview.ml
@@ -276,6 +276,28 @@ let render_cycle_detail ~box_width ~instance ~baker:_
   in
   String.concat "\n" [header; back_hint; ""; detail_box; ""; preview_box]
 
+let render_setup_cta_box ~box_width =
+  let lines =
+    [
+      Widgets.themed_text "No payout configuration yet for this baker.";
+      "";
+      Widgets.themed_text "Press Tab to open the Configuration tab and set:";
+      Widgets.themed_muted
+        "  - payout key alias       (which key signs payouts)";
+      Widgets.themed_muted "  - baker fee              (% kept by the baker)";
+      Widgets.themed_muted "  - min payout / balance   (skip dust)";
+      Widgets.themed_muted "  - notification channels  (Discord/Telegram/...)";
+      "";
+      Widgets.themed_muted
+        "Once saved, Generate / Pay / Dry-run become available here.";
+    ]
+  in
+  Box.render
+    ~title:"Set up rewards"
+    ~style:Rounded
+    ~width:box_width
+    (String.concat "\n" lines)
+
 let resolve_network ~instance =
   match Octez_manager_lib.Service_registry.find ~instance with
   | Ok (Some svc) -> svc.Octez_manager_lib.Service.network
@@ -305,8 +327,12 @@ let render_dashboard ~box_width ~instance ~baker:_ (state : Rewards_state.state)
   let recent_box =
     render_recent_cycles_box ~box_width ~instance ~current_cycle recent
   in
+  let setup_cta =
+    if state.config_exists then [] else [render_setup_cta_box ~box_width; ""]
+  in
   let parts =
-    [network_line; ""; current_box; ""; completed_box; ""; recent_box]
+    setup_cta
+    @ [network_line; ""; current_box; ""; completed_box; ""; recent_box]
   in
   let parts =
     if state.overview_preview then

--- a/src/ui/pages/rewards/rewards_page.ml
+++ b/src/ui/pages/rewards/rewards_page.ml
@@ -69,6 +69,11 @@ let load_baker_instances () =
   in
   from_services @ from_env
 
+let config_exists_for_selected baker_instances selected_baker =
+  match List.nth_opt baker_instances selected_baker with
+  | Some (instance, _) -> Payout_config.exists ~instance
+  | None -> false
+
 let init () =
   let baker_instances = load_baker_instances () in
   let active_tab =
@@ -87,6 +92,9 @@ let init () =
         |> Option.value ~default:0
     | None -> 0
   in
+  let config_exists =
+    config_exists_for_selected baker_instances selected_baker
+  in
   Navigation.make
     {
       Rewards_state.baker_instances;
@@ -104,6 +112,7 @@ let init () =
       config = None;
       config_cursor = 0;
       config_dirty = false;
+      config_exists;
       history_cursor = 0;
       loading = false;
       error = None;
@@ -208,7 +217,10 @@ let refresh ps =
                 Rewards_scheduler.get_current_cycle ~instance
             | None -> None
           in
-          let s = {s with baker_instances; current_cycle} in
+          let config_exists =
+            config_exists_for_selected baker_instances s.selected_baker
+          in
+          let s = {s with baker_instances; current_cycle; config_exists} in
           let s = maybe_compute_blueprint s in
           let s = maybe_load_config s in
           let s = apply_pending_config s in
@@ -296,13 +308,15 @@ let keymap ps =
   let tab_keys =
     match s.active_tab with
     | Rewards_state.Overview ->
-        [
-          kb "g" "Generate";
-          kb "p" "Pay";
-          kb "d" "Dry-run";
-          kb "t" "Continual";
-          kb "r" "Refresh";
-        ]
+        if s.config_exists then
+          [
+            kb "g" "Generate";
+            kb "p" "Pay";
+            kb "d" "Dry-run";
+            kb "t" "Continual";
+            kb "r" "Refresh";
+          ]
+        else [kb "r" "Refresh"]
     | Rewards_state.Delegators ->
         [
           kb "j/k" "Navigate";
@@ -313,10 +327,13 @@ let keymap ps =
         ]
     | Rewards_state.History -> [kb "j/k" "Navigate"; kb "Enter" "View"]
     | Rewards_state.Configuration ->
+        let save_key =
+          if s.config_exists then kb "s" "Save" else kb "c" "Create"
+        in
         [
           kb "j/k" "Navigate";
           kb "Enter" "Edit";
-          kb "s" "Save";
+          save_key;
           kb "r" "Reset";
           kb "i" "Import";
           kb "n" "Notify";
@@ -510,14 +527,29 @@ let handle_config_key ps key =
             let field =
               List.nth Rewards_config_tab.all_fields s.config_cursor
             in
-            Rewards_config_tab.edit_field config field ;
+            let network =
+              match Rewards_state.selected_instance_name s with
+              | None -> None
+              | Some instance -> (
+                  match Service_registry.find ~instance with
+                  | Ok (Some svc) -> Some svc.Service.network
+                  | _ -> None)
+            in
+            Rewards_config_tab.edit_field ?network config field ;
             ps
         | None -> ps)
-  | Some (Keys.Char "s") -> (
+  | Some (Keys.Char "s") | Some (Keys.Char "c") -> (
       match (s.config, Rewards_state.selected_instance_name s) with
       | Some config, Some instance ->
           Rewards_config_tab.save_config ~instance config ;
-          Navigation.update (fun s -> {s with config_dirty = false}) ps
+          Navigation.update
+            (fun s ->
+              {
+                s with
+                config_dirty = false;
+                config_exists = Payout_config.exists ~instance;
+              })
+            ps
       | _ -> ps)
   | Some (Keys.Char "r") -> (
       match Rewards_state.selected_baker_pkh s with
@@ -1093,6 +1125,7 @@ let handled_keys () =
       Char "t";
       Char "i";
       Char "n";
+      Char "c";
     ]
 
 let has_modal _ = false
@@ -1150,13 +1183,15 @@ module Page : Miaou.Core.Tui_page.PAGE_SIG = struct
     let tab_keys =
       match s.active_tab with
       | Rewards_state.Overview ->
-          [
-            kh "g" "Generate";
-            kh "p" "Pay";
-            kh "d" "Dry-run";
-            kh "t" "Continual";
-            kh "r" "Refresh";
-          ]
+          if s.config_exists then
+            [
+              kh "g" "Generate";
+              kh "p" "Pay";
+              kh "d" "Dry-run";
+              kh "t" "Continual";
+              kh "r" "Refresh";
+            ]
+          else [kh "r" "Refresh"]
       | Rewards_state.Delegators ->
           [
             kh "j/k" "Navigate";
@@ -1167,10 +1202,13 @@ module Page : Miaou.Core.Tui_page.PAGE_SIG = struct
           ]
       | Rewards_state.History -> [kh "j/k" "Navigate"; kh "Enter" "View"]
       | Rewards_state.Configuration ->
+          let save_hint =
+            if s.config_exists then kh "s" "Save" else kh "c" "Create"
+          in
           [
             kh "j/k" "Navigate";
             kh "Enter" "Edit";
-            kh "s" "Save";
+            save_hint;
             kh "r" "Reset";
             kh "i" "Import";
             kh "n" "Notify";

--- a/src/ui/pages/rewards/rewards_state.ml
+++ b/src/ui/pages/rewards/rewards_state.ml
@@ -38,6 +38,8 @@ type state = {
   config : Payout_config.t option;  (** Loaded payout config for editing *)
   config_cursor : int;  (** Selected field in config tab *)
   config_dirty : bool;  (** True if config has unsaved changes *)
+  config_exists : bool;
+      (** True if a saved config file exists on disk for the selected baker *)
   history_cursor : int;
   loading : bool;
   error : string option;

--- a/src/ui/pages/rewards/rewards_state.mli
+++ b/src/ui/pages/rewards/rewards_state.mli
@@ -37,6 +37,7 @@ type state = {
   config : Octez_manager_rewards.Payout_config.t option;
   config_cursor : int;
   config_dirty : bool;
+  config_exists : bool;
   history_cursor : int;
   loading : bool;
   error : string option;


### PR DESCRIPTION
## Summary

- **Set up rewards CTA on Overview**: when the selected baker has no payout config on disk, the Rewards Overview shows a panel pointing to the Configuration tab, and action shortcuts that require config (`g`/`p`/`d`/`t`) are hidden from the key hints until then.
- **`c` to create, `s` to save**: the Configuration tab shows a `* Not yet saved  [c: create]` status line until the first save; pressing `c` writes the file (`s` continues to handle updates).
- **Indexer URL field**: new editable field in the Configuration tab. Editing it opens a picker listing local octez-index services matching the baker's network, the network-appropriate TzKT URL, and a "Custom URL..." entry for free-form input.

Internals: adds `Payout_config.exists` (cheap stat-only check) and a `config_exists` field on `Rewards_state.state`, populated on every `refresh` tick — no I/O on the render path.

## Test plan

- [ ] Fresh baker (no `~/.config/octez-manager/rewards/<instance>/config.json`):
  - [ ] Overview shows the "Set up rewards" panel above the network badge.
  - [ ] Overview key hints show only `r` Refresh (plus common `Tab`/`Esc`/`b`).
  - [ ] Configuration tab shows `* Not yet saved  [c: create]` status line at the bottom.
  - [ ] Pressing `c` writes `config.json`, toast confirms "Configuration saved", status line clears, Overview action keys (`g`/`p`/`d`/`t`) reappear.
- [ ] Baker with existing config:
  - [ ] No CTA panel; full action keys present.
  - [ ] Editing a field shows `* Unsaved changes  [s: save]` (existing behaviour preserved).
- [ ] Indexer URL picker:
  - [ ] Baker on a network with a registered octez-index service: picker lists `<instance>  (<endpoint>)` plus `TzKT  (<network-appropriate-url>)` plus `Custom URL...`.
  - [ ] Baker on a network without a local indexer: picker shows TzKT default + Custom URL... only.
  - [ ] Selecting a local indexer or TzKT entry updates the field immediately.
  - [ ] `Custom URL...` opens the validated free-text prompt; URL must start with `http://` or `https://`; trailing slash is trimmed on save.
  - [ ] `Esc` cancels the picker without changing the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)