### PR TITLE
fix(cli): validate version before download and fix domain-unsafe R.error_msgf

### DIFF
--- a/lib/common/download.ml
+++ b/lib/common/download.ml
@@ -170,12 +170,26 @@ let download_file_with_progress_blocking ~url ~dest_path ~on_progress =
   in
   loop () ;
   Mutex.protect active_download_lock (fun () -> active_download := None) ;
-  close_in_noerr ic ;
-  close_in_noerr ec ;
+  (* NOTE: We use Printf.sprintf + Error (`Msg ...) instead of R.error_msgf
+     because this function may be called from parallel domains, and
+     Format.kasprintf (used by R.error_msgf) is not domain-safe in OCaml 5. *)
   match Unix.close_process_full (ic, oc, ec) with
   | Unix.WEXITED 0 -> Ok ()
-  | Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
-      R.error_msgf "curl download failed for %s" url
+  | Unix.WEXITED 22 ->
+      Error
+        (`Msg
+           (Printf.sprintf
+              "curl download failed for %s (HTTP error - file not found)"
+              url))
+  | Unix.WEXITED code ->
+      Error
+        (`Msg
+           (Printf.sprintf
+              "curl download failed for %s (exit code %d)"
+              url
+              code))
+  | Unix.WSIGNALED _ | Unix.WSTOPPED _ ->
+      Error (`Msg (Printf.sprintf "curl download failed for %s" url))
 
 let download_file_with_progress ~url ~dest_path ~on_progress =
   Cmd_runner.append_debug_log

--- a/src/cli/cmd_binaries.ml
+++ b/src/cli/cmd_binaries.ml
@@ -249,6 +249,25 @@ let download_octez_cmd =
         else version
       in
 
+      (* Verify the version exists before starting downloads *)
+      (match Binary_downloader.fetch_versions ~include_rc:true () with
+      | Ok versions ->
+          let exists =
+            List.exists
+              (fun (v : Binary_downloader.version_info) ->
+                String.equal v.version version)
+              versions
+          in
+          if not exists then (
+            Printf.eprintf
+              "Error: Version %s not found. Use 'octez-manager binaries \
+               list-remote' to see available versions.\n"
+              version ;
+            exit 1)
+      | Error _ ->
+          (* Can't fetch version list; proceed and let download fail *)
+          ()) ;
+
       Printf.printf "Downloading Octez v%s...\n\n" version ;
 
       (* Initialize multi-line progress display *)
@@ -282,14 +301,29 @@ let download_octez_cmd =
       in
 
       (* Perform download *)
-      match
+      let download_result =
         Binary_downloader.download_version
           ~version
           ~verify_checksums
           ~multi_progress
           ()
-      with
-      | Error (`Msg msg) -> Cli_helpers.cmdliner_error msg
+      in
+      match download_result with
+      | Error (`Msg msg) ->
+          (* Clear progress display *)
+          Printf.printf "\n%!" ;
+          (* Provide user-friendly error message *)
+          let user_msg =
+            if String_utils.string_contains ~needle:"curl download failed" msg
+            then
+              Printf.sprintf
+                "Error: Version %s not found or unavailable. The requested \
+                 binaries could not be downloaded. Use 'octez-manager binaries \
+                 list-remote' to see available versions."
+                version
+            else msg
+          in
+          Cli_helpers.cmdliner_error user_msg
       | Ok result ->
           (* Mark all binaries complete with their final sizes *)
           Mutex.lock display_mutex ;

--- a/src/eio_process.ml
+++ b/src/eio_process.ml
@@ -375,9 +375,25 @@ let download_file_with_progress_eio (Mgr mgr) ~url ~dest_path ~on_progress =
     | exception End_of_file -> ()
   in
   loop () ;
+  (* NOTE: We use Printf.sprintf + Error (`Msg ...) instead of R.error_msgf
+     because this function may be called from parallel domains via the download
+     pool, and Format.kasprintf (used by R.error_msgf) is not domain-safe. *)
   match Eio.Process.await proc with
   | `Exited 0 -> Ok ()
-  | _ -> R.error_msgf "curl download failed for %s" url
+  | `Exited 22 ->
+      Error
+        (`Msg
+           (Printf.sprintf
+              "curl download failed for %s (HTTP error - file not found)"
+              url))
+  | `Exited code ->
+      Error
+        (`Msg
+           (Printf.sprintf
+              "curl download failed for %s (exit code %d)"
+              url
+              code))
+  | _ -> Error (`Msg (Printf.sprintf "curl download failed for %s" url))
 
 (* --- Initialization --- *)
 

--- a/test/test_binary_downloader_extended.ml
+++ b/test/test_binary_downloader_extended.ml
@@ -371,6 +371,44 @@ let checksum_tests =
       test_verify_downloaded_binaries_mismatch_fails );
   ]
 
+(* ============================================================ *)
+(* Error Message Tests *)
+(* ============================================================ *)
+
+let test_curl_error_message_http_404 () =
+  (* Simulate a curl HTTP 404 error message *)
+  let error_msg =
+    "curl download failed for https://example.com/file (HTTP error - file not \
+     found)"
+  in
+  check
+    bool
+    "error mentions HTTP error"
+    true
+    (contains_substring error_msg "HTTP error") ;
+  check
+    bool
+    "error mentions file not found"
+    true
+    (contains_substring error_msg "file not found")
+
+let test_curl_error_message_with_exit_code () =
+  (* Simulate a curl error with exit code *)
+  let error_msg =
+    "curl download failed for https://example.com/file (exit code 7)"
+  in
+  check
+    bool
+    "error mentions exit code"
+    true
+    (contains_substring error_msg "exit code")
+
+let error_message_tests =
+  [
+    ("curl HTTP 404 error message", `Quick, test_curl_error_message_http_404);
+    ("curl error with exit code", `Quick, test_curl_error_message_with_exit_code);
+  ]
+
 let () =
   Alcotest.run
     "Binary_downloader_extended"
@@ -381,4 +419,5 @@ let () =
       ("size_formatting", size_tests);
       ("binaries", binaries_tests);
       ("checksums", checksum_tests);
+      ("error_messages", error_message_tests);
     ]


### PR DESCRIPTION
## Summary

- Validate requested version against the remote version list before starting downloads, failing immediately with a clear error message
- Fix `R.error_msgf` producing empty error messages when called from parallel domains (OCaml 5 `Format` module is not domain-safe)
- Add specific curl exit code handling (HTTP 404 vs other failures)

## Before

```
$ octez-manager binaries download octez 25.0
Downloading Octez v25.0...

[→] octez-node      ░░░░░░░░░░░░░░░░░░░░   0% (0 bytes / 1 KB)
[→] octez-client    ░░░░░░░░░░░░░░░░░░░░   0% (0 bytes / 1 KB)
[→] octez-baker     ░░░░░░░░░░░░░░░░░░░░   0% (0 bytes / 1 KB)
[→] octez-dal-node  ░░░░░░░░░░░░░░░░░░░░   0% (0 bytes / 1 KB)
octez-manager:
```

## After

```
$ octez-manager binaries download octez 25.0
Error: Version 25.0 not found. Use 'octez-manager binaries list-remote' to see available versions.
```