### PR TITLE
fix(installer): validate binary access before writing service registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Node installation now validates that the service user can execute the Octez binaries *before* writing any state. Previously a failed install (e.g. binaries in a directory the service user cannot access) left a stale service registry entry that kept the instance name and RPC port occupied (#987)
+
 ## [1.0.0-rc3] - 2026-05-26
 
 ### Changed

--- a/src/installer/node.ml
+++ b/src/installer/node.ml
@@ -53,6 +53,16 @@ let install_node ?(quiet = false) ?on_log (request : node_request) =
   let* () =
     System_user.ensure_service_account ~quiet ~name:request.service_user ()
   in
+  log "Validating binary access...\n" ;
+  (* Fail before any state is written: a failure after the service registry
+     entry is created (e.g. inside Systemd.install_unit) would leave a stale
+     record occupying the instance name and RPC port. *)
+  let* () =
+    Systemd.validate_bin_dir
+      ~user:request.service_user
+      ~app_bin_dir:request.app_bin_dir
+      ~role:"node"
+  in
   log "Ensuring system directories...\n" ;
   let* () =
     if Paths.is_root () then


### PR DESCRIPTION
## Summary

Since f6c47eb1 (the #958 fix) the service registry entry is written **before** systemd operations — but `Systemd.install_unit` is also where binary accessibility is validated. An install that fails that check (binaries in a directory the service user cannot traverse) aborts with the registry entry already written and **no rollback**, leaving a ghost instance that keeps the instance name and RPC port occupied. Subsequent installs then fail with "Port 8732 is used by instance 'X'" for an instance that never actually existed.

Fix: validate binary access (`Systemd.validate_bin_dir`) right after the service account is ensured, **before any state is written**. This also fails fast — previously an install with inaccessible binaries would download and import a full snapshot before discovering the problem.

Part of #987 (node installer; the other installers still need the same audit).

## Tests

This bug is demonstrated by the existing integration test `node/25-binary-access-validation.sh`:
- Test 2 installs with a `chmod 700` binary dir and correctly fails —
- Test 3 then fixes permissions and reinstalls, which **fails without this fix** ("RPC address: Port 8732 is used by instance 'test-bin-access'" from the stale entry Test 2 left behind) and **passes with it**.

It failed exactly this way in CI run 29836354670 (shard 5) on #986, which is what surfaced the bug. Note: the test only runs green in CI once #986 (octez v25 bump) is in the base — before that, all node tests fail at startup on the shadownet protocol drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)