### PR TITLE
fix(cli): add --yes flag and non-zero exit for refused instance removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `octez-manager instance <name> remove` on an instance with dependents now has a working `--yes`/`-y` flag to confirm removal non-interactively. Previously the command told users to "Use --yes to confirm" but that flag did not exist (it was a usage error), and without it the command silently exited 0 without removing anything; it now exits non-zero when refused (fixes #998)
+
 - Node and DAL node edit operations no longer corrupt dependent env files through quote accumulation. Previously, `Node_env.read` returned values with surrounding quotes intact while `Node_env.write_pairs` escaped them again, causing a new layer of escaping on every edit cycle. A baker with `OCTEZ_BAKER_DELEGATES_ARGS="tz1a tz1b"` would fail to start after an unrelated node edit because the value became `\"tz1a tz1b\"` with literal inner quotes. `Node_env.read` now unescapes values symmetrically with how `write_pairs` escapes them, ensuring round-trip stability (fixes #995)
 
 - The transfer flow's "Select network" picker no longer shows a redundant double unit ("0.000000 ꜩ tez" → "0.000000 ꜩ") (fixes #971)

--- a/completions/octez-manager.bash
+++ b/completions/octez-manager.bash
@@ -27,35 +27,35 @@ _octez_manager() {
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
 
-  local commands="baker binaries cleanup-dependencies cleanup-orphans group import install-accuser install-baker install-dal-node install-index install-node install-signatory instance [ACTION] list list-available-networks list-snapshots purge-all rewards rpc sandbox self-update ui version web"
+  local commands="baker binaries cleanup-dependencies cleanup-orphans group import install-accuser install-baker install-dal-node install-index install-node install-signatory instance [INSTANCE] list list-available-networks list-snapshots purge-all rewards rpc sandbox self-update ui version web"
   local instance_actions="start stop restart remove purge show show-service logs edit export-logs set-env get-env"
   local history_modes="archive full rolling"
   local snapshot_kinds="rolling full full:50 archive"
   local lb_votes="on off pass"
-  local _ACTION__baker_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__binaries_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__cleanup_dependencies_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__cleanup_orphans_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__group_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__import_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__install_accuser_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__install_baker_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__install_dal_node_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__install_index_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__install_node_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__install_signatory_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__instance_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__list_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__list_available_networks_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__list_snapshots_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__purge_all_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__rewards_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__rpc_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__sandbox_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__self_update_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__ui_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__version_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
-  local _ACTION__web_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__baker_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__binaries_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__cleanup_dependencies_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__cleanup_orphans_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__group_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__import_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__install_accuser_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__install_baker_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__install_dal_node_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__install_index_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__install_node_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__install_signatory_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__instance_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__list_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__list_available_networks_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__list_snapshots_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__purge_all_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__rewards_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__rpc_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__sandbox_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__self_update_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__ui_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__version_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
+  local _INSTANCE__web_opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
   local baker_finalize_unstake_opts="--delegate --json -y --yes --help --version"
   local baker_list_opts="--json --help --version"
   local baker_register_opts="--delegate --json -y --yes --help --version"
@@ -173,12 +173,12 @@ _octez_manager() {
         return 0
       fi
       if [[ $cur == -* ]]; then
-        opts="--delete-data-dir --force-purge --help --version"
+        opts="--delete-data-dir --force-purge -y --yes --help --version"
         COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
       fi
       return 0
       ;;
-    [ACTION])
+    [INSTANCE])
       if [[ $COMP_CWORD -eq 2 ]]; then
         if [[ $cur == -* ]]; then
           opts="--compare-indexers --indexer-network --local-indexer --page --theme --ui-log --ui-logfile --unreleased-binaries --help --version"
@@ -191,122 +191,122 @@ _octez_manager() {
         case "$subcmd" in
           baker)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__baker_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__baker_opts" -- "$cur") )
             fi
             ;;
           binaries)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__binaries_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__binaries_opts" -- "$cur") )
             fi
             ;;
           cleanup-dependencies)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__cleanup_dependencies_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__cleanup_dependencies_opts" -- "$cur") )
             fi
             ;;
           cleanup-orphans)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__cleanup_orphans_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__cleanup_orphans_opts" -- "$cur") )
             fi
             ;;
           group)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__group_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__group_opts" -- "$cur") )
             fi
             ;;
           import)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__import_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__import_opts" -- "$cur") )
             fi
             ;;
           install-accuser)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__install_accuser_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__install_accuser_opts" -- "$cur") )
             fi
             ;;
           install-baker)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__install_baker_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__install_baker_opts" -- "$cur") )
             fi
             ;;
           install-dal-node)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__install_dal_node_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__install_dal_node_opts" -- "$cur") )
             fi
             ;;
           install-index)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__install_index_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__install_index_opts" -- "$cur") )
             fi
             ;;
           install-node)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__install_node_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__install_node_opts" -- "$cur") )
             fi
             ;;
           install-signatory)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__install_signatory_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__install_signatory_opts" -- "$cur") )
             fi
             ;;
           instance)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__instance_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__instance_opts" -- "$cur") )
             fi
             ;;
           list)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__list_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__list_opts" -- "$cur") )
             fi
             ;;
           list-available-networks)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__list_available_networks_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__list_available_networks_opts" -- "$cur") )
             fi
             ;;
           list-snapshots)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__list_snapshots_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__list_snapshots_opts" -- "$cur") )
             fi
             ;;
           purge-all)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__purge_all_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__purge_all_opts" -- "$cur") )
             fi
             ;;
           rewards)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__rewards_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__rewards_opts" -- "$cur") )
             fi
             ;;
           rpc)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__rpc_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__rpc_opts" -- "$cur") )
             fi
             ;;
           sandbox)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__sandbox_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__sandbox_opts" -- "$cur") )
             fi
             ;;
           self-update)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__self_update_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__self_update_opts" -- "$cur") )
             fi
             ;;
           ui)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__ui_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__ui_opts" -- "$cur") )
             fi
             ;;
           version)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__version_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__version_opts" -- "$cur") )
             fi
             ;;
           web)
             if [[ $cur == -* ]]; then
-              COMPREPLY=( $(compgen -W "$_ACTION__web_opts" -- "$cur") )
+              COMPREPLY=( $(compgen -W "$_INSTANCE__web_opts" -- "$cur") )
             fi
             ;;
         esac

--- a/completions/octez-manager.zsh
+++ b/completions/octez-manager.zsh
@@ -18,7 +18,7 @@ _octez-manager() {
     'install-node:Install an octez-node systemd instance'
     'install-signatory:Install an octez-signatory service'
     'instance'
-    '[ACTION]:Manage existing Octez services.'
+    '[INSTANCE]:Manage existing Octez services.'
     'list:Show services'
     'list-available-networks:Show networks advertised on teztnets.com (with fallbacks).'
     'list-snapshots:List downloads published on snapshots.tzinit.org for a network.'
@@ -70,8 +70,8 @@ _octez-manager() {
     'pass:Abstain from voting (default)'
   )
 
-  local -a opts__ACTION_
-  opts__ACTION_=(
+  local -a opts__INSTANCE_
+  opts__INSTANCE_=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -253,6 +253,8 @@ _octez-manager() {
   opts_instance=(
     '--delete-data-dir[Also delete the recorded data directory when removing.]'
     '--force-purge[Skip confirmation prompt when purging base directory.]'
+    '-y[Assume yes to confirmation prompts (e.g. removing an instance with dependents).]'
+    '--yes[Assume yes to confirmation prompts (e.g. removing an instance with dependents).]'
     '--help[Show this help in format FMT. The value FMT must be one of auto, pager, groff or plain. With auto, the format is pager or plain whenever the TERM env var is dumb or undefined.]:FMT:'
     '--version[Show version information.]'
   )
@@ -353,8 +355,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__baker
-  opts__ACTION__baker=(
+  local -a opts__INSTANCE__baker
+  opts__INSTANCE__baker=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -367,8 +369,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__binaries
-  opts__ACTION__binaries=(
+  local -a opts__INSTANCE__binaries
+  opts__INSTANCE__binaries=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -381,8 +383,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__cleanup_dependencies
-  opts__ACTION__cleanup_dependencies=(
+  local -a opts__INSTANCE__cleanup_dependencies
+  opts__INSTANCE__cleanup_dependencies=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -395,8 +397,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__cleanup_orphans
-  opts__ACTION__cleanup_orphans=(
+  local -a opts__INSTANCE__cleanup_orphans
+  opts__INSTANCE__cleanup_orphans=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -409,8 +411,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__group
-  opts__ACTION__group=(
+  local -a opts__INSTANCE__group
+  opts__INSTANCE__group=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -423,8 +425,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__import
-  opts__ACTION__import=(
+  local -a opts__INSTANCE__import
+  opts__INSTANCE__import=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -437,8 +439,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__install_accuser
-  opts__ACTION__install_accuser=(
+  local -a opts__INSTANCE__install_accuser
+  opts__INSTANCE__install_accuser=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -451,8 +453,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__install_baker
-  opts__ACTION__install_baker=(
+  local -a opts__INSTANCE__install_baker
+  opts__INSTANCE__install_baker=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -465,8 +467,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__install_dal_node
-  opts__ACTION__install_dal_node=(
+  local -a opts__INSTANCE__install_dal_node
+  opts__INSTANCE__install_dal_node=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -479,8 +481,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__install_index
-  opts__ACTION__install_index=(
+  local -a opts__INSTANCE__install_index
+  opts__INSTANCE__install_index=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -493,8 +495,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__install_node
-  opts__ACTION__install_node=(
+  local -a opts__INSTANCE__install_node
+  opts__INSTANCE__install_node=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -507,8 +509,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__install_signatory
-  opts__ACTION__install_signatory=(
+  local -a opts__INSTANCE__install_signatory
+  opts__INSTANCE__install_signatory=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -521,8 +523,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__instance
-  opts__ACTION__instance=(
+  local -a opts__INSTANCE__instance
+  opts__INSTANCE__instance=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -535,8 +537,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__list
-  opts__ACTION__list=(
+  local -a opts__INSTANCE__list
+  opts__INSTANCE__list=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -549,8 +551,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__list_available_networks
-  opts__ACTION__list_available_networks=(
+  local -a opts__INSTANCE__list_available_networks
+  opts__INSTANCE__list_available_networks=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -563,8 +565,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__list_snapshots
-  opts__ACTION__list_snapshots=(
+  local -a opts__INSTANCE__list_snapshots
+  opts__INSTANCE__list_snapshots=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -577,8 +579,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__purge_all
-  opts__ACTION__purge_all=(
+  local -a opts__INSTANCE__purge_all
+  opts__INSTANCE__purge_all=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -591,8 +593,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__rewards
-  opts__ACTION__rewards=(
+  local -a opts__INSTANCE__rewards
+  opts__INSTANCE__rewards=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -605,8 +607,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__rpc
-  opts__ACTION__rpc=(
+  local -a opts__INSTANCE__rpc
+  opts__INSTANCE__rpc=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -619,8 +621,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__sandbox
-  opts__ACTION__sandbox=(
+  local -a opts__INSTANCE__sandbox
+  opts__INSTANCE__sandbox=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -633,8 +635,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__self_update
-  opts__ACTION__self_update=(
+  local -a opts__INSTANCE__self_update
+  opts__INSTANCE__self_update=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -647,8 +649,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__ui
-  opts__ACTION__ui=(
+  local -a opts__INSTANCE__ui
+  opts__INSTANCE__ui=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -661,8 +663,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__version
-  opts__ACTION__version=(
+  local -a opts__INSTANCE__version
+  opts__INSTANCE__version=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -675,8 +677,8 @@ _octez-manager() {
     '--version[Show version information.]'
   )
 
-  local -a opts__ACTION__web
-  opts__ACTION__web=(
+  local -a opts__INSTANCE__web
+  opts__INSTANCE__web=(
     '--compare-indexers[When a local indexer is registered, also query public TzKT on every fetch and log divergences.]'
     '--indexer-network[Network the local indexer serves (default\: mainnet). Only relevant when --local-indexer is set.]:NETWORK:'
     '--local-indexer[Register a local TzKT-compatible indexer endpoint. This URL is tried before the public TzKT API.]:URL:'
@@ -1118,9 +1120,9 @@ _octez-manager() {
               $opts_instance
           fi
           ;;
-        [ACTION])
-          local -a subcmds__ACTION_
-          subcmds__ACTION_=(
+        [INSTANCE])
+          local -a subcmds__INSTANCE_
+          subcmds__INSTANCE_=(
             'baker:Baker wallet operations'
             'binaries:Manage Octez and Signatory binaries'
             'cleanup-dependencies:Remove stale dependency entries from service configurations. This cleans up references to services that have been removed.'
@@ -1149,107 +1151,107 @@ _octez-manager() {
           if (( CURRENT == 2 )); then
             if [[ $cur == -* ]]; then
               _arguments \
-                $opts__ACTION_
+                $opts__INSTANCE_
             else
-              _describe -t subcommands '[ACTION] subcommands' subcmds__ACTION_
+              _describe -t subcommands '[INSTANCE] subcommands' subcmds__INSTANCE_
             fi
           else
             case $words[2] in
               baker)
                 _arguments \
-                  $opts__ACTION__baker
+                  $opts__INSTANCE__baker
                 ;;
               binaries)
                 _arguments \
-                  $opts__ACTION__binaries
+                  $opts__INSTANCE__binaries
                 ;;
               cleanup-dependencies)
                 _arguments \
-                  $opts__ACTION__cleanup_dependencies
+                  $opts__INSTANCE__cleanup_dependencies
                 ;;
               cleanup-orphans)
                 _arguments \
-                  $opts__ACTION__cleanup_orphans
+                  $opts__INSTANCE__cleanup_orphans
                 ;;
               group)
                 _arguments \
-                  $opts__ACTION__group
+                  $opts__INSTANCE__group
                 ;;
               import)
                 _arguments \
-                  $opts__ACTION__import
+                  $opts__INSTANCE__import
                 ;;
               install-accuser)
                 _arguments \
-                  $opts__ACTION__install_accuser
+                  $opts__INSTANCE__install_accuser
                 ;;
               install-baker)
                 _arguments \
-                  $opts__ACTION__install_baker
+                  $opts__INSTANCE__install_baker
                 ;;
               install-dal-node)
                 _arguments \
-                  $opts__ACTION__install_dal_node
+                  $opts__INSTANCE__install_dal_node
                 ;;
               install-index)
                 _arguments \
-                  $opts__ACTION__install_index
+                  $opts__INSTANCE__install_index
                 ;;
               install-node)
                 _arguments \
-                  $opts__ACTION__install_node
+                  $opts__INSTANCE__install_node
                 ;;
               install-signatory)
                 _arguments \
-                  $opts__ACTION__install_signatory
+                  $opts__INSTANCE__install_signatory
                 ;;
               instance)
                 _arguments \
-                  $opts__ACTION__instance
+                  $opts__INSTANCE__instance
                 ;;
               list)
                 _arguments \
-                  $opts__ACTION__list
+                  $opts__INSTANCE__list
                 ;;
               list-available-networks)
                 _arguments \
-                  $opts__ACTION__list_available_networks
+                  $opts__INSTANCE__list_available_networks
                 ;;
               list-snapshots)
                 _arguments \
-                  $opts__ACTION__list_snapshots
+                  $opts__INSTANCE__list_snapshots
                 ;;
               purge-all)
                 _arguments \
-                  $opts__ACTION__purge_all
+                  $opts__INSTANCE__purge_all
                 ;;
               rewards)
                 _arguments \
-                  $opts__ACTION__rewards
+                  $opts__INSTANCE__rewards
                 ;;
               rpc)
                 _arguments \
-                  $opts__ACTION__rpc
+                  $opts__INSTANCE__rpc
                 ;;
               sandbox)
                 _arguments \
-                  $opts__ACTION__sandbox
+                  $opts__INSTANCE__sandbox
                 ;;
               self-update)
                 _arguments \
-                  $opts__ACTION__self_update
+                  $opts__INSTANCE__self_update
                 ;;
               ui)
                 _arguments \
-                  $opts__ACTION__ui
+                  $opts__INSTANCE__ui
                 ;;
               version)
                 _arguments \
-                  $opts__ACTION__version
+                  $opts__INSTANCE__version
                 ;;
               web)
                 _arguments \
-                  $opts__ACTION__web
+                  $opts__INSTANCE__web
                 ;;
             esac
           fi

--- a/src/cli/cmd_instance.ml
+++ b/src/cli/cmd_instance.ml
@@ -194,11 +194,20 @@ let instance_term =
           ["force-purge"]
           ~doc:"Skip confirmation prompt when purging base directory.")
   in
+  let yes =
+    Arg.(
+      value & flag
+      & info
+          ["yes"; "y"]
+          ~doc:
+            "Assume yes to confirmation prompts (e.g. removing an instance \
+             with dependents).")
+  in
   let extra_args =
     (* Additional positional args after ACTION (used by set-env) *)
     Arg.(value & pos_right 1 string [] & info [] ~docv:"ARGS")
   in
-  let run instance action delete_data_dir force_purge extra_args =
+  let run instance action delete_data_dir force_purge yes extra_args =
     match (instance, action) with
     | None, _ ->
         (* A usage error with non-zero exit, consistent with the other
@@ -243,29 +252,36 @@ let instance_term =
               ()
         | Remove ->
             with_service ~instance:inst (fun svc ->
-                let proceed =
-                  if svc.S.dependents = [] then true
-                  else if Cli_helpers.is_interactive () then (
-                    Format.printf
-                      "This will stop dependent instances: %s@."
-                      (String.concat ", " svc.S.dependents) ;
-                    Cli_helpers.prompt_yes_no
-                      "Proceed with removal?"
-                      ~default:false)
-                  else (
-                    Format.printf
-                      "Instance has dependents: %s. Use --yes to confirm.@."
-                      (String.concat ", " svc.S.dependents) ;
-                    false)
-                in
-                if proceed then
+                if svc.S.dependents = [] || yes then
                   Cli_helpers.run_result
                     (Removal.remove_service
                        ~quiet:false
                        ~delete_data_dir
                        ~instance:inst
                        ())
-                else `Ok ())
+                else if Cli_helpers.is_interactive () then (
+                  Format.printf
+                    "This will stop dependent instances: %s@."
+                    (String.concat ", " svc.S.dependents) ;
+                  if
+                    Cli_helpers.prompt_yes_no
+                      "Proceed with removal?"
+                      ~default:false
+                  then
+                    Cli_helpers.run_result
+                      (Removal.remove_service
+                         ~quiet:false
+                         ~delete_data_dir
+                         ~instance:inst
+                         ())
+                  else `Ok ())
+                else
+                  let msg =
+                    Printf.sprintf
+                      "Instance has dependents: %s. Use --yes to confirm."
+                      (String.concat ", " svc.S.dependents)
+                  in
+                  Cli_helpers.cmdliner_error msg)
         | Purge ->
             Cli_helpers.run_result
               (Removal.purge_service
@@ -929,7 +945,7 @@ let instance_term =
   in
   Term.(
     ret
-      (const run $ instance $ action $ delete_data_dir $ force_purge
+      (const run $ instance $ action $ delete_data_dir $ force_purge $ yes
      $ extra_args))
 
 let instance_cmd =
@@ -951,7 +967,9 @@ let instance_cmd =
           `I
             ( "remove",
               "Remove the service. Use $(b,--delete-data-dir) to also delete \
-               the recorded data directory." );
+               the recorded data directory. If the instance has dependents, \
+               removal is refused (non-zero exit) unless $(b,--yes) is given, \
+               or you confirm interactively." );
           `I
             ( "purge",
               "Remove the service and delete its data. Use $(b,--force-purge) \

--- a/test/integration/cli-tester/tests/node/27-remove-with-dependents-requires-yes.sh
+++ b/test/integration/cli-tester/tests/node/27-remove-with-dependents-requires-yes.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Test: 'instance remove' on an instance with dependents refuses
+# non-interactively unless --yes is given, and exits non-zero
+# (regression test for #998: previously this printed a message
+# telling the user to pass --yes, but exited 0 without removing
+# anything, and --yes/-y did not even exist as a flag).
+set -euo pipefail
+source /tests/lib.sh
+
+test_init "Remove with dependents requires --yes"
+
+NODE_INSTANCE="test-remove-yes-node"
+BAKER_INSTANCE="test-remove-yes-baker"
+NODE_RPC="127.0.0.1:$(alloc_port)"
+NODE_NET="0.0.0.0:$(alloc_port)"
+
+register_instance "$NODE_INSTANCE"
+register_instance "$BAKER_INSTANCE"
+
+# Install a node (no snapshot needed - we never start it).
+echo "Installing node..."
+om install-node \
+	--instance "$NODE_INSTANCE" \
+	--network shadownet \
+	--rpc-addr "$NODE_RPC" \
+	--net-addr "$NODE_NET" \
+	--service-user tezos \
+	--no-enable 2>&1
+
+# Install a baker depending on the node, so the node has a dependent.
+echo "Installing baker depending on node..."
+om install-baker \
+	--instance "$BAKER_INSTANCE" \
+	--node-instance "$NODE_INSTANCE" \
+	--liquidity-baking-vote pass \
+	--service-user tezos \
+	--no-enable 2>&1
+
+if ! instance_exists "$NODE_INSTANCE"; then
+	echo "ERROR: Node instance not created"
+	exit 1
+fi
+
+# --- Step 1: remove without --yes must be refused (non-zero exit,
+#     nothing removed). The CLI runs non-interactively here (no tty).
+echo "Attempting remove without --yes (should be refused)..."
+set +e
+output=$(om instance "$NODE_INSTANCE" remove 2>&1)
+rc=$?
+set -e
+
+if [ "$rc" -eq 0 ]; then
+	echo "ERROR: 'remove' without --yes exited 0; it should refuse and"
+	echo "exit non-zero when the instance has dependents"
+	echo "Output was: $output"
+	exit 1
+fi
+
+assert_contains "$output" "dependents" \
+	"Expected refusal message to mention dependents"
+assert_contains "$output" "--yes" \
+	"Expected refusal message to mention --yes"
+
+if ! instance_exists "$NODE_INSTANCE"; then
+	echo "ERROR: Node instance was removed even though removal was refused"
+	exit 1
+fi
+echo "Refused as expected (exit $rc), instance still present"
+
+# --- Step 2: remove with --yes must proceed.
+echo "Attempting remove with --yes (should proceed)..."
+om instance "$NODE_INSTANCE" remove --yes 2>&1
+
+if instance_exists "$NODE_INSTANCE"; then
+	echo "ERROR: Node instance still exists after 'remove --yes'"
+	exit 1
+fi
+echo "Instance removed with --yes"
+
+echo "Remove-with-dependents --yes test passed"

--- a/test/integration/cli-tester/tests/node/27-remove-with-dependents-requires-yes.sh
+++ b/test/integration/cli-tester/tests/node/27-remove-with-dependents-requires-yes.sh
@@ -61,7 +61,13 @@ assert_contains "$output" "dependents" \
 assert_contains "$output" "--yes" \
 	"Expected refusal message to mention --yes"
 
-if ! instance_exists "$NODE_INSTANCE"; then
+# NOTE: we assert on the registry file rather than instance_exists:
+# the baker shares the node's data dir, so the baker's `om list` row
+# contains the node instance name and instance_exists would
+# false-positive on it even after the node is removed.
+NODE_REGISTRY_FILE="/etc/octez_manager/services/${NODE_INSTANCE}.json"
+
+if [ ! -f "$NODE_REGISTRY_FILE" ]; then
 	echo "ERROR: Node instance was removed even though removal was refused"
 	exit 1
 fi
@@ -71,7 +77,7 @@ echo "Refused as expected (exit $rc), instance still present"
 echo "Attempting remove with --yes (should proceed)..."
 om instance "$NODE_INSTANCE" remove --yes 2>&1
 
-if instance_exists "$NODE_INSTANCE"; then
+if [ -f "$NODE_REGISTRY_FILE" ]; then
 	echo "ERROR: Node instance still exists after 'remove --yes'"
 	exit 1
 fi

--- a/test/integration/cli-tester/tests/shards.json
+++ b/test/integration/cli-tester/tests/shards.json
@@ -2,8 +2,8 @@
   "metadata": {
     "generated_at": "2026-04-09T00:00:00.000000",
     "generated_by": "Rebase: merge main (101 tests) + install-index test",
-    "total_tests": 105,
-    "total_duration": 819.05,
+    "total_tests": 106,
+    "total_duration": 829.05,
     "shard_count": 5,
     "mean_shard_duration": 163.81,
     "max_shard_duration": 190.61,
@@ -58,10 +58,11 @@
       "import/55-import-node-identity-preservation.sh",
       "import/56-import-node-missing-config-created.sh",
       "install/01-verified-release.sh",
-      "cli/01-version-consistency.sh"
+      "cli/01-version-consistency.sh",
+      "node/27-remove-with-dependents-requires-yes.sh"
     ],
-    "test_count": 19,
-    "total_duration": 146.78
+    "test_count": 20,
+    "total_duration": 156.78
   },
   "shard-3": {
     "tests": [


### PR DESCRIPTION
Fixes #998.

## Problem

Non-interactive `octez-manager instance <name> remove` on an instance with dependents:
- printed `Instance has dependents: ... Use --yes to confirm.` but **exited 0 without removing anything** — scripts read this as a successful removal;
- the suggested `--yes` flag **did not exist** on the `instance` command, so following the instruction produced a cmdliner usage error.

## Fix

- Add a `--yes`/`-y` flag to the `instance` command (same convention as `baker`/`sandbox`). With `--yes`, removal of an instance with dependents proceeds without prompting (interactive or not).
- Without `--yes` in a non-interactive context, the refusal now returns a cmdliner error (non-zero exit) instead of `` `Ok () ``.
- Interactive prompt flow is unchanged; `purge` is untouched.
- Regenerated shell completions (`make completions`).

## Test

New integration test `test/integration/cli-tester/tests/node/27-remove-with-dependents-requires-yes.sh` (registered in `shards.json`): installs a node + dependent baker, asserts `remove` without `--yes` exits non-zero, mentions dependents/`--yes`, and leaves the instance intact; then asserts `remove --yes` removes it. Reproduced pre-fix behavior manually (exit 0 no-op, `unknown option '--yes'`) and post-fix behavior (exit 124 refusal, successful removal with `--yes`).

## Checklist
- [x] CHANGELOG entry under [Unreleased] → Fixed
- [x] `dune build`, `dune runtest`, `dune fmt`, `./scripts/check-copyright.sh` all pass
- [x] Completions regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)