### PR TITLE
fix(ci): ensure correct ocamlformat version regardless of cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,13 @@ jobs:
           opam install . --deps-only --with-test --jobs=4
           opam install ocamlformat.0.28.1
 
+      - name: Ensure correct ocamlformat version
+        run: |
+          eval $(opam env)
+          if ! ocamlformat --version | grep -q "0.28.1"; then
+            opam install ocamlformat.0.28.1 --jobs=4
+          fi
+
       - name: Cache dune build
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary

- Add an unconditional step to verify ocamlformat 0.28.1 is installed, reinstalling if the cached/container version differs
- Fixes CI failures where the container image has ocamlformat 0.29.0 pre-installed and the cache-hit skips the install step