### PR TITLE
fix(ui): confirm before discarding unsaved edits on wizard Esc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Install wizards now ask for confirmation before discarding unsaved edits: pressing Esc on a modified form opens a "Discard changes?" prompt instead of silently dropping everything; untouched forms still exit immediately (fixes #975)
+
 - Node installation now validates that the service user can execute the Octez binaries *before* writing any state. Previously a failed install (e.g. binaries in a directory the service user cannot access) left a stale service registry entry that kept the instance name and RPC port occupied (#987)
 - Install wizards (node, baker, DAL node, accuser) now reject instance names containing spaces or punctuation with an inline validation error, instead of reporting the form as valid and failing at install time; the sandbox creation wizard likewise validates the sandbox name (fixes #966)
 - `octez-manager baker list --json` now emits an empty JSON array (`[]`) instead of a plain-text hint when no baker instances exist, keeping the output machine-readable for scripts (fixes #968)

--- a/src/ui/form_builder.ml
+++ b/src/ui/form_builder.ml
@@ -436,7 +436,13 @@ module Make (S : sig
   val spec : model spec
 end) =
 struct
-  type state = {model_ref : S.model ref; focus : Focus_ring.t}
+  type state = {
+    model_ref : S.model ref;
+    focus : Focus_ring.t;
+    initial_values : (string * string) list;
+        (** Per-field (label, display value) snapshot taken at init, used to
+            detect unsaved edits when leaving the form. *)
+  }
 
   type msg = unit
 
@@ -454,10 +460,22 @@ struct
   let cursor_of_focus s =
     match Focus_ring.current_index s.focus with Some i -> i | None -> 0
 
+  (** Snapshot of every field's (label, display value), used to detect
+      unsaved edits. *)
+  let field_values model =
+    S.spec.fields model
+    |> List.map (fun (Field f) -> (f.label, f.to_string (f.get model)))
+
+  let is_dirty s =
+    let pair_equal (l1, v1) (l2, v2) =
+      String.equal l1 l2 && String.equal v1 v2
+    in
+    not (List.equal pair_equal s.initial_values (field_values !(s.model_ref)))
+
   let init () =
     let model_ref = ref (S.spec.initial_model ()) in
     let focus = build_focus_ring !model_ref in
-    let s = {model_ref; focus} in
+    let s = {model_ref; focus; initial_values = field_values !model_ref} in
     (* Call on_init hook if provided *)
     (match S.spec.on_init with Some f -> f !model_ref | None -> ()) ;
     Navigation.make s
@@ -706,6 +724,18 @@ struct
     Themed_page.render_layout ~size ~header ~footer ~child:(fun _ ->
         Table_widget.Table.render table)
 
+  (** Leave the form via Esc. If the user has unsaved edits, ask for
+      confirmation instead of silently discarding them. *)
+  let leave ps =
+    if is_dirty ps.Navigation.s then (
+      Modal_helpers.confirm_modal
+        ~title:"Discard changes?"
+        ~message:"You have unsaved changes. Leave and discard them?"
+        ~on_result:(fun confirmed -> if confirmed then Context.navigate_back ())
+        () ;
+      refresh ps)
+    else Navigation.back ps
+
   let handle_modal_key ps key ~size:_ =
     Miaou.Core.Modal_manager.handle_key key ;
     refresh ps
@@ -722,7 +752,7 @@ struct
       | `Handled -> Navigation.update (fun s -> {s with focus}) ps
       | `Bubble -> (
           match Miaou.Core.Keys.of_string key with
-          | Some Miaou.Core.Keys.Escape -> Navigation.back ps
+          | Some Miaou.Core.Keys.Escape -> leave ps
           | Some Miaou.Core.Keys.Up ->
               Navigation.update (fun s -> move_state s (-1)) ps
           | Some Miaou.Core.Keys.Down ->
@@ -773,7 +803,7 @@ struct
           | `Bubble -> (
               match key with
               | Miaou.Core.Keys.Escape ->
-                  (Navigation.back ps, Miaou_interfaces.Key_event.Handled)
+                  (leave ps, Miaou_interfaces.Key_event.Handled)
               | Miaou.Core.Keys.Up ->
                   ( Navigation.update (fun s -> move_state s (-1)) ps,
                     Miaou_interfaces.Key_event.Handled )

--- a/test/test_install_node_form.ml
+++ b/test/test_install_node_form.ml
@@ -779,6 +779,75 @@ let validation_tests =
   ]
 
 (* ============================================================ *)
+(* Regression tests for issue #975: Esc discards edits silently *)
+(* ============================================================ *)
+
+(** A pristine form must exit on Esc without asking for confirmation. *)
+let test_esc_pristine_form_no_confirmation () =
+  TH.with_test_env (fun () ->
+      HD.Stateful.init (module Install_node_form.Page) ;
+
+      ignore (TH.send_key_and_wait "Escape") ;
+      Unix.sleepf 0.02 ;
+
+      let screen = TH.get_screen_text () in
+      check
+        bool
+        "pristine form exits without a discard prompt"
+        false
+        (TH.contains_substring screen "Discard changes?"))
+
+(** A form with unsaved edits must ask for confirmation on Esc, and
+    cancelling the prompt must keep the form (and the edit) intact. *)
+let test_esc_dirty_form_asks_confirmation () =
+  TH.with_test_env (fun () ->
+      HD.Stateful.init (module Install_node_form.Page) ;
+
+      (* Edit History Mode: rolling -> full (second choice in the picker). *)
+      TH.navigate_down 1 ;
+      Unix.sleepf 0.02 ;
+      ignore (TH.send_key_and_wait "Enter") ;
+      Unix.sleepf 0.02 ;
+      ignore (TH.send_key_and_wait "Down") ;
+      ignore (TH.send_key_and_wait "Enter") ;
+      Unix.sleepf 0.02 ;
+      TH.assert_screen_contains "full" ;
+
+      (* Esc on the dirty form must open the confirmation modal
+         (regression test for #975: it used to leave silently). *)
+      ignore (TH.send_key_and_wait "Escape") ;
+      Unix.sleepf 0.02 ;
+      TH.assert_screen_contains "Discard changes?" ;
+
+      (* Cancelling the prompt keeps the form and the edit. The choice
+         modal recognizes the normalized "Esc" key name, which is what a
+         real terminal delivers. *)
+      ignore (TH.send_key_and_wait "Esc") ;
+      Unix.sleepf 0.02 ;
+      let screen = TH.get_screen_text () in
+      check
+        bool
+        "prompt dismissed"
+        false
+        (TH.contains_substring screen "Discard changes?") ;
+      check
+        bool
+        "form still shown with the edit"
+        true
+        (TH.contains_substring screen "Install Node"
+        && TH.contains_substring screen "full"))
+
+let esc_confirmation_tests =
+  [
+    ( "pristine form exits without prompt",
+      `Quick,
+      test_esc_pristine_form_no_confirmation );
+    ( "dirty form asks for confirmation",
+      `Quick,
+      test_esc_dirty_form_asks_confirmation );
+  ]
+
+(* ============================================================ *)
 (* Regression tests for issue #113: snapshot kind duplication  *)
 (* ============================================================ *)
 
@@ -819,5 +888,6 @@ let () =
     [
       ("node_form", form_tests);
       ("validation", validation_tests);
+      ("esc_confirmation", esc_confirmation_tests);
       ("snapshot_display", snapshot_display_tests);
     ]


### PR DESCRIPTION
## Summary

Pressing Esc in an install wizard silently discarded every edit (#975) — one stray keypress from a half-filled form to nothing.

`Form_builder.Make` now snapshots each field's `(label, display value)` at init and compares on Esc:

- **pristine form** → exits immediately, exactly as before;
- **modified form** → opens a "Discard changes? / You have unsaved changes. Leave and discard them?" Yes/No modal. *Yes* navigates back through the existing `Context.navigate_back` pending-navigation mechanism (already consumed by the form's `refresh`); *No*/Esc keeps the form with all edits intact.

The comparison uses each field's own display string (`f.to_string (f.get model)`), so it needs no per-field instrumentation, works with dynamic field lists, and avoids polymorphic equality on models. Both Escape entry points (`handle_key` and `on_key`) route through the new `leave` function. All wizards generated by the functor get the behavior: node, baker, DAL node, accuser, index, signatory, sandbox.

No fields added/removed/reordered — golden-path `~downs` counts unaffected (the golden path submits forms and never presses Esc mid-form).

Verified live in tmux: pristine-exit, dirty-prompt, cancel-keeps-edits, and Yes-discards paths.

## Tests

New headless suite `esc_confirmation` in `test_install_node_form.ml`:
- *pristine form exits without prompt* — guards the unchanged fast path;
- *dirty form asks for confirmation* — edits History Mode, asserts the prompt appears on Esc, cancels, and asserts the form and edit survive. **Fails without the fix** (no prompt; verified by stashing `src/ui`), passes with it.

Fixes #975

🤖 Generated with [Claude Code](https://claude.com/claude-code)