### PR TITLE
fix(ui): derive RPC endpoint network from teztnets hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- The RPC browser now derives a public endpoint's network from its teztnets hostname (e.g. `rpc.ushuaianet.teztnets.com` → Ushuaianet) instead of showing "Unknown" for testnets missing from a static list (fixes #970)
+
 - Install wizards now ask for confirmation before discarding unsaved edits: pressing Esc on a modified form opens a "Discard changes?" prompt instead of silently dropping everything; untouched forms still exit immediately (fixes #975)
 
 - Node installation now validates that the service user can execute the Octez binaries *before* writing any state. Previously a failed install (e.g. binaries in a directory the service user cannot access) left a stale service registry entry that kept the instance name and RPC port occupied (#987)

--- a/src/ui/public_nodes_cache.ml
+++ b/src/ui/public_nodes_cache.ml
@@ -56,13 +56,56 @@ let extract_network_from_url (url : string) : string option =
       (* Note: rpc.tzkt.io removed - it has network in path: rpc.tzkt.io/mainnet *)
     ]
   in
+  (* Derive the network slug from a teztnets hostname such as
+     "rpc.<slug>.teztnets.com" or "<slug>.teztnets.com". Teztnets rotate, so
+     this keeps working for networks that postdate the static list below. *)
+  let teztnets_hostname_slug () =
+    let host =
+      let without_scheme =
+        match String.index_opt lower_url ':' with
+        | Some i
+          when i + 2 < String.length lower_url
+               && String.sub lower_url i 3 = "://" ->
+            String.sub lower_url (i + 3) (String.length lower_url - i - 3)
+        | _ -> lower_url
+      in
+      match String.index_opt without_scheme '/' with
+      | Some i -> String.sub without_scheme 0 i
+      | None -> without_scheme
+    in
+    let suffix = ".teztnets.com" in
+    if
+      String.length host > String.length suffix
+      && String.sub
+           host
+           (String.length host - String.length suffix)
+           (String.length suffix)
+         = suffix
+    then
+      let prefix =
+        String.sub host 0 (String.length host - String.length suffix)
+      in
+      let slug =
+        match String.rindex_opt prefix '.' with
+        | Some i -> String.sub prefix (i + 1) (String.length prefix - i - 1)
+        | None -> prefix
+      in
+      let is_slug_char = function
+        | 'a' .. 'z' | '0' .. '9' | '-' -> true
+        | _ -> false
+      in
+      if slug <> "" && slug <> "rpc" && String.for_all is_slug_char slug then
+        Some slug
+      else None
+    else None
+  in
   match
     List.find_opt
       (fun (pattern, _) -> contains_substring lower_url pattern)
       known_url_mappings
   with
   | Some (_, network) -> Some network
-  | None ->
+  | None -> (
       (* Fall back to searching for network name in URL *)
       let known_networks =
         [
@@ -74,7 +117,13 @@ let extract_network_from_url (url : string) : string option =
           "mondaynet";
         ]
       in
-      List.find_opt (fun net -> contains_substring lower_url net) known_networks
+      match
+        List.find_opt
+          (fun net -> contains_substring lower_url net)
+          known_networks
+      with
+      | Some net -> Some net
+      | None -> teztnets_hostname_slug ())
 
 (** Parse Taquito JSON format to extract public nodes *)
 let parse_taquito_json (txt : string) : node_info list =

--- a/test/test_public_nodes_cache.ml
+++ b/test/test_public_nodes_cache.ml
@@ -124,6 +124,63 @@ let test_to_service_no_network () =
     svc.Octez_manager_lib.Service.network
 
 (* ============================================================ *)
+(* Network extraction from URLs                                  *)
+(* ============================================================ *)
+
+(* Regression tests for #970: RPC endpoints of teztnets networks missing
+   from the static known-network list (e.g. ushuaianet) were grouped under
+   "Unknown" in the RPC browser. The network slug is now derived from the
+   teztnets hostname itself. *)
+
+let check_network url expected =
+  Alcotest.(check (option string))
+    url
+    expected
+    (Public_nodes_cache.extract_network_from_url url)
+
+let test_extract_known_static_networks () =
+  check_network "https://mainnet.smartpy.io" (Some "mainnet") ;
+  check_network "https://tezos-shadownet.octez.io" (Some "shadownet") ;
+  check_network "https://rpc.tzbeta.net" (Some "mainnet") ;
+  check_network "https://rpc.tzkt.io/mainnet" (Some "mainnet")
+
+let test_extract_teztnets_hostname_slug () =
+  (* Networks absent from the static list resolve via the hostname. *)
+  check_network "https://rpc.ushuaianet.teztnets.com" (Some "ushuaianet") ;
+  check_network "https://rpc.bakingnet.teztnets.com" (Some "bakingnet") ;
+  check_network "https://futurenet.teztnets.com" (Some "futurenet")
+
+let test_extract_teztnets_static_list_precedence () =
+  (* Networks in the static list keep their current (prefix-free) name even
+     when the hostname carries a rotation suffix. *)
+  check_network
+    "https://rpc.weeklynet-2026-07-15.teztnets.com"
+    (Some "weeklynet")
+
+let test_extract_unknown_urls () =
+  check_network "https://rpc.example.org" None ;
+  (* A bare teztnets host without a network slug stays unknown. *)
+  check_network "https://teztnets.com" None ;
+  check_network "https://rpc.teztnets.com" None
+
+let extraction_tests =
+  [
+    Alcotest.test_case
+      "static networks"
+      `Quick
+      test_extract_known_static_networks;
+    Alcotest.test_case
+      "teztnets hostname slug"
+      `Quick
+      test_extract_teztnets_hostname_slug;
+    Alcotest.test_case
+      "static list precedence"
+      `Quick
+      test_extract_teztnets_static_list_precedence;
+    Alcotest.test_case "unknown urls" `Quick test_extract_unknown_urls;
+  ]
+
+(* ============================================================ *)
 (* Test Runner                                                   *)
 (* ============================================================ *)
 
@@ -145,4 +202,5 @@ let () =
           Alcotest.test_case "basic" `Quick test_to_service;
           Alcotest.test_case "no network" `Quick test_to_service_no_network;
         ] );
+      ("extract_network_from_url", extraction_tests);
     ]

--- a/test/ui_regressions/node_network_shadownet.screen
+++ b/test/ui_regressions/node_network_shadownet.screen
@@ -1,0 +1,25 @@
+SIZE:240x24
+ Install Node                                                                   
+ ✓ Form is valid - ready to install!                                            
+--------------------------------------------------------------------------------
+┌───────────────────────┬──────────────────────────────────────────────┬───────┐
+│ Parameter             │ Value                                        │ S     │
+├───────────────────────┼──────────────────────────────────────────────┼───────┤
+│ Network               │ Shadownet                                    │ ✓     │
+│ History Mode          │ archive                                      │ ✓     │
+│ App Bin Dir           │ /usr/bin                                     │ ✓     │
+│ Data Dir              │ …ocal/share/octez/node-shadownet-archive     │ ✓     │
+│ RPC Address           │ 127.0.0.1:8732                               │ ✓     │
+│ P2P Address           │ 0.0.0.0:9732                                 │ ✓     │
+│ Extra Args            │ (none)                                       │ ✓     │
+│ Service User          │ valentin                                     │ ✓     │
+│ Enable on Boot        │ true                                         │ ✓     │
+│ Start Now             │ true                                         │ ✓     │
+│ Instance Name         │ node-shadownet-archive                       │ ✓     │
+│ Group                 │ None                                         │ ✓     │
+│ Confirm & Install     │ Ready                                        │ ✓     │
+└───────────────────────┴──────────────────────────────────────────────┴───────┘
+                                                                                
+                                                                                
+--------------------------------------------------------------------------------
+  Rolling: minimal disk (~50GB). Full: all blocks. Archive: all states (1TB+).  


### PR DESCRIPTION
## Summary

The RPC browser (tab 4) grouped `https://rpc.ushuaianet.teztnets.com` under a network category literally labeled **"Unknown"**, while the install wizard showed the same network as "Ushuaianet" (#970).

Root cause: `Public_nodes_cache.extract_network_from_url` matches URLs against a **hardcoded network list** (`mainnet, shadownet, tallinnnet, weeklynet, dailynet, mondaynet`) that has rotted — three dead testnets present, the live ones missing.

Fix: when the static list has no match, derive the slug from the teztnets hostname itself (`rpc.<slug>.teztnets.com` / `<slug>.teztnets.com`), so every current and future teztnets rotation resolves with zero list maintenance. Deliberately **not** wired to the dynamic Teztnets networks cache: that would make grouping depend on cache warm-up state, while the hostname already carries the answer deterministically. Precedence is unchanged — explicit mappings first (`tzbeta.net` → mainnet), then the static list (so rotation-suffixed weeklynet hosts keep grouping as plain "weeklynet"), then the new hostname rule, then `None`/"Unknown" as last resort. Guards reject empty/`rpc`/non-slug hostnames.

Verified live in tmux: the RPC browser now shows "• Ushuaianet" instead of "• Unknown".

## Tests

New `extract_network_from_url` suite in `test_public_nodes_cache.ml`: static networks unchanged, teztnets slugs resolved (ushuaianet, bakingnet, a hypothetical futurenet), static-list precedence for rotation-suffixed weeklynet, and unknown/bare-host URLs still `None`. The "teztnets hostname slug" case **fails without the fix** (verified by stashing the src change) and passes with it.

Fixes #970

🤖 Generated with [Claude Code](https://claude.com/claude-code)