### PR TITLE
fix(installer): write service registry before systemd operations

### DIFF
--- a/src/installer/dal_node.ml
+++ b/src/installer/dal_node.ml
@@ -46,6 +46,33 @@ let install_daemon ?(quiet = false) (request : daemon_request) =
   let* () = ensure_directories ~owner ~group directories in
   let* () = ensure_logging_base_directory ~owner ~group logging_mode in
   let* () = ensure_runtime_log_directory ~owner ~group logging_mode in
+  (* In edit mode, preserve existing dependents list *)
+  let existing_dependents =
+    if request.preserve_data then
+      match Service_registry.find ~instance:request.instance with
+      | Ok (Some existing) -> existing.Service.dependents
+      | _ -> []
+    else []
+  in
+  let service =
+    Service.make
+      ~instance:request.instance
+      ~role:request.role
+      ~network:request.network
+      ~history_mode:request.history_mode
+      ~data_dir:request.data_dir
+      ~rpc_addr:request.rpc_addr
+      ~net_addr:request.net_addr
+      ~service_user:request.service_user
+      ~app_bin_dir:request.app_bin_dir
+      ?bin_source:request.bin_source
+      ~logging_mode
+      ~extra_args:request.service_args
+      ~depends_on:request.depends_on
+      ~dependents:existing_dependents
+      ()
+  in
+  let* () = Service_registry.write service in
   let extra_env =
     let service_args = String.concat " " request.service_args |> String.trim in
     let args_entry =
@@ -105,33 +132,6 @@ let install_daemon ?(quiet = false) (request : daemon_request) =
     if request.preserve_data then Ok ()
     else reown_runtime_paths ~owner ~group ~paths:directories ~logging_mode
   in
-  (* In edit mode, preserve existing dependents list *)
-  let existing_dependents =
-    if request.preserve_data then
-      match Service_registry.find ~instance:request.instance with
-      | Ok (Some existing) -> existing.Service.dependents
-      | _ -> []
-    else []
-  in
-  let service =
-    Service.make
-      ~instance:request.instance
-      ~role:request.role
-      ~network:request.network
-      ~history_mode:request.history_mode
-      ~data_dir:request.data_dir
-      ~rpc_addr:request.rpc_addr
-      ~net_addr:request.net_addr
-      ~service_user:request.service_user
-      ~app_bin_dir:request.app_bin_dir
-      ?bin_source:request.bin_source
-      ~logging_mode
-      ~extra_args:request.service_args
-      ~depends_on:request.depends_on
-      ~dependents:existing_dependents
-      ()
-  in
-  let* () = Service_registry.write service in
   (* In edit mode, update dependent endpoints if RPC address changed (for DAL nodes) *)
   let* () =
     if

--- a/src/installer/index.ml
+++ b/src/installer/index.ml
@@ -62,6 +62,46 @@ let install ?(quiet = false) (request : index_request) =
     | _ -> []
   in
   let all_service_args = watched_args @ db_args @ request.extra_args in
+  (* Resolve parent service for network and dependencies *)
+  let parent_svc_opt =
+    match request.depends_on with
+    | None -> None
+    | Some parent_instance -> (
+        match Service_registry.find ~instance:parent_instance with
+        | Ok (Some parent_svc) -> Some parent_svc
+        | _ -> None)
+  in
+  let network =
+    match parent_svc_opt with
+    | Some parent_svc -> parent_svc.Service.network
+    | None -> ""
+  in
+  let existing_dependents =
+    if request.preserve_data then
+      match Service_registry.find ~instance:request.instance with
+      | Ok (Some existing) -> existing.Service.dependents
+      | _ -> []
+    else []
+  in
+  let service =
+    Service.make
+      ~instance:request.instance
+      ~role:"index"
+      ~network
+      ~history_mode:History_mode.default
+      ~data_dir:request.base_dir
+      ~rpc_addr:request.rpc_addr
+      ~net_addr:""
+      ~service_user:request.service_user
+      ~app_bin_dir:request.app_bin_dir
+      ?bin_source:request.bin_source
+      ~logging_mode
+      ~extra_args:all_service_args
+      ~depends_on:request.depends_on
+      ~dependents:existing_dependents
+      ()
+  in
+  let* () = Service_registry.write service in
   let service_args_str = String.concat " " all_service_args |> String.trim in
   (* Convert node_endpoint host:port to full URI *)
   let node_endpoint = endpoint_of_rpc request.node_endpoint in
@@ -91,24 +131,11 @@ let install ?(quiet = false) (request : index_request) =
       ~user:request.service_user
       ()
   in
-  let parent_svc_opt =
-    match request.depends_on with
-    | None -> None
-    | Some parent_instance -> (
-        match Service_registry.find ~instance:parent_instance with
-        | Ok (Some parent_svc) -> Some parent_svc
-        | _ -> None)
-  in
   let depends_on_for_systemd =
     match parent_svc_opt with
     | Some parent_svc ->
         Some [(parent_svc.Service.role, parent_svc.Service.instance)]
     | None -> None
-  in
-  let network =
-    match parent_svc_opt with
-    | Some parent_svc -> parent_svc.Service.network
-    | None -> ""
   in
   let* () =
     Systemd.write_dropin
@@ -125,32 +152,6 @@ let install ?(quiet = false) (request : index_request) =
     if request.preserve_data then Ok ()
     else reown_runtime_paths ~owner ~group ~paths:directories ~logging_mode
   in
-  let existing_dependents =
-    if request.preserve_data then
-      match Service_registry.find ~instance:request.instance with
-      | Ok (Some existing) -> existing.Service.dependents
-      | _ -> []
-    else []
-  in
-  let service =
-    Service.make
-      ~instance:request.instance
-      ~role:"index"
-      ~network
-      ~history_mode:History_mode.default
-      ~data_dir:request.base_dir
-      ~rpc_addr:request.rpc_addr
-      ~net_addr:""
-      ~service_user:request.service_user
-      ~app_bin_dir:request.app_bin_dir
-      ?bin_source:request.bin_source
-      ~logging_mode
-      ~extra_args:all_service_args
-      ~depends_on:request.depends_on
-      ~dependents:existing_dependents
-      ()
-  in
-  let* () = Service_registry.write service in
   (* Register as dependent on parent if depends_on is set *)
   let* () =
     match request.depends_on with

--- a/src/installer/node.ml
+++ b/src/installer/node.ml
@@ -182,6 +182,8 @@ let install_node ?(quiet = false) ?on_log (request : node_request) =
       ~dependents:existing_dependents
       ()
   in
+  log "Writing service registry...\n" ;
+  let* () = Service_registry.write service in
   log "Installing systemd unit...\n" ;
   let* () =
     Systemd.install_unit
@@ -225,8 +227,6 @@ let install_node ?(quiet = false) ?on_log (request : node_request) =
       ~app_bin_dir:request.app_bin_dir
       ()
   in
-  log "Writing service registry...\n" ;
-  let* () = Service_registry.write service in
   (* In edit mode, update dependent endpoints if RPC address changed *)
   let* () =
     if request.preserve_data then (

--- a/src/installer/signatory.ml
+++ b/src/installer/signatory.ml
@@ -306,6 +306,32 @@ Security:
     File_ops.write_file ~mode:0o644 ~owner ~group config_path yaml_content
   in
 
+  (* Parse RPC address for service registry *)
+  let rpc_addr = Rpc_addr.of_string validated_address in
+
+  (* Create service record *)
+  let service =
+    Service.make
+      ~instance:request.instance
+      ~role:"signatory"
+      ~network:"" (* Signatory is network-agnostic *)
+      ~history_mode:History_mode.default (* N/A for signatory *)
+      ~data_dir
+      ~rpc_addr
+      ~net_addr:"" (* N/A for signatory *)
+      ~service_user:request.service_user
+      ~app_bin_dir:request.app_bin_dir
+      ?bin_source:request.bin_source
+      ~logging_mode
+      ~extra_args:[] (* Signatory args are in config file *)
+      ~depends_on:None
+      ~dependents:[]
+      ()
+  in
+
+  (* Register service *)
+  let* () = Service_registry.write service in
+
   (* Write environment file *)
   let backend_kind_str =
     match request.backend with
@@ -360,32 +386,6 @@ Security:
         ~paths:[data_dir; keys_path]
         ~logging_mode
   in
-
-  (* Parse RPC address for service registry *)
-  let rpc_addr = Rpc_addr.of_string validated_address in
-
-  (* Create service record *)
-  let service =
-    Service.make
-      ~instance:request.instance
-      ~role:"signatory"
-      ~network:"" (* Signatory is network-agnostic *)
-      ~history_mode:History_mode.default (* N/A for signatory *)
-      ~data_dir
-      ~rpc_addr
-      ~net_addr:"" (* N/A for signatory *)
-      ~service_user:request.service_user
-      ~app_bin_dir:request.app_bin_dir
-      ?bin_source:request.bin_source
-      ~logging_mode
-      ~extra_args:[] (* Signatory args are in config file *)
-      ~depends_on:None
-      ~dependents:[]
-      ()
-  in
-
-  (* Register service *)
-  let* () = Service_registry.write service in
 
   (* Enable and start if requested *)
   let* () =


### PR DESCRIPTION
## Summary

Fixes #958 — the flaky `node/01-install.sh` integration test that fails with "Instance not in registry".

## Root Cause

The `Service_registry.write` call happened **after** systemd operations (`install_unit`, `write_dropin`, `daemon-reload`). In CI containers, systemd operations can intermittently fail (D-Bus timeouts, permission issues), causing the install command to error out before the registry entry is written.

## Fix

Move `Service_registry.write` to immediately after the service record is created, **before** any systemd operations. This ensures the instance is registered even if systemd operations fail.

Applied to all installers: node, dal_node, signatory, index.

## Verification

- `dune build` ✅
- `dune runtest` ✅ (278 tests pass)
- `dune fmt` ✅