### PR TITLE
fix(test): pre-generate node identity in external-signer test

### DIFF
--- a/test/integration/cli-tester/tests/signatory/04-external-signer.sh
+++ b/test/integration/cli-tester/tests/signatory/04-external-signer.sh
@@ -32,6 +32,8 @@ om install-node \
 	--service-user tezos \
 	--no-enable 2>&1
 
+inject_identity "$NODE_INSTANCE"
+
 echo "==> Step 2: Start node to enable baker installation"
 om instance "$NODE_INSTANCE" start 2>&1
 


### PR DESCRIPTION
## Summary

- Pre-inject node identity in `04-external-signer.sh` to fix flaky timeout

## Problem

The test was timing out (90s) waiting for node RPC readiness because the node was stuck generating an identity file (PoW computation).

## Fix

Added `inject_identity "$NODE_INSTANCE"` after node installation and before starting the service — the same pattern used by other integration tests.

Fixes #955