### PR TITLE
fix(ui): validate instance name characters inline in install wizards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - Node installation now validates that the service user can execute the Octez binaries *before* writing any state. Previously a failed install (e.g. binaries in a directory the service user cannot access) left a stale service registry entry that kept the instance name and RPC port occupied (#987)
+- Install wizards (node, baker, DAL node, accuser) now reject instance names containing spaces or punctuation with an inline validation error, instead of reporting the form as valid and failing at install time; the sandbox creation wizard likewise validates the sandbox name (fixes #966)
 
 ## [1.0.0-rc3] - 2026-05-26
 

--- a/src/ui/form_builder_bundles.ml
+++ b/src/ui/form_builder_bundles.ml
@@ -159,12 +159,14 @@ let core_service_fields ~get_core ~set_core ~binary ~subcommand ?baker_mode
               Form_builder_common.cached_service_states_nonblocking ()
             in
             let name = (get_core m).instance_name in
-            if not (is_nonempty name) then Error "Instance name is required"
-            else if
-              instance_in_use ~states name
-              && not (edit_mode && original_instance = Some name)
-            then Error "Instance name already exists"
-            else Ok ());
+            match validate_instance_name_syntax name with
+            | Error e -> Error e
+            | Ok () ->
+                if
+                  instance_in_use ~states name
+                  && not (edit_mode && original_instance = Some name)
+                then Error "Instance name already exists"
+                else Ok ());
       ]
   in
   (* Service User - readonly in edit mode *)

--- a/src/ui/form_builder_common.ml
+++ b/src/ui/form_builder_common.ml
@@ -56,6 +56,13 @@ type node_config = {
 
 let is_nonempty s = String.trim s <> ""
 
+let validate_instance_name_syntax name =
+  if not (is_nonempty name) then Error "Instance name is required"
+  else
+    match Config.validate_instance_name_chars ~instance:name with
+    | Ok () -> Ok ()
+    | Error (`Msg msg) -> Error msg
+
 let normalize s = String.lowercase_ascii (String.trim s)
 
 let instance_in_use ~states name =

--- a/src/ui/form_builder_common.mli
+++ b/src/ui/form_builder_common.mli
@@ -62,6 +62,11 @@ type node_config = {
 (** Check if string is non-empty after trimming *)
 val is_nonempty : string -> bool
 
+(** Validate an instance name for inline form display: non-empty and only
+    characters valid in systemd unit names (a-z, A-Z, 0-9, '-', '_', '.').
+    Returns the message to show next to the field on error. *)
+val validate_instance_name_syntax : string -> (unit, string) result
+
 (** Lowercase and trim a string *)
 val normalize : string -> string
 

--- a/src/ui/pages/install_accuser_form_v3.ml
+++ b/src/ui/pages/install_accuser_form_v3.ml
@@ -338,13 +338,16 @@ let spec =
                   Form_builder_common.cached_service_states_nonblocking ()
                 in
                 let name = m.core.instance_name in
-                if not (Form_builder_common.is_nonempty name) then
-                  Error "Instance name is required"
-                else if
-                  Form_builder_common.instance_in_use ~states name
-                  && not (m.edit_mode && m.original_instance = Some name)
-                then Error "Instance name already exists"
-                else Ok ());
+                match
+                  Form_builder_common.validate_instance_name_syntax name
+                with
+                | Error e -> Error e
+                | Ok () ->
+                    if
+                      Form_builder_common.instance_in_use ~states name
+                      && not (m.edit_mode && m.original_instance = Some name)
+                    then Error "Instance name already exists"
+                    else Ok ());
           ]
         (* 10. Group *)
         @ [

--- a/src/ui/pages/install_baker_form_v3.ml
+++ b/src/ui/pages/install_baker_form_v3.ml
@@ -860,17 +860,21 @@ let spec =
                   if base_dir_changed then {m' with delegates = []} else m')
               ~validate:(fun m ->
                 let states = Form_builder_common.cached_service_states () in
-                if not (Form_builder_common.is_nonempty m.core.instance_name)
-                then Error "Instance name is required"
-                else if
-                  Form_builder_common.instance_in_use
-                    ~states
+                match
+                  Form_builder_common.validate_instance_name_syntax
                     m.core.instance_name
-                  && not
-                       (m.edit_mode
-                       && m.original_instance = Some m.core.instance_name)
-                then Error "Instance name already exists"
-                else Ok ());
+                with
+                | Error e -> Error e
+                | Ok () ->
+                    if
+                      Form_builder_common.instance_in_use
+                        ~states
+                        m.core.instance_name
+                      && not
+                           (m.edit_mode
+                           && m.original_instance = Some m.core.instance_name)
+                    then Error "Instance name already exists"
+                    else Ok ());
           ]
         (* 10. Group *)
         @ [

--- a/src/ui/pages/install_dal_node_form_v3.ml
+++ b/src/ui/pages/install_dal_node_form_v3.ml
@@ -331,15 +331,18 @@ let spec =
                   Form_builder_common.cached_service_states_nonblocking ()
                 in
                 let name = m.core.instance_name in
-                if not (Form_builder_common.is_nonempty name) then
-                  Error "Instance name is required"
-                else if
-                  Form_builder_common.instance_in_use ~states name
-                  && not
-                       (m.edit_mode
-                       && m.original_instance = Some m.core.instance_name)
-                then Error "Instance name already exists"
-                else Ok ());
+                match
+                  Form_builder_common.validate_instance_name_syntax name
+                with
+                | Error e -> Error e
+                | Ok () ->
+                    if
+                      Form_builder_common.instance_in_use ~states name
+                      && not
+                           (m.edit_mode
+                           && m.original_instance = Some m.core.instance_name)
+                    then Error "Instance name already exists"
+                    else Ok ());
           ]
         (* 10. Group *)
         @ [

--- a/src/ui/pages/install_node_form_v3.ml
+++ b/src/ui/pages/install_node_form_v3.ml
@@ -878,17 +878,21 @@ let spec =
                 let states =
                   Form_builder_common.cached_service_states_nonblocking ()
                 in
-                if not (Form_builder_common.is_nonempty m.core.instance_name)
-                then Error "Instance name is required"
-                else if
-                  Form_builder_common.instance_in_use
-                    ~states
+                match
+                  Form_builder_common.validate_instance_name_syntax
                     m.core.instance_name
-                  && not
-                       (m.edit_mode
-                       && m.original_instance = Some m.core.instance_name)
-                then Error "Instance name already exists"
-                else Ok ())
+                with
+                | Error e -> Error e
+                | Ok () ->
+                    if
+                      Form_builder_common.instance_in_use
+                        ~states
+                        m.core.instance_name
+                      && not
+                           (m.edit_mode
+                           && m.original_instance = Some m.core.instance_name)
+                    then Error "Instance name already exists"
+                    else Ok ())
             |> with_hint
                  "Unique identifier for this node. Used in systemd unit and \
                   default paths.";

--- a/src/ui/pages/sandbox_create_form.ml
+++ b/src/ui/pages/sandbox_create_form.ml
@@ -104,10 +104,27 @@ let network_field =
 
 let sandbox_name_field =
   Form_builder.(
-    text
+    validated_text
       ~label:"Sandbox Name"
       ~get:(fun m -> m.sandbox_name)
       ~set:(fun sandbox_name m -> {m with sandbox_name})
+      ~validate:(fun m ->
+        (* Must satisfy Sandbox_config_registry.is_safe_name, which rejects
+           the name with an exception at creation time otherwise. *)
+        let name = m.sandbox_name in
+        let is_valid_char = function
+          | 'a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '-' | '_' -> true
+          | _ -> false
+        in
+        if not (Form_builder_common.is_nonempty name) then
+          Error "Sandbox name is required"
+        else if String.length name > 64 then
+          Error "Sandbox name must be at most 64 characters"
+        else if not (String.for_all is_valid_char name) then
+          Error
+            "Only alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), and \
+             underscores (_) are allowed"
+        else Ok ())
     |> with_hint
          "Unique name for this sandbox. Auto-generated if left as default.")
 

--- a/test/test_form_builder_bundles.ml
+++ b/test/test_form_builder_bundles.ml
@@ -397,6 +397,67 @@ let test_combined_core_and_client_fields () =
     (List.length combined)
 
 (******************************************************************************)
+(*                    INSTANCE NAME SYNTAX VALIDATION                        *)
+(******************************************************************************)
+
+(* Regression tests for #966: the install wizards accepted instance names
+   with spaces and punctuation and reported the form as valid, deferring the
+   failure to systemd at install time. *)
+
+let check_syntax_result name expected_ok =
+  let result = FBC.validate_instance_name_syntax name in
+  check
+    bool
+    (Printf.sprintf
+       "%S is %s"
+       name
+       (if expected_ok then "valid" else "invalid"))
+    expected_ok
+    (Result.is_ok result)
+
+let test_instance_name_syntax_valid () =
+  List.iter
+    (fun name -> check_syntax_result name true)
+    ["node-mainnet"; "baker_1"; "a.b.c"; "NODE-2"; "n"]
+
+let test_instance_name_syntax_invalid () =
+  List.iter
+    (fun name -> check_syntax_result name false)
+    [
+      "";
+      "   ";
+      "my node";
+      "node-mainnetmy node!";
+      "node@mainnet";
+      "node/mainnet";
+      "node$";
+      "nœud";
+    ]
+
+let test_instance_name_syntax_error_messages () =
+  (match FBC.validate_instance_name_syntax "" with
+  | Error msg ->
+      check string "empty name message" "Instance name is required" msg
+  | Ok () -> fail "empty name must be rejected") ;
+  let contains_substring haystack needle =
+    let hl = String.length haystack and nl = String.length needle in
+    let rec loop i =
+      if i + nl > hl then false
+      else if String.equal (String.sub haystack i nl) needle then true
+      else loop (i + 1)
+    in
+    loop 0
+  in
+  match FBC.validate_instance_name_syntax "my node!" with
+  | Error msg ->
+      check
+        bool
+        "invalid chars message names the problem"
+        true
+        (contains_substring msg "invalid characters")
+  | Ok () -> fail "name with space and '!' must be rejected"
+
+(******************************************************************************)
 (*                              TEST SUITE                                   *)
 (******************************************************************************)
 
@@ -418,6 +479,15 @@ let () =
             `Quick
             test_core_service_skip_service_fields;
           test_case "edit_mode" `Quick test_core_service_edit_mode;
+        ] );
+      ( "Instance Name Syntax",
+        [
+          test_case "valid names" `Quick test_instance_name_syntax_valid;
+          test_case "invalid names" `Quick test_instance_name_syntax_invalid;
+          test_case
+            "error messages"
+            `Quick
+            test_instance_name_syntax_error_messages;
         ] );
       ( "Client Bundle",
         [

--- a/test/test_install_node_form.ml
+++ b/test/test_install_node_form.ml
@@ -590,13 +590,16 @@ let test_instance_name_with_spaces () =
   TH.with_test_env (fun () ->
       HD.Stateful.init (module Install_node_form.Page) ;
 
-      TH.navigate_down 10 ;
+      (* Navigate to the Instance Name field. *)
+      TH.navigate_down 14 ;
       Unix.sleepf 0.02 ;
 
       ignore (TH.send_key_and_wait "Enter") ;
       Unix.sleepf 0.02 ;
 
-      (* Instance names with spaces are problematic for systemd *)
+      (* Instance names with spaces break systemd unit naming. Appending to
+         the valid default produces e.g. "node-shadownetmy node name".
+         Regression test for #966: this used to be accepted as valid. *)
       TH.type_string "my node name" ;
       Unix.sleepf 0.02 ;
 
@@ -604,13 +607,19 @@ let test_instance_name_with_spaces () =
       Unix.sleepf 0.02 ;
 
       let screen = TH.get_screen_text () in
-
-      (* Should either reject or replace spaces *)
+      (* The editor must stay open (star-prefixed modal title) and show the
+         inline validation warning. The full message may be truncated by the
+         80-column test terminal, so match its stable prefix. *)
       check
         bool
-        "form handles spaces in instance name"
+        "editor stays open on invalid instance name"
         true
-        (String.length screen > 0))
+        (TH.contains_substring screen "★ Instance Name") ;
+      check
+        bool
+        "instance name with spaces shows inline validation error"
+        true
+        (TH.contains_substring screen "⚠ Instance name"))
 
 let test_reserved_instance_names () =
   TH.with_test_env (fun () ->


### PR DESCRIPTION
## Summary

The install wizards (node, baker, DAL node, accuser) only checked that the instance name was **non-empty and unused** — a name like `my node!` showed `✓` and "Form is valid - ready to install!", deferring the failure to systemd at install time (instance names end up in unit names and paths).

- New `Form_builder_common.validate_instance_name_syntax` routes the existing `Config.validate_instance_name_chars` charset check (already enforced by the installer and by `flows.ml`) into the inline field validators, so the user sees "Instance name '…' contains invalid characters. Only alphanumeric characters (a-z, A-Z, 0-9), hyphens (-), underscores (_), and dots (.) are allowed." while typing.
- Wired into all five instance-name validators: the shared `core_service_fields` bundle plus the node, baker, DAL-node, and accuser forms.
- The **sandbox** creation wizard's name field had *no* validation at all, and an unsafe name reaches `Sandbox_config_registry.config_path`, which raises `Invalid_argument` — it now validates the same rules as `Sandbox_config_registry.is_safe_name` inline (a‑zA‑Z0‑9, `-`, `_`, ≤64 chars).

No fields were added, removed, or reordered — golden-path `~downs` counts are unaffected.

## Tests

- New unit suite "Instance Name Syntax" in `test_form_builder_bundles.ml`: valid names, invalid names (spaces, `!`, `@`, `/`, `$`, non-ASCII, empty), and error-message content.
- Strengthened the previously vacuous headless test `test_instance_name_with_spaces` in `test_install_node_form.ml` (its assertion was `String.length screen > 0`, i.e. always true): it now navigates to Instance Name, types a name with spaces, and asserts the editor stays open with the inline `⚠` error. **Verified to fail without the fix and pass with it** (the pre-existing local failures in `node_form` tests are unchanged and also occur on `main`).

Fixes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)