### PR TITLE
fix(modals): correct key-mapping arms for PageUp/PageDown/Home/End

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Cascade import in TUI**: Import wizard now supports cascade import mode, allowing users to import services with all their dependencies or dependents in the correct order. Toggle with 'c' in the configure step. (fixes #886)
 
+### Fixed
+
+- PageUp, PageDown, Home, and End keys now work correctly in all choice menus and modals
+
 ## [1.0.0] - 2026-04-16
 
 ### Added

--- a/src/ui/modal_helpers.ml
+++ b/src/ui/modal_helpers.ml
@@ -81,10 +81,10 @@ let open_text_modal ~title ~lines =
         | Some Miaou.Core.Keys.Down -> "Down"
         | Some (Miaou.Core.Keys.Char "k") -> "Up"
         | Some (Miaou.Core.Keys.Char "j") -> "Down"
-        | Some (Miaou.Core.Keys.Char "Page_up") -> "Page_up"
-        | Some (Miaou.Core.Keys.Char "Page_down") -> "Page_down"
-        | Some (Miaou.Core.Keys.Char "Home") -> "g"
-        | Some (Miaou.Core.Keys.Char "End") -> "G"
+        | Some Miaou.Core.Keys.PageUp -> "Page_up"
+        | Some Miaou.Core.Keys.PageDown -> "Page_down"
+        | Some Miaou.Core.Keys.Home -> "g"
+        | Some Miaou.Core.Keys.End -> "G"
         | Some (Miaou.Core.Keys.Char "Esc")
         | Some (Miaou.Core.Keys.Char "Escape")
         | Some (Miaou.Core.Keys.Char "q") ->
@@ -180,10 +180,10 @@ let open_choice_modal (type choice) ~title ~(items : choice list) ~to_string
         | Some Miaou.Core.Keys.Down -> "Down"
         | Some (Miaou.Core.Keys.Char "k") -> "Up"
         | Some (Miaou.Core.Keys.Char "j") -> "Down"
-        | Some (Miaou.Core.Keys.Char "Page_up") -> "PageUp"
-        | Some (Miaou.Core.Keys.Char "Page_down") -> "PageDown"
-        | Some (Miaou.Core.Keys.Char "Home") -> "Home"
-        | Some (Miaou.Core.Keys.Char "End") -> "End"
+        | Some Miaou.Core.Keys.PageUp -> "PageUp"
+        | Some Miaou.Core.Keys.PageDown -> "PageDown"
+        | Some Miaou.Core.Keys.Home -> "Home"
+        | Some Miaou.Core.Keys.End -> "End"
         | Some Miaou.Core.Keys.Enter -> "Enter"
         | Some (Miaou.Core.Keys.Char "Esc")
         | Some (Miaou.Core.Keys.Char "Escape")
@@ -379,10 +379,10 @@ let open_choice_modal_with_hint (type choice) ~title ~(items : choice list)
         | Some Miaou.Core.Keys.Down -> "Down"
         | Some (Miaou.Core.Keys.Char "k") -> "Up"
         | Some (Miaou.Core.Keys.Char "j") -> "Down"
-        | Some (Miaou.Core.Keys.Char "Page_up") -> "PageUp"
-        | Some (Miaou.Core.Keys.Char "Page_down") -> "PageDown"
-        | Some (Miaou.Core.Keys.Char "Home") -> "Home"
-        | Some (Miaou.Core.Keys.Char "End") -> "End"
+        | Some Miaou.Core.Keys.PageUp -> "PageUp"
+        | Some Miaou.Core.Keys.PageDown -> "PageDown"
+        | Some Miaou.Core.Keys.Home -> "Home"
+        | Some Miaou.Core.Keys.End -> "End"
         | Some Miaou.Core.Keys.Enter -> "Enter"
         | Some (Miaou.Core.Keys.Char "?") -> "Hint"
         | Some (Miaou.Core.Keys.Char "Esc")
@@ -698,10 +698,10 @@ let open_multiselect_modal (type choice) ~title ~(items : unit -> choice list)
         | Some Miaou.Core.Keys.Down -> "Down"
         | Some (Miaou.Core.Keys.Char "k") -> "Up"
         | Some (Miaou.Core.Keys.Char "j") -> "Down"
-        | Some (Miaou.Core.Keys.Char "Page_up") -> "PageUp"
-        | Some (Miaou.Core.Keys.Char "Page_down") -> "PageDown"
-        | Some (Miaou.Core.Keys.Char "Home") -> "Home"
-        | Some (Miaou.Core.Keys.Char "End") -> "End"
+        | Some Miaou.Core.Keys.PageUp -> "PageUp"
+        | Some Miaou.Core.Keys.PageDown -> "PageDown"
+        | Some Miaou.Core.Keys.Home -> "Home"
+        | Some Miaou.Core.Keys.End -> "End"
         | Some Miaou.Core.Keys.Enter -> "Enter"
         | Some (Miaou.Core.Keys.Char "Esc")
         | Some (Miaou.Core.Keys.Char "Escape")
@@ -2551,10 +2551,10 @@ let open_theme_picker_modal ~title ~items ~to_string ~load_theme ~on_select
         | Some Miaou.Core.Keys.Down -> "Down"
         | Some (Miaou.Core.Keys.Char "k") -> "Up"
         | Some (Miaou.Core.Keys.Char "j") -> "Down"
-        | Some (Miaou.Core.Keys.Char "Page_up") -> "PageUp"
-        | Some (Miaou.Core.Keys.Char "Page_down") -> "PageDown"
-        | Some (Miaou.Core.Keys.Char "Home") -> "Home"
-        | Some (Miaou.Core.Keys.Char "End") -> "End"
+        | Some Miaou.Core.Keys.PageUp -> "PageUp"
+        | Some Miaou.Core.Keys.PageDown -> "PageDown"
+        | Some Miaou.Core.Keys.Home -> "Home"
+        | Some Miaou.Core.Keys.End -> "End"
         | Some Miaou.Core.Keys.Enter -> "Enter"
         | Some (Miaou.Core.Keys.Char "Esc")
         | Some (Miaou.Core.Keys.Char "Escape")


### PR DESCRIPTION
## Depends on

- **Blocked by:** trilitech/miaou#131 — fixes `input_parser.ml` to recognise the terminal CSI sequences (`ESC[5~`, `ESC[6~`, `ESC[H`, `ESC[F`, `ESC[1~`, `ESC[4~`, `ESC[7~`, `ESC[8~`) for PageUp/PageDown/Home/End. Without that PR, the parser still emits `Unknown "5"` etc. and these keys never reach the modal handler.

This PR alone is a no-op until the Miaou pin picks up the input_parser fix.

## Summary

- 5 dead match arms in `modal_helpers.ml` used `Miaou.Core.Keys.Char "Page_up"` etc., which can never match — `Miaou.Core.Keys.t` has dedicated `PageUp`/`PageDown`/`Home`/`End` variants
- Replaces all 5 locations with the correct variant patterns: pager modal (lines 84-87) and 4 Select_widget modals (lines 183-186, 382-385, 701-704, 2554-2557)
- Once miaou#131 is merged and the pin updated, navigation in all choice menus and modals works correctly

## Building locally with the miaou fix

The fix branch carries miaou's 0.4.2 version, but `octez-manager.opam` pins each miaou package to 0.4.1 — so use `--with-version=0.4.1` to align with `pin-depends`:

```bash
URL="git+https://github.com/picojulien/miaou.git#fix/input-parser-pageup-home-end" && for p in miaou-core miaou-driver-matrix miaou-driver-term miaou-driver-web miaou-runner miaou-registry; do opam pin -yn --with-version=0.4.1 $p "$URL"; done && opam reinstall -y miaou-core miaou-driver-matrix miaou-driver-term miaou-driver-web miaou-runner miaou-registry && dune build
```

To roll back to the upstream pin once miaou#131 is merged:

```bash
for p in miaou-core miaou-driver-matrix miaou-driver-term miaou-driver-web miaou-runner miaou-registry; do opam pin remove -y $p; done && opam install -y . --deps-only
```

## Where to test in the TUI

The fix touches every choice modal opened via `Modal_helpers`. Concrete reproductions:

| Where | How to open | Why useful |
|---|---|---|
| **Instance action menu** | Highlight any instance in the main list and press `Enter` | The original report — reviewer can confirm Home/End jump and PageUp/PageDown step through the action list |
| **Theme selector** | Settings page → "Theme" entry (or wherever themes are picked) | Long enough list to exercise PageDown / End meaningfully |
| **Network / protocol picker** in install wizards | `Install` flow → network or protocol field | Multi-screen list — PageUp/PageDown visibly scrolls |
| **Log pager** | Open any service's logs | Uses Pager_widget — verifies `g`/`G` (Home/End) and `Page_up`/`Page_down` |
| **Wallet / delegate / key pickers** | Wallets page → pick an item from a long alias list | Long list → PageUp/PageDown step through 8 items at a time |

Suggested smoke test:
1. Open instance action menu → press `End` → cursor jumps to last item, `Home` → cursor jumps to first.
2. Open theme selector or any list with > 8 entries → press `PageDown` → cursor jumps 8 items down, `PageUp` → jumps 8 items up.
3. Open service logs (pager) → press `PageDown` / `PageUp` → page scrolls; `g` / `G` jump to top / bottom.

## Test plan

- [x] `dune build` passes
- [x] `dune runtest` passes
- [x] `dune fmt` clean
- [x] `./scripts/check-copyright.sh` clean

**Note on test coverage:** A headless TUI test cannot be written for this fix before miaou#131 lands — the key sequences (`ESC[5~` etc.) cannot be injected into the key handler until the parser recognises them. Once miaou#131 merges and the opam pin is updated, end-to-end key behaviour can be verified by extending existing modal navigation tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)