### PR TITLE
test(integration): avoid grep -q SIGPIPE flakiness under pipefail

### DIFF
--- a/test/integration/cli-tester/tests/baker/26-baker-basic-install.sh
+++ b/test/integration/cli-tester/tests/baker/26-baker-basic-install.sh
@@ -79,7 +79,7 @@ fi
 echo "Systemd service exists"
 
 # Verify service shows in list (using --internal for robustness)
-if ! om list --internal 2>&1 | grep -q "$BAKER_INSTANCE"; then
+if ! om list --internal 2>&1 | grep "$BAKER_INSTANCE" >/dev/null; then
 	echo "ERROR: Baker instance not in list output"
 	om list --internal
 	exit 1

--- a/test/integration/cli-tester/tests/binaries/01-download-and-verify.sh
+++ b/test/integration/cli-tester/tests/binaries/01-download-and-verify.sh
@@ -85,7 +85,7 @@ fi
 echo "✓ Metadata file present"
 
 # Verify we can list the downloaded version
-if ! om binaries list 2>&1 | grep -q "v$VERSION"; then
+if ! om binaries list 2>&1 | grep "v$VERSION" >/dev/null; then
 	echo "ERROR: Downloaded version not shown in binaries list"
 	exit 1
 fi

--- a/test/integration/cli-tester/tests/dal/18-dal-basic-install.sh
+++ b/test/integration/cli-tester/tests/dal/18-dal-basic-install.sh
@@ -85,7 +85,7 @@ fi
 echo "Systemd service exists"
 
 # Verify service shows in list (using --internal for robustness)
-if ! om list --internal 2>&1 | grep -q "$DAL_INSTANCE"; then
+if ! om list --internal 2>&1 | grep "$DAL_INSTANCE" >/dev/null; then
 	echo "ERROR: DAL instance not in list output"
 	om list --internal
 	exit 1

--- a/test/integration/cli-tester/tests/import/43-import-detect-service-based.sh
+++ b/test/integration/cli-tester/tests/import/43-import-detect-service-based.sh
@@ -31,7 +31,7 @@ fi
 echo "External service detected correctly"
 
 # Verify it shows up with 'external' marker when using --all or --external
-if ! om list --external 2>&1 | grep -q "$INSTANCE"; then
+if ! om list --external 2>&1 | grep "$INSTANCE" >/dev/null; then
 	echo "ERROR: External service not marked as external"
 	om list --external 2>&1
 	exit 1

--- a/test/integration/cli-tester/tests/import/50-import-field-overrides.sh
+++ b/test/integration/cli-tester/tests/import/50-import-field-overrides.sh
@@ -42,7 +42,7 @@ if ! service_is_managed "$CUSTOM_INSTANCE"; then
 fi
 
 # Verify original name is not in managed instances
-if om list 2>&1 | grep -v "external" | grep -q "$EXTERNAL_INSTANCE"; then
+if om list 2>&1 | grep -v "external" | grep "$EXTERNAL_INSTANCE" >/dev/null; then
 	echo "WARNING: Original name found in managed instances"
 fi
 

--- a/test/integration/cli-tester/tests/lib.sh
+++ b/test/integration/cli-tester/tests/lib.sh
@@ -67,7 +67,7 @@ _OM_USER_LOCK="/tmp/om-service-user.lock"
 instance_exists() {
 	local instance="$1"
 	# Primary check: ask octez-manager
-	if om list 2>&1 | grep -q "$instance"; then
+	if om list 2>&1 | grep "$instance" >/dev/null; then
 		return 0
 	fi
 	# Fallback: check the service registry file directly.
@@ -109,7 +109,7 @@ service_exists() {
 	# fully propagated through systemd's internal state
 	while [ $retry -lt $max_retries ]; do
 		# Template units are listed as role@.service, not role@instance.service
-		if systemctl list-unit-files "octez-${role}@.service" 2>/dev/null | grep -q "octez-${role}@"; then
+		if systemctl list-unit-files "octez-${role}@.service" 2>/dev/null | grep "octez-${role}@" >/dev/null; then
 			return 0
 		fi
 
@@ -429,7 +429,7 @@ SERVICE
 # Check if external service is detected
 external_service_detected() {
 	local service_name="$1"
-	om list --external 2>&1 | grep -q "$service_name"
+	om list --external 2>&1 | grep "$service_name" >/dev/null
 }
 
 # Wait for external service to be detected (with retries)
@@ -455,7 +455,7 @@ wait_for_external_service() {
 service_is_managed() {
 	local instance="$1"
 	# Check that instance appears in list but NOT in external services section
-	om list 2>&1 | grep -v "External Octez Services" | grep -q "$instance"
+	om list 2>&1 | grep -v "External Octez Services" | grep "$instance" >/dev/null
 }
 
 # Verify external service is disabled

--- a/test/integration/cli-tester/tests/node/21-systemd-failure-detection.sh
+++ b/test/integration/cli-tester/tests/node/21-systemd-failure-detection.sh
@@ -74,7 +74,7 @@ else
 fi
 
 # Verify om list shows the instance (it should still exist)
-if om list | grep -q "$NODE_INSTANCE"; then
+if om list | grep "$NODE_INSTANCE" >/dev/null; then
 	echo "Instance still visible in om list"
 else
 	echo "ERROR: Instance disappeared from list"
@@ -85,7 +85,7 @@ fi
 LIST_OUTPUT=$(om list)
 echo "om list output:"
 echo "$LIST_OUTPUT"
-if echo "$LIST_OUTPUT" | grep -q "$NODE_INSTANCE"; then
+if echo "$LIST_OUTPUT" | grep "$NODE_INSTANCE" >/dev/null; then
 	echo "om list shows the instance"
 else
 	echo "ERROR: Instance not in om list"

--- a/test/integration/cli-tester/tests/signatory/02-baker-dependency.sh
+++ b/test/integration/cli-tester/tests/signatory/02-baker-dependency.sh
@@ -33,7 +33,7 @@ om install-signatory \
 	--no-enable 2>&1
 
 echo "==> Step 2: Verify signatory appears in om list"
-if ! om list 2>&1 | grep -q "$SIGNATORY_INSTANCE"; then
+if ! om list 2>&1 | grep "$SIGNATORY_INSTANCE" >/dev/null; then
 	echo "ERROR: Signatory instance '$SIGNATORY_INSTANCE' not found in om list"
 	echo "Full om list output:"
 	om list 2>&1
@@ -121,7 +121,7 @@ systemctl daemon-reload
 echo "==> Step 10: Verify systemd can resolve the dependency chain"
 # This command would have failed with "Unit octez-signatory@X.service not found"
 # before the fix in src/systemd_dropin.ml:53
-if ! systemctl list-dependencies "$BAKER_UNIT" 2>&1 | grep -q "signatory@${SIGNATORY_INSTANCE}.service"; then
+if ! systemctl list-dependencies "$BAKER_UNIT" 2>&1 | grep "signatory@${SIGNATORY_INSTANCE}.service" >/dev/null; then
 	echo "ERROR: systemd cannot resolve signatory dependency"
 	systemctl list-dependencies "$BAKER_UNIT" || true
 	exit 1
@@ -129,7 +129,7 @@ fi
 
 echo "==> Step 11: Verify no dependency resolution errors"
 # Try to start the baker (should fail gracefully since node isn't running, but dependency should resolve)
-if systemctl start "$BAKER_UNIT" 2>&1 | grep -q "not found"; then
+if systemctl start "$BAKER_UNIT" 2>&1 | grep "not found" >/dev/null; then
 	echo "ERROR: systemd reports 'not found' when starting baker"
 	systemctl status "$BAKER_UNIT" || true
 	exit 1

--- a/test/integration/cli-tester/tests/signatory/04-external-signer.sh
+++ b/test/integration/cli-tester/tests/signatory/04-external-signer.sh
@@ -58,7 +58,7 @@ om install-baker \
 
 echo "==> Step 4: Verify baker installation succeeded"
 # Baker is installed successfully if registry entry exists
-if ! om list 2>&1 | grep -q "$BAKER_INSTANCE"; then
+if ! om list 2>&1 | grep "$BAKER_INSTANCE" >/dev/null; then
 	echo "ERROR: Baker instance '$BAKER_INSTANCE' not found in om list"
 	om list 2>&1
 	exit 1
@@ -106,13 +106,13 @@ echo "==> Step 7: Verify systemd dependencies"
 systemctl daemon-reload
 
 # Should depend on node only, not signatory
-if ! systemctl list-dependencies "$BAKER_UNIT" | grep -q "octez-node@${NODE_INSTANCE}.service"; then
+if ! systemctl list-dependencies "$BAKER_UNIT" | grep "octez-node@${NODE_INSTANCE}.service" >/dev/null; then
 	echo "ERROR: Baker not dependent on node"
 	systemctl list-dependencies "$BAKER_UNIT"
 	exit 1
 fi
 
-if systemctl list-dependencies "$BAKER_UNIT" | grep -q "signatory@"; then
+if systemctl list-dependencies "$BAKER_UNIT" | grep "signatory@" >/dev/null; then
 	echo "ERROR: Baker with external URI should not depend on local signatory"
 	systemctl list-dependencies "$BAKER_UNIT"
 	exit 1

--- a/test/integration/cli-tester/tests/signatory/05-multiple-instances.sh
+++ b/test/integration/cli-tester/tests/signatory/05-multiple-instances.sh
@@ -81,7 +81,7 @@ for instance in "$SIGNATORY1_INSTANCE" "$SIGNATORY2_INSTANCE" "$SIGNATORY3_INSTA
 		exit 1
 	fi
 	# Verify it's listed as signatory role
-	if ! om list 2>&1 | grep "$instance" | grep -q "signatory"; then
+	if ! om list 2>&1 | grep "$instance" | grep "signatory" >/dev/null; then
 		echo "ERROR: Instance $instance not listed as signatory role"
 		om list 2>&1 | grep "$instance"
 		exit 1
@@ -160,27 +160,27 @@ BAKER1_UNIT="octez-baker@${BAKER1_INSTANCE}.service"
 BAKER2_UNIT="octez-baker@${BAKER2_INSTANCE}.service"
 
 # Baker 1 -> Signatory 1
-if ! systemctl list-dependencies "$BAKER1_UNIT" | grep -q "signatory@${SIGNATORY1_INSTANCE}.service"; then
+if ! systemctl list-dependencies "$BAKER1_UNIT" | grep "signatory@${SIGNATORY1_INSTANCE}.service" >/dev/null; then
 	echo "ERROR: Baker1 not dependent on signatory1"
 	systemctl list-dependencies "$BAKER1_UNIT"
 	exit 1
 fi
 
 # Baker 2 -> Signatory 2
-if ! systemctl list-dependencies "$BAKER2_UNIT" | grep -q "signatory@${SIGNATORY2_INSTANCE}.service"; then
+if ! systemctl list-dependencies "$BAKER2_UNIT" | grep "signatory@${SIGNATORY2_INSTANCE}.service" >/dev/null; then
 	echo "ERROR: Baker2 not dependent on signatory2"
 	systemctl list-dependencies "$BAKER2_UNIT"
 	exit 1
 fi
 
 echo "==> Step 8: Verify cross-contamination - baker1 should NOT depend on signatory2 or signatory3"
-if systemctl list-dependencies "$BAKER1_UNIT" | grep -q "signatory@${SIGNATORY2_INSTANCE}.service"; then
+if systemctl list-dependencies "$BAKER1_UNIT" | grep "signatory@${SIGNATORY2_INSTANCE}.service" >/dev/null; then
 	echo "ERROR: Baker1 incorrectly depends on signatory2"
 	systemctl list-dependencies "$BAKER1_UNIT"
 	exit 1
 fi
 
-if systemctl list-dependencies "$BAKER1_UNIT" | grep -q "signatory@${SIGNATORY3_INSTANCE}.service"; then
+if systemctl list-dependencies "$BAKER1_UNIT" | grep "signatory@${SIGNATORY3_INSTANCE}.service" >/dev/null; then
 	echo "ERROR: Baker1 incorrectly depends on signatory3"
 	systemctl list-dependencies "$BAKER1_UNIT"
 	exit 1


### PR DESCRIPTION
## Summary

`node/21-systemd-failure-detection` failed on #984's rebase run (shard 4) with the self-contradicting output:

```
Failure result correctly reported: exit-code
ERROR: Instance disappeared from list
```

Root cause: `om list | grep -q "$NODE_INSTANCE"` under `set -o pipefail`. `grep -q` exits at the first match, which can SIGPIPE the producing `om list` (exit 141); pipefail then reports the whole pipeline as failed **even though the match succeeded**. It's a race on whether the producer finishes writing before grep exits — the same test passed on #983's and #988's runs minutes apart. Same bug class as the `node/01-install` fix that went in with #986.

This PR sweeps the whole integration suite: every pipeline-terminal `grep -q pattern` fed by a command (`om`, `systemctl`, `echo`) becomes `grep pattern >/dev/null` — plain grep reads its entire input, so the producer never gets SIGPIPE, and the exit status semantics are identical. 22 sites across 10 files, including the `instance_exists` / external-service helpers in `lib.sh` that many tests call.

Test-only change; no product code. `bash -n` passes on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)