### PR TITLE
fix(cli): emit [] from baker list --json when no instances exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Node installation now validates that the service user can execute the Octez binaries *before* writing any state. Previously a failed install (e.g. binaries in a directory the service user cannot access) left a stale service registry entry that kept the instance name and RPC port occupied (#987)
 - Install wizards (node, baker, DAL node, accuser) now reject instance names containing spaces or punctuation with an inline validation error, instead of reporting the form as valid and failing at install time; the sandbox creation wizard likewise validates the sandbox name (fixes #966)
+- `octez-manager baker list --json` now emits an empty JSON array (`[]`) instead of a plain-text hint when no baker instances exist, keeping the output machine-readable for scripts (fixes #968)
 
 ## [1.0.0-rc3] - 2026-05-26
 

--- a/src/cli/cmd_baker.ml
+++ b/src/cli/cmd_baker.ml
@@ -116,10 +116,13 @@ let list_run json =
   in
   match baker_states with
   | [] ->
-      Printf.printf
-        "No baker instances found. Use 'octez-manager install-baker' to create \
-         one.\n\
-         %!" ;
+      (* With --json the output must stay machine-readable even when empty. *)
+      if json then Printf.printf "[]\n%!"
+      else
+        Printf.printf
+          "No baker instances found. Use 'octez-manager install-baker' to \
+           create one.\n\
+           %!" ;
       `Ok ()
   | _ ->
       if json then (

--- a/test/integration/cli-tester/tests/baker/45-baker-list-no-instances.sh
+++ b/test/integration/cli-tester/tests/baker/45-baker-list-no-instances.sh
@@ -46,4 +46,13 @@ if [[ "$json_output" == *"capability missing"* ]] || [[ "$json_output" == *"Fail
   exit 1
 fi
 
+# --json must emit machine-readable output even when the list is empty
+# (regression test for https://github.com/trilitech/octez-manager/issues/968
+# where it printed a plain-text hint instead of a JSON document).
+if ! echo "$json_output" | jq -e 'type == "array"' >/dev/null 2>&1; then
+  echo "ERROR: 'baker list --json' did not emit a JSON array"
+  echo "Output: $json_output"
+  exit 1
+fi
+
 echo "Baker list no-instances test passed"


### PR DESCRIPTION
## Summary

With `--json` explicitly requested, `octez-manager baker list --json` printed a plain-text hint ("No baker instances found. Use 'octez-manager install-baker' to create one.") when the list was empty — breaking any script that pipes the output to `jq`/a JSON parser.

The empty case now prints `[]`, consistent with the other JSON list commands (`group list --json`, `list-snapshots --json`, which build their output via Yojson and already handled empty correctly — I audited all `--json` flags in `src/cli/`; `cmd_baker.ml` was the only offender). The human-friendly hint is unchanged in the default text mode.

## Tests

Extended the existing integration test `baker/45-baker-list-no-instances.sh` (already registered in shards.json) with a `jq -e 'type == "array"'` assertion on the `--json` output. Fails without the fix (prose is not JSON), passes with it.

Fixes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)