### PR TITLE
fix(installer): validate binary access early in all remaining installers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Baker, accuser, DAL node, signatory, and indexer installation now validate binary access before writing any state, like node installation: a failed install no longer leaves a stale service registry entry occupying the instance name and address (fixes #987)
 - Node installation now validates that the service user can execute the Octez binaries *before* writing any state. Previously a failed install (e.g. binaries in a directory the service user cannot access) left a stale service registry entry that kept the instance name and RPC port occupied (#987)
 - Install wizards (node, baker, DAL node, accuser) now reject instance names containing spaces or punctuation with an inline validation error, instead of reporting the form as valid and failing at install time; the sandbox creation wizard likewise validates the sandbox name (fixes #966)
 - `octez-manager baker list --json` now emits an empty JSON array (`[]`) instead of a plain-text hint when no baker instances exist, keeping the output machine-readable for scripts (fixes #968)

--- a/src/installer/dal_node.ml
+++ b/src/installer/dal_node.ml
@@ -26,6 +26,15 @@ let install_daemon ?(quiet = false) (request : daemon_request) =
   let* () =
     System_user.ensure_service_account ~quiet ~name:request.service_user ()
   in
+  (* Fail before any state is written: a failure after the service registry
+     entry is created (e.g. inside Systemd.install_unit) would leave a stale
+     record occupying the instance name and RPC port. *)
+  let* () =
+    Systemd.validate_bin_dir
+      ~user:request.service_user
+      ~app_bin_dir:request.app_bin_dir
+      ~role:request.role
+  in
   let* () =
     if Paths.is_root () then
       System_user.ensure_system_directories

--- a/src/installer/index.ml
+++ b/src/installer/index.ml
@@ -26,6 +26,15 @@ let install ?(quiet = false) (request : index_request) =
   let* () =
     System_user.ensure_service_account ~quiet ~name:request.service_user ()
   in
+  (* Fail before any state is written: a failure after the service registry
+     entry is created (e.g. inside Systemd.install_unit) would leave a stale
+     record occupying the instance name and RPC port. *)
+  let* () =
+    Systemd.validate_bin_dir
+      ~user:request.service_user
+      ~app_bin_dir:request.app_bin_dir
+      ~role:"index"
+  in
   let* () =
     if Paths.is_root () then
       System_user.ensure_system_directories

--- a/src/installer/signatory.ml
+++ b/src/installer/signatory.ml
@@ -200,6 +200,15 @@ let install_signatory ?(quiet = false) (request : signatory_request) =
   let* () =
     System_user.ensure_service_account ~quiet ~name:request.service_user ()
   in
+  (* Fail before any state is written: a failure after the service registry
+     entry is created (e.g. inside Systemd.install_unit) would leave a stale
+     record occupying the instance name and RPC port. *)
+  let* () =
+    Systemd.validate_bin_dir
+      ~user:request.service_user
+      ~app_bin_dir:request.app_bin_dir
+      ~role:"signatory"
+  in
   let* () =
     if Paths.is_root () then
       System_user.ensure_system_directories

--- a/test/integration/cli-tester/tests/shards.json
+++ b/test/integration/cli-tester/tests/shards.json
@@ -2,7 +2,7 @@
   "metadata": {
     "generated_at": "2026-04-09T00:00:00.000000",
     "generated_by": "Rebase: merge main (101 tests) + install-index test",
-    "total_tests": 103,
+    "total_tests": 104,
     "total_duration": 819.05,
     "shard_count": 5,
     "mean_shard_duration": 163.81,
@@ -58,10 +58,11 @@
       "import/55-import-node-identity-preservation.sh",
       "import/56-import-node-missing-config-created.sh",
       "install/01-verified-release.sh",
-      "cli/01-version-consistency.sh"
+      "cli/01-version-consistency.sh",
+      "signatory/06-binary-access-no-stale-registry.sh"
     ],
-    "test_count": 19,
-    "total_duration": 146.78
+    "test_count": 20,
+    "total_duration": 152.78
   },
   "shard-3": {
     "tests": [

--- a/test/integration/cli-tester/tests/signatory/06-binary-access-no-stale-registry.sh
+++ b/test/integration/cli-tester/tests/signatory/06-binary-access-no-stale-registry.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Test: A failed signatory install must not leave a stale registry entry
+# Regression test for https://github.com/trilitech/octez-manager/issues/987
+# where installers wrote the service registry entry before the binary-access
+# validation in Systemd.install_unit; a failed install left a ghost instance
+# occupying the instance name and address. Covers the non-node installers
+# (the node variant is covered by node/25-binary-access-validation.sh).
+set -euo pipefail
+source /tests/lib.sh
+
+test_init "Failed signatory install leaves no stale registry entry"
+
+INSTANCE="test-sig-bin-access"
+RESTRICTED_DIR="/tmp/restricted-signatory-bin"
+
+# Register instance and data dir for automatic cleanup (also pre-cleans leftovers)
+register_instance "$INSTANCE"
+register_data_dir "$RESTRICTED_DIR"
+
+SIGNER_PORT=$(alloc_port)
+METRICS_PORT=$(alloc_port)
+
+install_signatory() {
+	om install-signatory \
+		--instance "$INSTANCE" \
+		--backend file \
+		--authorized-keys "tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx" \
+		--address "127.0.0.1:$SIGNER_PORT" \
+		--metrics-address "127.0.0.1:$METRICS_PORT" \
+		--app-bin-dir "$1" \
+		--service-user tezos \
+		--no-enable 2>&1
+}
+
+# Step 1: Install from a directory the service user cannot traverse — must fail.
+echo "Step 1: Installing with restricted binary directory (should fail)"
+mkdir -p "$RESTRICTED_DIR"
+cp /usr/local/bin/signatory "$RESTRICTED_DIR/"
+chmod 755 "$RESTRICTED_DIR/signatory"
+chmod 700 "$RESTRICTED_DIR" # Owner (root) only
+
+if install_signatory "$RESTRICTED_DIR"; then
+	echo "ERROR: Installation should have failed with restricted directory"
+	exit 1
+fi
+echo "✓ Installation correctly rejected restricted directory"
+
+# Step 2: The failed install must not have left a registry entry behind.
+LIST_OUTPUT=$(om list 2>&1)
+if [[ "$LIST_OUTPUT" == *"$INSTANCE"* ]]; then
+	echo "ERROR: Failed install left a stale registry entry"
+	echo "$LIST_OUTPUT"
+	exit 1
+fi
+echo "✓ No stale registry entry after failed install"
+
+# Step 3: Installing again with accessible binaries and the SAME instance
+# name and ports must succeed (a stale entry would block the name/address).
+echo "Step 3: Reinstalling with accessible binaries (should succeed)"
+install_signatory /usr/local/bin
+
+if ! instance_exists "$INSTANCE"; then
+	echo "ERROR: Reinstall failed after a previously failed install"
+	exit 1
+fi
+echo "✓ Reinstall succeeded with the same instance name and address"
+
+echo "Test passed"


### PR DESCRIPTION
## Summary

Completes #987: #988 fixed the node installer; this applies the identical treatment to every other install path. All of them wrote the service registry entry **before** `Systemd.install_unit` performed the binary-access check, so an install failing that check left a ghost instance occupying the instance name and address:

- `dal_node.ml`'s shared `install_daemon` — covers **baker**, **accuser**, and **DAL node** (baker delegates to it, then rewrites the record with signer info)
- `signatory.ml` — own flow
- `index.ml` — own flow

Each now calls `Systemd.validate_bin_dir` right after the service account is ensured, before any state is written (the account must exist first because the check runs `test -x` *as* the service user). This also fails fast instead of doing directory/config work destined to be aborted.

## Tests

New integration test `signatory/06-binary-access-no-stale-registry.sh` (registered in shards.json, shard-2):
1. installs signatory from a `chmod 700` binary dir → must fail (both before and after the fix),
2. asserts `om list` shows **no stale entry** → **fails without this fix** (signatory performed no binary access between its pure validations and the registry write, so the old code always reached the write), **passes with it**,
3. reinstalls with the same instance name and address from an accessible dir → must succeed.

Signatory was picked as the representative case because it installs without a running node; the shared `install_daemon` path gets the same one-line fix and is exercised by every baker/accuser/DAL install test already in the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)