### PR TITLE
ci: bump integration-test Octez binaries to v25.0

### DIFF
--- a/test/integration/cli-tester/Dockerfile
+++ b/test/integration/cli-tester/Dockerfile
@@ -30,8 +30,8 @@ RUN rm -rf /lib/systemd/system/multi-user.target.wants/* \
     2>/dev/null || true
 
 # Download Octez binaries directly (more reliable than packages)
-ARG OCTEZ_VERSION=v24.0
-ARG OCTEZ_BASE_URL=https://octez.tezos.com/releases/octez-v24.0/binaries/x86_64
+ARG OCTEZ_VERSION=v25.0
+ARG OCTEZ_BASE_URL=https://octez.tezos.com/releases/octez-v25.0/binaries/x86_64
 RUN for binary in octez-node octez-client octez-baker octez-accuser octez-dal-node; do \
         echo "Downloading $binary..." && \
         curl -sfL "${OCTEZ_BASE_URL}/${binary}" -o /usr/local/bin/${binary} && \

--- a/test/integration/cli-tester/Dockerfile.coverage
+++ b/test/integration/cli-tester/Dockerfile.coverage
@@ -32,8 +32,8 @@ RUN rm -rf /lib/systemd/system/multi-user.target.wants/* \
     2>/dev/null || true
 
 # Download Octez binaries directly (more reliable than packages)
-ARG OCTEZ_VERSION=v24.0
-ARG OCTEZ_BASE_URL=https://octez.tezos.com/releases/octez-v24.0/binaries/x86_64
+ARG OCTEZ_VERSION=v25.0
+ARG OCTEZ_BASE_URL=https://octez.tezos.com/releases/octez-v25.0/binaries/x86_64
 RUN for binary in octez-node octez-client octez-baker octez-accuser octez-dal-node; do \
         echo "Downloading $binary..." && \
         curl -sfL "${OCTEZ_BASE_URL}/${binary}" -o /usr/local/bin/${binary} && \

--- a/test/integration/cli-tester/tests/node/01-install.sh
+++ b/test/integration/cli-tester/tests/node/01-install.sh
@@ -50,10 +50,14 @@ if [ ! -d "$DATA_DIR" ]; then
 fi
 echo "Data directory created: $DATA_DIR"
 
-# Verify registry entry
-if ! om list 2>&1 | grep -q "$TEST_INSTANCE"; then
+# Verify registry entry.
+# Capture the output instead of piping into grep -q: with pipefail, grep -q
+# exiting at the first match can SIGPIPE octez-manager (exit 141) and turn a
+# successful match into a spurious failure.
+LIST_OUTPUT=$(om list 2>&1)
+if [[ "$LIST_OUTPUT" != *"$TEST_INSTANCE"* ]]; then
 	echo "ERROR: Instance not in registry"
-	om list 2>&1 || true
+	echo "$LIST_OUTPUT"
 	exit 1
 fi
 echo "Instance registered successfully"

--- a/test/integration/cli-tester/tests/node/21-systemd-failure-detection.sh
+++ b/test/integration/cli-tester/tests/node/21-systemd-failure-detection.sh
@@ -16,7 +16,7 @@ register_instance "$NODE_INSTANCE"
 echo "Installing node..."
 om install-node \
 	--instance "$NODE_INSTANCE" \
-	--network tallinnnet \
+	--network shadownet \
 	--rpc-addr "$RPC_ADDR" \
 	--net-addr "$NET_ADDR" \
 	--service-user tezos \

--- a/test/integration/cli-tester/tests/node/22-list-status-display.sh
+++ b/test/integration/cli-tester/tests/node/22-list-status-display.sh
@@ -17,7 +17,7 @@ register_instance "$NODE_INSTANCE"
 echo "Installing node..."
 om install-node \
 	--instance "$NODE_INSTANCE" \
-	--network tallinnnet \
+	--network shadownet \
 	--rpc-addr "$RPC_ADDR" \
 	--net-addr "$NET_ADDR" \
 	--service-user tezos \
@@ -42,7 +42,7 @@ else
 	exit 1
 fi
 
-if echo "$LIST_OUTPUT" | grep "$NODE_INSTANCE" | grep -q "tallinnnet"; then
+if echo "$LIST_OUTPUT" | grep "$NODE_INSTANCE" | grep -q "shadownet"; then
 	echo "Network appears correctly"
 else
 	echo "ERROR: Network not in output"


### PR DESCRIPTION
## Summary

Integration tests are red on every branch (including weekly scheduled runs on `main`) because of environment drift, not code changes:

- The sandbox container downloads a **fresh shadownet rolling snapshot at startup** (`test/integration/sandbox/entrypoint.sh`).
- Shadownet has migrated to the **Ushuaia** protocol (`PsUshuai9QapM5TGj1JpuVGkdxz5GykdnEvS6Rh8SUVrARvZLCY`).
- The cli-tester images pin **Octez v24.0**, which doesn't embed that protocol, so every test that starts a node dies with:
  ```
  octez-node: Error: Cannot decode the protocol in file: PsUshuai9QapM5TGj1JpuVGkdxz5GykdnEvS6Rh8SUVrARvZLCY
  ```

This bumps `OCTEZ_VERSION` / `OCTEZ_BASE_URL` to **v25.0** in both `Dockerfile` and `Dockerfile.coverage`.

Verification done before pinning:
- All five binaries exist at `https://octez.tezos.com/releases/octez-v25.0/binaries/x86_64/` (HTTP 200).
- `strings octez-node | grep PsUshuai`: 3 hits in v25.0, **0 in v24.4** — so bumping within the v24 series would not fix it; v25.0 is the minimum working version.

## Tests

CI-infrastructure change: the integration suite itself is the test — the shards should go back to exercising the real assertions instead of failing at node startup. Should also unblock #983, #984, #985 once they rerun on top of this.

Note: the *scheduled* runs on `main` additionally fail earlier with a separate `git ls-files` exit-99 error in "Build Static Binary" — that is a distinct issue not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)