### PR TITLE
fix(download): surface stall warning and log progress parse failures

### DIFF
--- a/lib/common/download.ml
+++ b/lib/common/download.ml
@@ -127,6 +127,8 @@ let download_file_with_progress_blocking ~url ~dest_path ~on_progress =
   close_out oc ;
   let buffer = Buffer.create 128 in
   let input_char_opt ch = try Some (input_char ch) with End_of_file -> None in
+  let parse_failure_count = ref 0 in
+  let max_logged_failures = 3 in
   let rec loop () =
     match input_char_opt ec with
     | None -> ()
@@ -160,9 +162,27 @@ let download_file_with_progress_blocking ~url ~dest_path ~on_progress =
                          Int64.to_int received_bytes |> max 0 |> min max_int
                        in
                        on_progress received_int (Some total_int)
-                   | _ -> ())
-               | _ -> ()
-           with _ -> ()) ;
+                   | _ ->
+                       if !parse_failure_count < max_logged_failures then (
+                         incr parse_failure_count ;
+                         Cmd_runner.append_debug_log
+                           (Printf.sprintf
+                              "DOWNLOAD_PROGRESS parse failure (size): %s"
+                              trimmed)))
+               | _ ->
+                   if !parse_failure_count < max_logged_failures then (
+                     incr parse_failure_count ;
+                     Cmd_runner.append_debug_log
+                       (Printf.sprintf
+                          "DOWNLOAD_PROGRESS parse failure (format): %s"
+                          trimmed))
+           with _ ->
+             if !parse_failure_count < max_logged_failures then (
+               incr parse_failure_count ;
+               Cmd_runner.append_debug_log
+                 (Printf.sprintf
+                    "DOWNLOAD_PROGRESS parse exception: %s"
+                    (String.trim line)))) ;
           loop ())
         else (
           Buffer.add_char buffer c ;

--- a/src/eio_process.ml
+++ b/src/eio_process.ml
@@ -339,6 +339,8 @@ let download_file_with_progress_eio (Mgr mgr) ~url ~dest_path ~on_progress =
   Eio.Flow.close stderr_w ;
   let buffer = Buffer.create 128 in
   let reader = Eio.Buf_read.of_flow ~max_size:(10 * 1024 * 1024) stderr_r in
+  let parse_failure_count = ref 0 in
+  let max_logged_failures = 3 in
   let rec loop () =
     match Eio.Buf_read.any_char reader with
     | c ->
@@ -365,9 +367,27 @@ let download_file_with_progress_eio (Mgr mgr) ~url ~dest_path ~on_progress =
                          Int64.to_int received_bytes |> max 0 |> min max_int
                        in
                        on_progress received_int (Some total_int)
-                   | _ -> ())
-               | _ -> ()
-           with _ -> ()) ;
+                   | _ ->
+                       if !parse_failure_count < max_logged_failures then (
+                         incr parse_failure_count ;
+                         Cmd_runner.append_debug_log
+                           (Printf.sprintf
+                              "DOWNLOAD_PROGRESS parse failure (size): %s"
+                              trimmed)))
+               | _ ->
+                   if !parse_failure_count < max_logged_failures then (
+                     incr parse_failure_count ;
+                     Cmd_runner.append_debug_log
+                       (Printf.sprintf
+                          "DOWNLOAD_PROGRESS parse failure (format): %s"
+                          trimmed))
+           with _ ->
+             if !parse_failure_count < max_logged_failures then (
+               incr parse_failure_count ;
+               Cmd_runner.append_debug_log
+                 (Printf.sprintf
+                    "DOWNLOAD_PROGRESS parse exception: %s"
+                    (String.trim line)))) ;
           loop ())
         else (
           Buffer.add_char buffer c ;

--- a/src/ui/context.ml
+++ b/src/ui/context.ml
@@ -365,6 +365,8 @@ type multi_progress_state = {
   binaries : binary_progress list;
   finished_at : float option;
   checksum_message : string option;
+  started_at : float;
+  last_progress_update : float;
 }
 
 let multi_progress : multi_progress_state option ref = ref None
@@ -415,6 +417,7 @@ let format_status_icon status =
 
 (* Start multi-progress *)
 let multi_progress_start ~version ~binaries =
+  let now = Unix.gettimeofday () in
   let widgets =
     List.map
       (fun name ->
@@ -430,11 +433,19 @@ let multi_progress_start ~version ~binaries =
   in
   multi_progress :=
     Some
-      {version; binaries = widgets; finished_at = None; checksum_message = None} ;
+      {
+        version;
+        binaries = widgets;
+        finished_at = None;
+        checksum_message = None;
+        started_at = now;
+        last_progress_update = now;
+      } ;
   mark_download_dirty ()
 
 (* Update progress for a specific binary *)
 let multi_progress_update ~binary ~downloaded ~total =
+  let now = Unix.gettimeofday () in
   multi_progress :=
     Option.map
       (fun mp ->
@@ -462,7 +473,7 @@ let multi_progress_update ~binary ~downloaded ~total =
               else bp)
             mp.binaries
         in
-        {mp with binaries})
+        {mp with binaries; last_progress_update = now})
       !multi_progress ;
   mark_download_dirty ()
 
@@ -502,6 +513,25 @@ let multi_progress_finish () =
       (fun mp -> {mp with finished_at = Some (Unix.gettimeofday ())})
       !multi_progress ;
   mark_download_dirty ()
+
+(* Check if download appears stalled (no progress for 45 seconds) *)
+let multi_progress_is_stalled () =
+  match !multi_progress with
+  | None -> false
+  | Some mp ->
+      let now = Unix.gettimeofday () in
+      (* If finished, not stalled *)
+      if Option.is_some mp.finished_at then false
+      else
+        (* Check if any binary has made progress *)
+        let has_progress =
+          List.exists
+            (fun bp -> bp.status = `InProgress || bp.status = `Complete)
+            mp.binaries
+        in
+        (* Stalled if: started >45s ago AND (no progress updates OR still pending) *)
+        now -. mp.started_at > 45.0
+        && ((not has_progress) || now -. mp.last_progress_update > 45.0)
 
 (* Render multi-progress display *)
 let render_multi_progress ~cols:_ =

--- a/src/ui/context.mli
+++ b/src/ui/context.mli
@@ -203,6 +203,10 @@ val multi_progress_checksum : string -> unit
 (** Finish multi-progress (will linger for a few seconds before clearing) *)
 val multi_progress_finish : unit -> unit
 
+(** Check if download appears stalled (no progress for 45 seconds).
+    Returns [true] if download has been running for >45s with no progress updates. *)
+val multi_progress_is_stalled : unit -> bool
+
 (** Render multi-progress display (returns multi-line string) *)
 val render_multi_progress : cols:int -> string
 

--- a/src/ui/modal_helpers.ml
+++ b/src/ui/modal_helpers.ml
@@ -1312,6 +1312,12 @@ let open_download_progress_modal ~version ~on_complete =
         Context.render_multi_progress ~cols:(size.LTerm_geom.cols - 4)
       in
       if String.trim multi_progress_lines <> "" then add multi_progress_lines
+      else if Context.multi_progress_is_stalled () then (
+        add
+          "\xe2\x9a\xa0 Download appears stalled (no progress for 45+ seconds)" ;
+        add "" ;
+        add "Check /tmp/octez_manager_cmds.log for curl output details." ;
+        add "You may need to cancel (Esc) and retry the download.")
       else add "Initializing download..." ;
 
       add "" ;


### PR DESCRIPTION
## Summary

- Adds debug logging when curl progress parsing fails (first 3 failures logged to `/tmp/octez_manager_cmds.log`), enabling diagnosis of format mismatches on newer curl versions
- Shows a stall warning in the download modal after 45 seconds with no progress updates, guiding users to check logs or retry
- No I/O added to view functions — stall detection uses cached timestamps

Fixes #936