### PR TITLE
fix(ui): archive history mode keeps manually selected snapshot (#1000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- The node install wizard no longer submits a snapshot import for archive nodes. Previously, manually selecting a snapshot and then switching History Mode to "archive" kept the hidden selection in the form state, producing an install that tried to bootstrap an archive node from a snapshot (fixes #1000)
+
 - Editing a baker or accuser instance no longer silently drops global CLI options (e.g. `--media-type`, `--endpoint`, `--password-filename`) on save. The edit form's "Extra Args" field previously prefilled only from the command-args half of the split, so re-submitting an otherwise-unchanged edit erased the global-args half from the env file; the field now prefills from both halves (fixes #996)
 
 - The import wizard no longer carries over a previously selected service's network override, custom instance name, or cascade settings when the user backs out of the configure step and selects a *different* external service. Previously, choosing a manual network override (or custom name / cascade mode) for one service and then going back to pick another service would silently apply the first service's settings to the second (fixes #999)

--- a/src/ui/pages/install_node_form_v3.ml
+++ b/src/ui/pages/install_node_form_v3.ml
@@ -1163,6 +1163,18 @@ module For_tests = struct
   let generate_instance_name = generate_instance_name
 
   let format_selected_snapshot = format_selected_snapshot
+
+  type nonrec model = model
+
+  let fresh_model = base_initial_model
+
+  let with_snapshot snapshot m = {m with snapshot}
+
+  let node_of m = m.node
+
+  let snapshot_of m = m.snapshot
+
+  let set_node_with_autoname = set_node_with_autoname
 end
 
 let page : Miaou.Core.Registry.page = (module Page)

--- a/src/ui/pages/install_node_form_v3.ml
+++ b/src/ui/pages/install_node_form_v3.ml
@@ -689,6 +689,9 @@ let set_node_with_autoname node m =
         ~network:node.network
         ~history_mode:node.history_mode
     in
+    let new_is_archive =
+      String.(lowercase_ascii (trim node.history_mode)) = "archive"
+    in
     (* Only auto-update if instance name matches the old generated name *)
     if String.equal m.core.instance_name old_name then
       let new_data_dir = Paths.default_role_dir "node" new_name in
@@ -696,17 +699,19 @@ let set_node_with_autoname node m =
       let should_update_data_dir =
         String.equal (String.trim m.node.data_dir) old_default_dir
       in
-      (* Auto-update snapshot if:
+      (* Archive nodes never bootstrap from a snapshot, so switching to
+         archive must clear ANY selection, manual ones included — the
+         snapshot field is hidden in archive mode, so a surviving value
+         would bypass its validation entirely (issue #1000).
+         Otherwise, auto-update the snapshot if:
          1. Current snapshot is an auto snapshot and network or history_mode changed, OR
          2. Current snapshot is None and we're moving FROM archive mode to non-archive mode *)
       let old_is_archive =
         String.(lowercase_ascii (trim m.node.history_mode)) = "archive"
       in
-      let new_is_archive =
-        String.(lowercase_ascii (trim node.history_mode)) = "archive"
-      in
       let new_snapshot =
-        if
+        if new_is_archive then `None
+        else if
           (is_auto_snapshot m.snapshot
           || (m.snapshot = `None && old_is_archive && not new_is_archive))
           && ((not (String.equal m.node.network node.network))
@@ -728,6 +733,7 @@ let set_node_with_autoname node m =
         core = {m.core with instance_name = new_name};
         snapshot = new_snapshot;
       }
+    else if new_is_archive then {m with node; snapshot = `None}
     else {m with node}
 
 let spec =
@@ -1169,6 +1175,9 @@ module For_tests = struct
   let fresh_model = base_initial_model
 
   let with_snapshot snapshot m = {m with snapshot}
+
+  let with_instance_name instance_name m =
+    {m with core = {m.core with instance_name}}
 
   let node_of m = m.node
 

--- a/src/ui/pages/install_node_form_v3.mli
+++ b/src/ui/pages/install_node_form_v3.mli
@@ -58,4 +58,28 @@ module For_tests : sig
       Shows "tzinit · {label}" using the human-readable label (or the
       kind slug as fallback), without duplicating the slug in parentheses. *)
   val format_selected_snapshot : tzinit_snapshot -> string
+
+  (** Opaque form model, exposed only to drive {!set_node_with_autoname}
+      from tests. Fields are intentionally not revealed. *)
+  type model
+
+  (** A model as the wizard produces it for a fresh (non-edit) install:
+      network = ["shadownet"], history_mode = ["rolling"], with the
+      instance name auto-generated to match. *)
+  val fresh_model : unit -> model
+
+  (** Test-only setter overriding the model's snapshot selection directly,
+      bypassing any field on-change logic. *)
+  val with_snapshot : snapshot_selection -> model -> model
+
+  (** Read back the model's node configuration. *)
+  val node_of : model -> Form_builder_common.node_config
+
+  (** Read back the model's current snapshot selection. *)
+  val snapshot_of : model -> snapshot_selection
+
+  (** The autoname/autosnapshot transition applied whenever the Network or
+      History Mode field changes value (this is the [~set_node] callback
+      wired into the History Mode field). *)
+  val set_node_with_autoname : Form_builder_common.node_config -> model -> model
 end

--- a/src/ui/pages/install_node_form_v3.mli
+++ b/src/ui/pages/install_node_form_v3.mli
@@ -72,6 +72,10 @@ module For_tests : sig
       bypassing any field on-change logic. *)
   val with_snapshot : snapshot_selection -> model -> model
 
+  (** Test-only setter overriding the instance name, to simulate a user
+      who renamed the instance away from the auto-generated name. *)
+  val with_instance_name : string -> model -> model
+
   (** Read back the model's node configuration. *)
   val node_of : model -> Form_builder_common.node_config
 

--- a/test/dune
+++ b/test/dune
@@ -989,6 +989,13 @@
   (backend bisect_ppx)))
 
 (test
+ (name test_install_node_form_pure)
+ (libraries alcotest octez_manager_lib octez-manager.ui)
+ (modules test_install_node_form_pure)
+ (instrumentation
+  (backend bisect_ppx)))
+
+(test
  (name test_log_viewer_page_pure)
  (libraries alcotest octez_manager_lib octez-manager.ui)
  (modules test_log_viewer_page_pure)

--- a/test/test_install_node_form_pure.ml
+++ b/test/test_install_node_form_pure.ml
@@ -68,6 +68,46 @@ let test_archive_clears_manual_snapshot_issue_1000 () =
     "`None"
     (describe (Install_node_form.For_tests.snapshot_of after))
 
+(** Same invariant through the other branch of [set_node_with_autoname]:
+    when the user has renamed the instance away from the auto-generated
+    name, the autoname branch is skipped, but switching to archive must
+    still clear a manually-selected snapshot. *)
+let test_archive_clears_manual_snapshot_renamed_instance () =
+  let manual_snapshot =
+    `Tzinit
+      Install_node_form.
+        {
+          network_slug = "shadownet";
+          kind_slug = "rolling";
+          label = "Tzinit \xc2\xb7 2026-07-20";
+        }
+  in
+  let before =
+    Install_node_form.For_tests.(
+      fresh_model ()
+      |> with_snapshot manual_snapshot
+      |> with_instance_name "my-custom-name")
+  in
+  let archive_node =
+    {
+      (Install_node_form.For_tests.node_of before) with
+      Octez_manager_ui.Form_builder_common.history_mode = "archive";
+    }
+  in
+  let after =
+    Install_node_form.For_tests.set_node_with_autoname archive_node before
+  in
+  let is_none =
+    match Install_node_form.For_tests.snapshot_of after with
+    | `None -> true
+    | `Url _ | `Tzinit _ -> false
+  in
+  check
+    bool
+    "archive must clear manual snapshot even for renamed instances"
+    true
+    is_none
+
 let () =
   Alcotest.run
     "Install Node Form (pure)"
@@ -78,5 +118,9 @@ let () =
             "archive clears manual snapshot (#1000)"
             `Quick
             test_archive_clears_manual_snapshot_issue_1000;
+          Alcotest.test_case
+            "archive clears manual snapshot on renamed instance (#1000)"
+            `Quick
+            test_archive_clears_manual_snapshot_renamed_instance;
         ] );
     ]

--- a/test/test_install_node_form_pure.ml
+++ b/test/test_install_node_form_pure.ml
@@ -1,0 +1,82 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Pure-state regression tests for the node installation form
+    ([install_node_form_v3.ml]) that exercise model-transition helpers
+    directly, without the headless TUI driver. *)
+
+open Alcotest
+module Install_node_form = Octez_manager_ui.Install_node_form_v3
+
+(* ============================================================ *)
+(* Regression test for issue #1000: switching to archive history *)
+(* mode must clear a manually-selected snapshot                  *)
+(* ============================================================ *)
+
+(** https://github.com/trilitech/octez-manager/issues/1000
+
+    Switching History Mode to "archive" hides the Snapshot field (see the
+    field-list guard in [install_node_form_v3.ml]), but
+    [set_node_with_autoname] -- the [~set_node] callback the History Mode
+    field actually invokes -- only resets the snapshot selection when it
+    is an *auto* snapshot ([is_auto_snapshot]). A manually-picked Tzinit
+    entry survives untouched in the model. Because the snapshot field is
+    no longer rendered, its [history_snapshot_conflict] validation never
+    runs again, so [on_submit] would build an archive install that still
+    carries a snapshot -- contradicting the wizard's own invariant that
+    archive installs never import a snapshot
+    ([create_default_snapshot] returns [`None] for archive). *)
+let test_archive_clears_manual_snapshot_issue_1000 () =
+  let manual_snapshot =
+    `Tzinit
+      Install_node_form.
+        {
+          network_slug = "shadownet";
+          kind_slug = "rolling";
+          label = "Tzinit \xc2\xb7 2026-07-20";
+          (* Does not start with "Auto (" -> a manual, user-chosen entry. *)
+        }
+  in
+  let before =
+    Install_node_form.For_tests.(with_snapshot manual_snapshot (fresh_model ()))
+  in
+  (* Same code path the History Mode field uses when the user switches the
+     mode to "archive": build the new node config and hand it to the
+     field's own [~set_node] setter. *)
+  let archive_node =
+    {
+      (Install_node_form.For_tests.node_of before) with
+      Octez_manager_ui.Form_builder_common.history_mode = "archive";
+    }
+  in
+  let after =
+    Install_node_form.For_tests.set_node_with_autoname archive_node before
+  in
+  let describe = function
+    | `None -> "`None"
+    | `Url u -> Printf.sprintf "`Url %S" u
+    | `Tzinit (t : Install_node_form.tzinit_snapshot) ->
+        Printf.sprintf "`Tzinit {label = %S; ...}" t.label
+  in
+  check
+    string
+    "archive history mode must clear manual snapshot selection"
+    "`None"
+    (describe (Install_node_form.For_tests.snapshot_of after))
+
+let () =
+  Alcotest.run
+    "Install Node Form (pure)"
+    [
+      ( "archive_snapshot_conflict",
+        [
+          Alcotest.test_case
+            "archive clears manual snapshot (#1000)"
+            `Quick
+            test_archive_clears_manual_snapshot_issue_1000;
+        ] );
+    ]


### PR DESCRIPTION
Fixes #1000.

Two commits, in order:
1. `test(ui): expose archive/manual-snapshot conflict (#1000)` — regression test only; **fails on main**, demonstrating the bug (CI for that commit alone was red by design: https://github.com/trilitech/octez-manager/actions/runs/30249700940).
2. `fix(ui): clear manual snapshot when switching history mode to archive` — the fix, turning that exact test green.

## Bug

Switching History Mode to `archive` hides the Snapshot field, but `set_node_with_autoname` — the callback the History Mode field invokes — only reset **auto** snapshot selections. A **manually chosen** Tzinit snapshot survived invisibly in the model, skipped the `history_snapshot_conflict` validation (hidden fields don't validate), and `on_submit` produced an archive install bootstrapping from a snapshot — contradicting the wizard's own invariant (`create_default_snapshot` returns `` `None `` for archive).

Failing assertion on main:
```
FAIL archive history mode must clear manual snapshot selection
   Expected: `None
   Received: `Tzinit {label = "Tzinit · 2026-07-20"; ...}
```

## Fix

Force the snapshot selection to `` `None `` on any switch to archive, in **both** branches of `set_node_with_autoname`: the autoname path and the renamed-instance path (which previously kept the model's snapshot entirely untouched — same hole, found while fixing).

## Tests

`test/test_install_node_form_pure.ml` (new pure-state suite, runs under `dune runtest`):
- `archive clears manual snapshot (#1000)` — drives the real setter, fails without the fix
- `archive clears manual snapshot on renamed instance (#1000)` — covers the second branch

Plus behavior-neutral `For_tests` exposure in the form module (abstract model + accessors).

## Checklist
- [x] CHANGELOG entry under [Unreleased] → Fixed (fixes #1000)
- [x] `dune build`, `dune runtest` (all suites green), `dune fmt`, `./scripts/check-copyright.sh` pass
- [x] Every commit compiles independently; no form fields added/removed (no golden-path impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)