### PR TITLE
fix(ui): reset stale import overrides when reselecting a service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- The import wizard no longer carries over a previously selected service's network override, custom instance name, or cascade settings when the user backs out of the configure step and selects a *different* external service. Previously, choosing a manual network override (or custom name / cascade mode) for one service and then going back to pick another service would silently apply the first service's settings to the second (fixes #999)
+
 - `octez-manager instance <name> remove` on an instance with dependents now has a working `--yes`/`-y` flag to confirm removal non-interactively. Previously the command told users to "Use --yes to confirm" but that flag did not exist (it was a usage error), and without it the command silently exited 0 without removing anything; it now exits non-zero when refused (fixes #998)
 
 - Node and DAL node edit operations no longer corrupt dependent env files through quote accumulation. Previously, `Node_env.read` returned values with surrounding quotes intact while `Node_env.write_pairs` escaped them again, causing a new layer of escaping on every edit cycle. A baker with `OCTEZ_BAKER_DELEGATES_ARGS="tz1a tz1b"` would fail to start after an unrelated node edit because the value became `\"tz1a tz1b\"` with literal inner quotes. `Node_env.read` now unescapes values symmetrically with how `write_pairs` escapes them, ensuring round-trip stability (fixes #995)

--- a/src/ui/pages/import_wizard.ml
+++ b/src/ui/pages/import_wizard.ml
@@ -129,7 +129,18 @@ let back ps =
   | SelectService -> Navigation.back ps
   | ConfigureImport ->
       Navigation.update
-        (fun s -> {s with step = SelectService; error = None})
+        (fun s ->
+          {
+            s with
+            step = SelectService;
+            error = None;
+            selected_service = None;
+            network_override = None;
+            custom_name = None;
+            cascade = false;
+            cascade_chain = [];
+            cascade_analysis = None;
+          })
         ps
   | ReviewImport ->
       Navigation.update

--- a/src/ui/pages/import_wizard.mli
+++ b/src/ui/pages/import_wizard.mli
@@ -61,6 +61,13 @@ val toggle_strategy : pstate -> pstate
 (** Toggle cascade import on/off and recompute dependency chain. *)
 val toggle_cascade : pstate -> pstate
 
+(** Navigate back one step in the wizard. Going from [ConfigureImport] to
+    [SelectService] resets the per-service configuration (selected service,
+    network override, custom name, cascade settings) so a subsequently
+    selected service doesn't inherit stale overrides. Going from
+    [ReviewImport] to [ConfigureImport] preserves the current configuration. *)
+val back : pstate -> pstate
+
 (** Return the header lines for the current wizard step. *)
 val header : state -> string list
 

--- a/test/test_import_wizard_pure.ml
+++ b/test/test_import_wizard_pure.ml
@@ -149,6 +149,91 @@ let test_toggle_round_trip () =
     (strategy_to_string ps''.Navigation.s.strategy)
 
 (* ============================================================ *)
+(* back Tests (issue #999 - stale overrides on service reselect) *)
+(* ============================================================ *)
+
+(* Regression test for #999: selecting service A, setting a network
+   override / custom name / cascade while configuring it, then going back
+   to the service list must clear that per-service state. Otherwise picking
+   a different service B inherits A's stale overrides (e.g. B gets imported
+   with A's manually-chosen network). *)
+let test_back_from_configure_resets_overrides () =
+  let svc_a = make_ext_svc "service-a" in
+  let analysis =
+    Import_cascade.analyze_dependencies
+      ~services:[svc_a]
+      ~target_services:[svc_a]
+  in
+  let ps =
+    wrap_state
+      (make_state
+         ~step:Import_wizard.ConfigureImport
+         ~external_services:[svc_a]
+         ~selected_service:svc_a
+         ~network_override:"mainnet"
+         ~custom_name:"my-custom-name"
+         ~cascade:true
+         ~cascade_chain:[svc_a]
+         ~cascade_analysis:analysis
+         ())
+  in
+  let ps' = Import_wizard.back ps in
+  let s = ps'.Navigation.s in
+  Alcotest.(check bool)
+    "step is SelectService"
+    true
+    (match s.step with Import_wizard.SelectService -> true | _ -> false) ;
+  Alcotest.(check bool)
+    "selected_service reset"
+    true
+    (Option.is_none s.selected_service) ;
+  Alcotest.(check (option string))
+    "network_override reset"
+    None
+    s.network_override ;
+  Alcotest.(check (option string)) "custom_name reset" None s.custom_name ;
+  Alcotest.(check bool) "cascade reset" false s.cascade ;
+  Alcotest.(check int) "cascade_chain reset" 0 (List.length s.cascade_chain) ;
+  Alcotest.(check bool)
+    "cascade_analysis reset"
+    true
+    (Option.is_none s.cascade_analysis)
+
+let test_back_from_review_preserves_configuration () =
+  let svc_a = make_ext_svc "service-a" in
+  let ps =
+    wrap_state
+      (make_state
+         ~step:Import_wizard.ReviewImport
+         ~external_services:[svc_a]
+         ~selected_service:svc_a
+         ~network_override:"mainnet"
+         ~custom_name:"my-custom-name"
+         ~cascade:true
+         ~cascade_chain:[svc_a]
+         ())
+  in
+  let ps' = Import_wizard.back ps in
+  let s = ps'.Navigation.s in
+  Alcotest.(check bool)
+    "step is ConfigureImport"
+    true
+    (match s.step with Import_wizard.ConfigureImport -> true | _ -> false) ;
+  Alcotest.(check bool)
+    "selected_service preserved"
+    true
+    (Option.is_some s.selected_service) ;
+  Alcotest.(check (option string))
+    "network_override preserved"
+    (Some "mainnet")
+    s.network_override ;
+  Alcotest.(check (option string))
+    "custom_name preserved"
+    (Some "my-custom-name")
+    s.custom_name ;
+  Alcotest.(check bool) "cascade preserved" true s.cascade
+
+(* ============================================================ *)
 (* header Tests                                                  *)
 (* ============================================================ *)
 
@@ -316,6 +401,17 @@ let () =
             "no selected service"
             `Quick
             test_toggle_cascade_no_selected_service;
+        ] );
+      ( "back",
+        [
+          Alcotest.test_case
+            "configure -> select resets overrides"
+            `Quick
+            test_back_from_configure_resets_overrides;
+          Alcotest.test_case
+            "review -> configure preserves configuration"
+            `Quick
+            test_back_from_review_preserves_configuration;
         ] );
       ( "header",
         [


### PR DESCRIPTION
Fixes #999.

## Problem

In the import wizard, the per-service configuration — `network_override` (chosen in the "Network Override Required" modal), `custom_name`, and the cascade settings — was never reset when navigating back from the configure step to the service list. Selecting a *different* external service afterwards silently inherited the previous service's settings: pick `mainnet` for service A, go back, pick service B (auto-detectable network) → B is imported as a `mainnet` instance with no indication anything was overridden.

## Fix

The `back` transition from `ConfigureImport` to `SelectService` now resets `selected_service`, `network_override`, `custom_name`, `cascade`, `cascade_chain`, and `cascade_analysis` to their initial values. Backing from `ReviewImport` to `ConfigureImport` (same service) intentionally preserves the configuration. Other exits from the wizard go through full page navigation, which re-inits state on next entry, so no other path leaks.

## Test

`test/test_import_wizard_pure.ml` gains two tests:
- `test_back_from_configure_resets_overrides` — reproduces #999; fails without the fix (`selected_service reset: Expected: true / Received: false`) and passes with it.
- `test_back_from_review_preserves_configuration` — guards the intentional non-reset on the review→configure transition.

`back` is now exposed in the `.mli` for pure tests, following the existing pattern used by `move_selection`/`toggle_strategy`/`toggle_cascade`.

## Checklist
- [x] CHANGELOG entry under [Unreleased] → Fixed
- [x] `dune build`, `dune runtest`, `dune fmt`, `./scripts/check-copyright.sh` all pass
- [x] No golden-path form field impact (import wizard not referenced there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)