### PR TITLE
fix(ui): drop redundant tez suffix in transfer network picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- The transfer flow's "Select network" picker no longer shows a redundant double unit ("0.000000 ꜩ tez" → "0.000000 ꜩ") (fixes #971)
+
 - `octez-manager instance` without arguments now fails with a usage error (non-zero exit) instead of printing the top-level help page with exit 0, and `octez-manager instance --help` now documents all available actions (start, stop, restart, remove, purge, show, show-service, logs, export-logs, edit, set-env, get-env) with examples (fixes #969)
 
 - The RPC browser now derives a public endpoint's network from its teztnets hostname (e.g. `rpc.ushuaianet.teztnets.com` → Ushuaianet) instead of showing "Unknown" for testnets missing from a static list (fixes #970)

--- a/src/ui/pages/wallets_page.ml
+++ b/src/ui/pages/wallets_page.ml
@@ -2083,6 +2083,19 @@ type network_choice = {
     prompting — sandbox keys must not be used on other networks.
     When a network has both local and public endpoints, shows both as separate
     choices, allowing the user to select which endpoint to use. *)
+
+(** Format one entry of the network-selection modal, e.g.
+    "shadownet (public)  1.500000 ꜩ  (syncing..)". The formatted balance
+    already carries the ꜩ symbol — no extra unit suffix. *)
+let format_network_choice ~label ~balance ~syncing =
+  let balance_str =
+    match balance with
+    | Some b -> Printf.sprintf "  %s" (Baker_wallet_data.format_tez b)
+    | None -> ""
+  in
+  let sync_str = if syncing then "  (syncing..)" else "" in
+  Printf.sprintf "%s%s%s" label balance_str sync_str
+
 let with_network (key : Keys_reader.key_metadata) ~(group : enriched_group)
     ~action =
   match group.sandbox_name with
@@ -2180,22 +2193,16 @@ let with_network (key : Keys_reader.key_metadata) ~(group : enriched_group)
             ~title:"Select network"
             ~items:multiple
             ~to_string:(fun c ->
-              let balance_str =
-                match
-                  List.find_opt
-                    (fun (wd : Keys_scheduler.wallet_data) ->
-                      String.equal wd.network c.network)
-                    wallet_data
-                with
-                | Some wd ->
-                    Printf.sprintf
-                      "  %s tez"
-                      (Baker_wallet_data.format_tez wd.spendable_balance)
-                | None -> ""
+              let balance =
+                List.find_opt
+                  (fun (wd : Keys_scheduler.wallet_data) ->
+                    String.equal wd.network c.network)
+                  wallet_data
+                |> Option.map (fun (wd : Keys_scheduler.wallet_data) ->
+                    wd.spendable_balance)
               in
-              let sync_str = if c.syncing then "  (syncing..)" else "" in
               let label =
-                Printf.sprintf "%s%s%s" c.label balance_str sync_str
+                format_network_choice ~label:c.label ~balance ~syncing:c.syncing
               in
               if String.equal c.network "mainnet" then
                 Widgets.themed_warning label
@@ -2644,6 +2651,8 @@ module Internal_for_tests = struct
   let default_client_base_dir = default_client_base_dir
 
   let get_all_base_dirs = get_all_base_dirs
+
+  let format_network_choice = format_network_choice
 end
 
 module Page = Page_Impl

--- a/src/ui/pages/wallets_page.mli
+++ b/src/ui/pages/wallets_page.mli
@@ -37,6 +37,11 @@ module Internal_for_tests : sig
 
   (** Get all base directories to scan for keys (default + managed, deduplicated). *)
   val get_all_base_dirs : unit -> string list
+
+  (** Format a network-selection modal entry from a label, an optional
+      spendable balance in mutez, and the syncing flag. *)
+  val format_network_choice :
+    label:string -> balance:string option -> syncing:bool -> string
 end
 
 (**/**)

--- a/test/test_wallets_page.ml
+++ b/test/test_wallets_page.ml
@@ -474,6 +474,48 @@ let scheduler_tests =
       test_scheduler_proactive_fetch );
   ]
 
+(* ============================================================ *)
+(* Network choice formatting (#971)                              *)
+(* ============================================================ *)
+
+(* Regression tests for #971: the transfer flow's "Select network" picker
+   displayed "0.000000 ꜩ tez" — format_tez already appends the ꜩ symbol
+   and the entry wrapped it in an extra " tez" suffix. *)
+
+let format_choice = Keys_page.Internal_for_tests.format_network_choice
+
+let test_network_choice_no_double_unit () =
+  let entry =
+    format_choice ~label:"mainnet (public)" ~balance:(Some "0") ~syncing:false
+  in
+  check string "single ꜩ unit" "mainnet (public)  0.000000 ꜩ" entry ;
+  check
+    bool
+    "no trailing 'tez' word"
+    false
+    (TH.contains_substring entry "tez\n" || TH.contains_substring entry " tez")
+
+let test_network_choice_variants () =
+  check
+    string
+    "no balance"
+    "shadownet (public)"
+    (format_choice ~label:"shadownet (public)" ~balance:None ~syncing:false) ;
+  check
+    string
+    "syncing suffix"
+    "shadownet (public)  1.500000 ꜩ  (syncing..)"
+    (format_choice
+       ~label:"shadownet (public)"
+       ~balance:(Some "1500000")
+       ~syncing:true)
+
+let network_choice_tests =
+  [
+    Alcotest.test_case "no double unit" `Quick test_network_choice_no_double_unit;
+    Alcotest.test_case "variants" `Quick test_network_choice_variants;
+  ]
+
 let () =
   Alcotest.run
     "Wallets_page"
@@ -482,4 +524,5 @@ let () =
       ("fold_unfold", fold_tests);
       ("refresh_on_dirty_flag", refresh_tests);
       ("scheduler_initial_fetch", scheduler_tests);
+      ("network_choice_format", network_choice_tests);
     ]


### PR DESCRIPTION
## Summary

The transfer flow's "Select network" picker showed `mainnet (public)  0.000000 ꜩ tez` — `Baker_wallet_data.format_tez` already appends the `ꜩ` symbol, and the modal entry wrapped it in an extra `" %s tez"` (#971). Same class as the rewards "(mutez)" suffix fixed in 7fceeeb5.

The entry formatting is extracted into a small pure helper, `format_network_choice ~label ~balance ~syncing` (exposed via `Internal_for_tests`), and the suffix dropped. Left deliberately untouched: `wallets_page.ml`'s duplicate local `format_tez` (no thousands separators) shadowing the `Baker_wallet_data` one — consolidating would change display output elsewhere; gardening material.

## Tests

New `network_choice_format` suite in `test_wallets_page.ml`: asserts the entry is exactly `mainnet (public)  0.000000 ꜩ` with no `" tez"` substring (fails on the old format string), plus the no-balance and syncing variants. Verified live in tmux that the picker renders cleanly.

Fixes #971

🤖 Generated with [Claude Code](https://claude.com/claude-code)