### PR TITLE
fix(ui): preserve baker/accuser global args across edit round-trips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Editing a baker or accuser instance no longer silently drops global CLI options (e.g. `--media-type`, `--endpoint`, `--password-filename`) on save. The edit form's "Extra Args" field previously prefilled only from the command-args half of the split, so re-submitting an otherwise-unchanged edit erased the global-args half from the env file; the field now prefills from both halves (fixes #996)
+
 - The import wizard no longer carries over a previously selected service's network override, custom instance name, or cascade settings when the user backs out of the configure step and selects a *different* external service. Previously, choosing a manual network override (or custom name / cascade mode) for one service and then going back to pick another service would silently apply the first service's settings to the second (fixes #999)
 
 - `octez-manager instance <name> remove` on an instance with dependents now has a working `--yes`/`-y` flag to confirm removal non-interactively. Previously the command told users to "Use --yes to confirm" but that flag did not exist (it was a usage error), and without it the command silently exited 0 without removing anything; it now exits non-zero when refused (fixes #998)

--- a/src/installer.ml
+++ b/src/installer.ml
@@ -55,4 +55,6 @@ module For_tests = struct
   let known_baker_global_options = known_baker_global_options
 
   let split_baker_extra_args = split_baker_extra_args
+
+  let join_baker_extra_args = join_baker_extra_args
 end

--- a/src/installer.mli
+++ b/src/installer.mli
@@ -78,4 +78,6 @@ module For_tests : sig
 
   val split_baker_extra_args :
     app_bin_dir:string -> string list -> string list * string list
+
+  val join_baker_extra_args : global:string -> command:string -> string
 end

--- a/src/installer/helpers.ml
+++ b/src/installer/helpers.ml
@@ -91,6 +91,17 @@ let split_baker_extra_args ~app_bin_dir extra_args =
     in
     Help_parser.split_extra_args ~global_options extra_args
 
+(** Reconstruct a single Extra Args field value from the [global] and
+    [command] halves persisted by {!split_baker_extra_args} (e.g. the
+    OCTEZ_BAKER_GLOBAL_ARGS / OCTEZ_BAKER_COMMAND_ARGS env pair). Used when
+    prefilling the baker/accuser edit forms so global options are not
+    silently dropped on save. Globals come first; either half may be empty
+    without introducing leading, trailing, or doubled spaces. *)
+let join_baker_extra_args ~global ~command =
+  [global; command] |> List.map String.trim
+  |> List.filter (fun s -> not (String.equal s ""))
+  |> String.concat " "
+
 let is_http_url s =
   let trimmed = String.trim s |> String.lowercase_ascii in
   String.starts_with ~prefix:"http://" trimmed

--- a/src/installer/helpers.mli
+++ b/src/installer/helpers.mli
@@ -40,6 +40,12 @@ val known_baker_global_options : string list
 val split_baker_extra_args :
   app_bin_dir:string -> string list -> string list * string list
 
+(** Reconstruct a single Extra Args field value from the global and command
+    halves persisted by {!split_baker_extra_args} (e.g. the
+    OCTEZ_BAKER_GLOBAL_ARGS / OCTEZ_BAKER_COMMAND_ARGS env pair). Used to
+    prefill the baker/accuser edit forms without losing global options. *)
+val join_baker_extra_args : global:string -> command:string -> string
+
 (** Check if string is an HTTP/HTTPS URL *)
 val is_http_url : string -> bool
 

--- a/src/ui/pages/install_accuser_form_v3.ml
+++ b/src/ui/pages/install_accuser_form_v3.ml
@@ -71,7 +71,11 @@ let make_initial_model () =
       in
       let base_dir = lookup "OCTEZ_CLIENT_BASE_DIR" in
       let node_endpoint = lookup "OCTEZ_NODE_ENDPOINT" in
-      let extra_args = lookup "OCTEZ_BAKER_COMMAND_ARGS" in
+      let extra_args =
+        Helpers.join_baker_extra_args
+          ~global:(lookup "OCTEZ_BAKER_GLOBAL_ARGS")
+          ~command:(lookup "OCTEZ_BAKER_COMMAND_ARGS")
+      in
       {
         core =
           {
@@ -543,6 +547,8 @@ module Page = Form_builder.Make (struct
 end)
 
 module For_tests = struct
+  let initial_model = make_initial_model
+
   let initial_base_dir = (make_initial_model ()).client.base_dir
 
   (** Simulate setting instance name and return the resulting base_dir.

--- a/src/ui/pages/install_accuser_form_v3.mli
+++ b/src/ui/pages/install_accuser_form_v3.mli
@@ -7,6 +7,19 @@
 
 (** Accuser installation form using field bundles *)
 
+(** Form model holding accuser configuration fields. *)
+type model = {
+  core : Form_builder_common.core_service_config;
+      (** Shared service config (name, bin dir, user, etc.). *)
+  client : Form_builder_common.client_config;
+      (** Client-side config (base dir, node endpoint). *)
+  edit_mode : bool;  (** [true] when editing an existing accuser instance. *)
+  original_instance : string option;
+      (** Original instance name in edit mode. *)
+  stopped_dependents : string list;
+      (** Services that were stopped for the edit. *)
+}
+
 (** Page identifier for registration *)
 val name : string
 
@@ -20,6 +33,10 @@ val register : unit -> unit
 module Page : Miaou.Core.Tui_page.PAGE_SIG
 
 module For_tests : sig
+  (** Build the model as it would be constructed on page entry, including
+      edit-mode prefill from a pending edit context, if any. *)
+  val initial_model : unit -> model
+
   val initial_base_dir : string
 
   (** Test helper: simulate setting instance name and return resulting base_dir *)

--- a/src/ui/pages/install_baker_form_v3.ml
+++ b/src/ui/pages/install_baker_form_v3.ml
@@ -103,7 +103,11 @@ let make_initial_model () =
       in
       let node_endpoint = lookup "OCTEZ_NODE_ENDPOINT" in
       let base_dir = lookup "OCTEZ_BAKER_BASE_DIR" in
-      let extra_args = lookup "OCTEZ_BAKER_COMMAND_ARGS" in
+      let extra_args =
+        Helpers.join_baker_extra_args
+          ~global:(lookup "OCTEZ_BAKER_GLOBAL_ARGS")
+          ~command:(lookup "OCTEZ_BAKER_COMMAND_ARGS")
+      in
       let dal_config = lookup "OCTEZ_DAL_CONFIG" in
       let dal_instance = lookup "OCTEZ_DAL_INSTANCE" in
       let dal =

--- a/src/ui/pages/instance_details.ml
+++ b/src/ui/pages/instance_details.ml
@@ -238,7 +238,11 @@ let view_details ~box_width svc =
           else dal_config
         in
         let base_dir = lookup "OCTEZ_BAKER_BASE_DIR" in
-        let env_args = lookup "OCTEZ_BAKER_COMMAND_ARGS" in
+        let env_args =
+          Helpers.join_baker_extra_args
+            ~global:(lookup "OCTEZ_BAKER_GLOBAL_ARGS")
+            ~command:(lookup "OCTEZ_BAKER_COMMAND_ARGS")
+        in
         let svc_args = String.concat " " svc.Service.extra_args in
         let extra_args =
           match (env_args, svc_args) with
@@ -300,7 +304,11 @@ let view_details ~box_width svc =
     | "accuser" ->
         let node_endpoint = lookup "OCTEZ_NODE_ENDPOINT" in
         let base_dir = lookup "OCTEZ_CLIENT_BASE_DIR" in
-        let env_args = lookup "OCTEZ_BAKER_COMMAND_ARGS" in
+        let env_args =
+          Helpers.join_baker_extra_args
+            ~global:(lookup "OCTEZ_BAKER_GLOBAL_ARGS")
+            ~command:(lookup "OCTEZ_BAKER_COMMAND_ARGS")
+        in
         let svc_args = String.concat " " svc.Service.extra_args in
         let extra_args =
           match (env_args, svc_args) with

--- a/test/unit_tests.ml
+++ b/test/unit_tests.ml
@@ -3099,6 +3099,156 @@ let installer_known_baker_global_options () =
     true
     (List.mem "--base-dir" opts)
 
+(* Regression tests for #996: baker/accuser edit-mode prefill only read
+   OCTEZ_BAKER_COMMAND_ARGS, so submitting an edit silently dropped every
+   option stored in OCTEZ_BAKER_GLOBAL_ARGS (e.g. --media-type,
+   --endpoint, --password-filename). [join_baker_extra_args] is the
+   inverse of [split_baker_extra_args] and is what the forms now call to
+   reconstruct the Extra Args field from both env keys. *)
+let installer_join_baker_extra_args () =
+  Alcotest.(check string)
+    "both empty"
+    ""
+    (Installer.For_tests.join_baker_extra_args ~global:"" ~command:"") ;
+  Alcotest.(check string)
+    "only command"
+    "--extra x"
+    (Installer.For_tests.join_baker_extra_args ~global:"" ~command:"--extra x") ;
+  Alcotest.(check string)
+    "only global"
+    "--media-type json"
+    (Installer.For_tests.join_baker_extra_args
+       ~global:"--media-type json"
+       ~command:"") ;
+  Alcotest.(check string)
+    "both halves joined, globals first"
+    "--media-type json --extra x"
+    (Installer.For_tests.join_baker_extra_args
+       ~global:"--media-type json"
+       ~command:"--extra x") ;
+  Alcotest.(check string)
+    "trims whitespace without doubling the separator"
+    "--media-type json --extra x"
+    (Installer.For_tests.join_baker_extra_args
+       ~global:"  --media-type json  "
+       ~command:"  --extra x  ")
+
+(* Round-trip property: for any (global, command) pair, joining then
+   re-splitting recovers the original halves. This is the exact property
+   the edit form relies on: prefill joins the two env values, and
+   submitting the form re-splits via [split_baker_extra_args]. *)
+let installer_join_split_baker_extra_args_round_trip () =
+  let app_bin_dir = "/nonexistent/path/that/does/not/exist" in
+  let words_of s =
+    match String.trim s with "" -> [] | s -> String.split_on_char ' ' s
+  in
+  let check_round_trip ~label ~global ~command =
+    let joined = Installer.For_tests.join_baker_extra_args ~global ~command in
+    let global_args, command_args =
+      Installer.For_tests.split_baker_extra_args ~app_bin_dir (words_of joined)
+    in
+    Alcotest.(check (list string))
+      (label ^ ": global half round-trips")
+      (words_of global)
+      global_args ;
+    Alcotest.(check (list string))
+      (label ^ ": command half round-trips")
+      (words_of command)
+      command_args
+  in
+  check_round_trip
+    ~label:"issue #996 repro (global + command)"
+    ~global:"--media-type json"
+    ~command:"--extra x" ;
+  check_round_trip
+    ~label:"only global"
+    ~global:"--endpoint http://127.0.0.1:8732"
+    ~command:"" ;
+  check_round_trip ~label:"only command" ~global:"" ~command:"--keep-alive" ;
+  check_round_trip ~label:"both empty" ~global:"" ~command:""
+
+(* Regression test for #996: the baker edit form must prefill Extra Args
+   from BOTH OCTEZ_BAKER_GLOBAL_ARGS and OCTEZ_BAKER_COMMAND_ARGS, not just
+   the command half. Without the fix, [extra_args] below would be
+   "--extra x" instead of "--media-type json --extra x", silently losing
+   --media-type on the next save. *)
+let install_baker_form_v3_edit_prefill_preserves_global_args () =
+  if is_ci () then Alcotest.skip ()
+  else
+    with_fake_xdg (fun _env ->
+        let inst = "baker-issue-996" in
+        let () =
+          expect_ok
+            (Node_env.write_pairs
+               ~inst
+               [
+                 ("OCTEZ_BAKER_GLOBAL_ARGS", "--media-type json");
+                 ("OCTEZ_BAKER_COMMAND_ARGS", "--extra x");
+               ])
+        in
+        let service =
+          Service.make
+            ~instance:inst
+            ~role:"baker"
+            ~network:"mainnet"
+            ~history_mode:History_mode.Rolling
+            ~data_dir:"/tmp/octez/baker-issue-996"
+            ~rpc_addr:(Rpc_addr.of_string "127.0.0.1:8732")
+            ~net_addr:""
+            ~service_user:"octez"
+            ~app_bin_dir:"/usr/bin"
+            ~logging_mode:Logging_mode.Journald
+            ()
+        in
+        Octez_manager_ui.Context.set_pending_edit_service
+          ~service
+          ~stopped_dependents:[] ;
+        let model = Install_baker_form_v3.For_tests.initial_model () in
+        Alcotest.(check string)
+          "extra_args prefilled from both global and command args"
+          "--media-type json --extra x"
+          model.core.extra_args)
+
+(* Same regression as above, for the accuser edit form. *)
+let install_accuser_form_v3_edit_prefill_preserves_global_args () =
+  if is_ci () then Alcotest.skip ()
+  else
+    with_fake_xdg (fun _env ->
+        let inst = "accuser-issue-996" in
+        let () =
+          expect_ok
+            (Node_env.write_pairs
+               ~inst
+               [
+                 ("OCTEZ_BAKER_GLOBAL_ARGS", "--media-type json");
+                 ("OCTEZ_BAKER_COMMAND_ARGS", "--extra x");
+               ])
+        in
+        let service =
+          Service.make
+            ~instance:inst
+            ~role:"accuser"
+            ~network:"mainnet"
+            ~history_mode:History_mode.Rolling
+            ~data_dir:"/tmp/octez/accuser-issue-996"
+            ~rpc_addr:(Rpc_addr.of_string "127.0.0.1:8732")
+            ~net_addr:""
+            ~service_user:"octez"
+            ~app_bin_dir:"/usr/bin"
+            ~logging_mode:Logging_mode.Journald
+            ()
+        in
+        Octez_manager_ui.Context.set_pending_edit_service
+          ~service
+          ~stopped_dependents:[] ;
+        let model =
+          Octez_manager_ui.Install_accuser_form_v3.For_tests.initial_model ()
+        in
+        Alcotest.(check string)
+          "extra_args prefilled from both global and command args"
+          "--media-type json --extra x"
+          model.core.extra_args)
+
 let system_user_validate_missing () =
   match
     System_user.validate_user_for_service ~user:"__missing_octez_user__"
@@ -6359,6 +6509,22 @@ let () =
             "known global options"
             `Quick
             installer_known_baker_global_options;
+          Alcotest.test_case
+            "join baker extra args"
+            `Quick
+            installer_join_baker_extra_args;
+          Alcotest.test_case
+            "join/split round-trip"
+            `Quick
+            installer_join_split_baker_extra_args_round_trip;
+          Alcotest.test_case
+            "baker edit form preserves global args (#996)"
+            `Quick
+            install_baker_form_v3_edit_prefill_preserves_global_args;
+          Alcotest.test_case
+            "accuser edit form preserves global args (#996)"
+            `Quick
+            install_accuser_form_v3_edit_prefill_preserves_global_args;
         ] );
       ( "snapshots.basic",
         [


### PR DESCRIPTION
Fixes #996.

## Problem

The wizard's Extra Args input is split at install time into `OCTEZ_BAKER_GLOBAL_ARGS` (options before the `run` subcommand: `--media-type`, `--endpoint`, `--password-filename`, …) and `OCTEZ_BAKER_COMMAND_ARGS`. The baker and accuser **edit** forms prefilled the field from `OCTEZ_BAKER_COMMAND_ARGS` only, so editing any field and saving rewrote the env file with the global half emptied — silent, permanent loss (e.g. a baker installed with `--media-type json` loses it when you later just add a delegate). The instance details page had the same read-back gap and displayed an incomplete Extra Args line.

## Fix

New `Helpers.join_baker_extra_args ~global ~command` — the documented inverse of `split_baker_extra_args` (globals first, empty halves handled, no stray spaces). Both edit prefills and the details-page display now use it; the installer re-splits on submit, so the round-trip is lossless.

## Tests

Registered under `installer.extra_args` in `test/unit_tests.ml`:
- unit tests of the helper (empty / only-global / only-command / both / whitespace)
- join→split round-trip property tests, including the exact `--media-type json` repro
- end-to-end edit-prefill tests for both forms: real env pairs written via `Node_env.write_pairs`, real `make_initial_model` via `For_tests`, asserting the field contains both halves

Verified the form tests fail without the fix (`Expected: "--media-type json --extra x" / Received: "--extra x"`) and pass with it.

## Checklist
- [x] CHANGELOG entry under [Unreleased] → Fixed
- [x] `dune build`, `dune runtest` (282 unit + 13 fuzz), `dune fmt`, `./scripts/check-copyright.sh` all pass
- [x] No golden-path field-count impact (prefill values only, no fields added/removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)