### PR TITLE
fix(cli): usage error and action docs for the instance command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `octez-manager instance` without arguments now fails with a usage error (non-zero exit) instead of printing the top-level help page with exit 0, and `octez-manager instance --help` now documents all available actions (start, stop, restart, remove, purge, show, show-service, logs, export-logs, edit, set-env, get-env) with examples (fixes #969)
+
 - The RPC browser now derives a public endpoint's network from its teztnets hostname (e.g. `rpc.ushuaianet.teztnets.com` → Ushuaianet) instead of showing "Unknown" for testnets missing from a static list (fixes #970)
 
 - Install wizards now ask for confirmation before discarding unsaved edits: pressing Esc on a modified form opens a "Discard changes?" prompt instead of silently dropping everything; untouched forms still exit immediately (fixes #975)

--- a/src/cli/cmd_instance.ml
+++ b/src/cli/cmd_instance.ml
@@ -200,7 +200,13 @@ let instance_term =
   in
   let run instance action delete_data_dir force_purge extra_args =
     match (instance, action) with
-    | None, _ -> `Help (`Pager, None)
+    | None, _ ->
+        (* A usage error with non-zero exit, consistent with the other
+           command groups — not the top-level help page with exit 0. *)
+        Cli_helpers.cmdliner_error
+          "INSTANCE required. Run 'octez-manager list' to see available \
+           instances, or 'octez-manager instance --help' for the list of \
+           actions."
     | Some inst, None -> (
         match Service_registry.find ~instance:inst with
         | Ok None ->
@@ -927,5 +933,41 @@ let instance_term =
      $ extra_args))
 
 let instance_cmd =
-  let info = Cmd.info "instance" ~doc:"Manage existing Octez services." in
+  let info =
+    Cmd.info
+      "instance"
+      ~doc:"Manage existing Octez services."
+      ~man:
+        [
+          `S Manpage.s_description;
+          `P
+            "Operate on a registered service instance. INSTANCE is the name \
+             shown by 'octez-manager list'; ACTION is one of the actions \
+             below.";
+          `S "ACTIONS";
+          `I ("start", "Start the service (and its stopped dependencies).");
+          `I ("stop", "Stop the service.");
+          `I ("restart", "Restart the service.");
+          `I
+            ( "remove",
+              "Remove the service. Use $(b,--delete-data-dir) to also delete \
+               the recorded data directory." );
+          `I
+            ( "purge",
+              "Remove the service and delete its data. Use $(b,--force-purge) \
+               to skip the confirmation prompt." );
+          `I ("show", "Show the instance configuration and status.");
+          `I ("show-service", "Show the generated systemd service definition.");
+          `I ("logs", "Show the service logs.");
+          `I ("export-logs", "Export logs and diagnostics to an archive.");
+          `I ("edit", "Edit the instance configuration.");
+          `I ("set-env", "Set an environment variable: set-env KEY VALUE.");
+          `I ("get-env", "Print environment variables (or one: get-env KEY).");
+          `S Manpage.s_examples;
+          `P "Start an instance:";
+          `Pre "  octez-manager instance node-mainnet start";
+          `P "Follow its logs:";
+          `Pre "  octez-manager instance node-mainnet logs";
+        ]
+  in
   Cmd.v info instance_term

--- a/test/integration/cli-tester/tests/cli/02-instance-no-args.sh
+++ b/test/integration/cli-tester/tests/cli/02-instance-no-args.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Test: 'octez-manager instance' without arguments errors like its sibling
+# command groups, and its --help documents the available actions.
+# Regression test for https://github.com/trilitech/octez-manager/issues/969
+# where the no-args invocation dumped the top-level man page with exit 0 and
+# the help never listed the actions.
+set -euo pipefail
+source /tests/lib.sh
+
+test_init "instance no-args error and action documentation"
+
+# No arguments: must fail with a usage error, not print the top-level help
+# with exit 0.
+set +e
+output=$(om instance 2>&1)
+exit_code=$?
+set -e
+
+if [ "$exit_code" -eq 0 ]; then
+	echo "ERROR: 'instance' with no args exited 0 (expected non-zero)"
+	echo "Output: $output"
+	exit 1
+fi
+
+assert_contains "$output" "INSTANCE required" \
+	"expected a usage error mentioning the missing INSTANCE"
+
+if [[ "$output" == *"Terminal UI for managing Octez services"* ]]; then
+	echo "ERROR: 'instance' with no args printed the top-level help page"
+	exit 1
+fi
+echo "No-args invocation errors correctly (exit $exit_code)"
+
+# --help must document the available actions.
+help_output=$(om instance --help 2>&1)
+for action in start stop restart remove purge show logs export-logs edit set-env get-env; do
+	assert_contains "$help_output" "$action" \
+		"expected 'instance --help' to document the '$action' action"
+done
+echo "Help documents all actions"
+
+echo "Test passed"

--- a/test/integration/cli-tester/tests/shards.json
+++ b/test/integration/cli-tester/tests/shards.json
@@ -2,7 +2,7 @@
   "metadata": {
     "generated_at": "2026-04-09T00:00:00.000000",
     "generated_by": "Rebase: merge main (101 tests) + install-index test",
-    "total_tests": 103,
+    "total_tests": 105,
     "total_duration": 819.05,
     "shard_count": 5,
     "mean_shard_duration": 163.81,
@@ -83,10 +83,11 @@
       "node/09-install-no-snapshot.sh",
       "import/53-import-cascade-accuser.sh",
       "import/61-import-cascade-all-configs-preserved.sh",
-      "index/01-install.sh"
+      "index/01-install.sh",
+      "cli/02-instance-no-args.sh"
     ],
-    "test_count": 18,
-    "total_duration": 149.0
+    "test_count": 19,
+    "total_duration": 151.0
   },
   "shard-4": {
     "tests": [


### PR DESCRIPTION
## Summary

Two halves of #969, both in `cmd_instance.ml`:

1. **`octez-manager instance` with no arguments** rendered the *top-level* octez-manager man page (`` `Help (`Pager, None) ``) and exited **0** — unhelpful (wrong help page) and wrong for scripts (success exit for a misuse). Its sibling groups (`baker`, `rpc`, `group`) fail with a short usage error and exit 124. It now does the same: `INSTANCE required. Run 'octez-manager list' … or 'octez-manager instance --help' for the list of actions.`

2. **`instance --help` never documented the actions.** The twelve actions existed only in the positional-arg enum and a runtime error string. The man page now has an ACTIONS section describing each (`start stop restart remove purge show show-service logs export-logs edit set-env get-env`), cross-referencing the `--delete-data-dir` / `--force-purge` flags where relevant, plus usage examples.

No flags or subcommands added — `make completions` confirms zero completions drift.

## Tests

New integration test `cli/02-instance-no-args.sh` (registered in shards.json, shard-3):
- `om instance` must exit non-zero with the `INSTANCE required` message and must NOT print the top-level help ("Terminal UI for managing Octez services") — **fails without the fix** on both the exit code and the output;
- `om instance --help` must mention every action — **fails without the fix** (help contained none of them).

Fixes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)