### PR TITLE
fix(ui): clear manual snapshot when switching history mode to archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- The node install wizard no longer submits a snapshot import for archive nodes. Previously, manually selecting a snapshot and then switching History Mode to "archive" kept the hidden selection in the form state, producing an install that tried to bootstrap an archive node from a snapshot (fixes #1000)
+
 - Editing a baker or accuser instance no longer silently drops global CLI options (e.g. `--media-type`, `--endpoint`, `--password-filename`) on save. The edit form's "Extra Args" field previously prefilled only from the command-args half of the split, so re-submitting an otherwise-unchanged edit erased the global-args half from the env file; the field now prefills from both halves (fixes #996)
 
 - The import wizard no longer carries over a previously selected service's network override, custom instance name, or cascade settings when the user backs out of the configure step and selects a *different* external service. Previously, choosing a manual network override (or custom name / cascade mode) for one service and then going back to pick another service would silently apply the first service's settings to the second (fixes #999)

--- a/src/ui/pages/install_node_form_v3.ml
+++ b/src/ui/pages/install_node_form_v3.ml
@@ -689,6 +689,9 @@ let set_node_with_autoname node m =
         ~network:node.network
         ~history_mode:node.history_mode
     in
+    let new_is_archive =
+      String.(lowercase_ascii (trim node.history_mode)) = "archive"
+    in
     (* Only auto-update if instance name matches the old generated name *)
     if String.equal m.core.instance_name old_name then
       let new_data_dir = Paths.default_role_dir "node" new_name in
@@ -696,17 +699,19 @@ let set_node_with_autoname node m =
       let should_update_data_dir =
         String.equal (String.trim m.node.data_dir) old_default_dir
       in
-      (* Auto-update snapshot if:
+      (* Archive nodes never bootstrap from a snapshot, so switching to
+         archive must clear ANY selection, manual ones included — the
+         snapshot field is hidden in archive mode, so a surviving value
+         would bypass its validation entirely (issue #1000).
+         Otherwise, auto-update the snapshot if:
          1. Current snapshot is an auto snapshot and network or history_mode changed, OR
          2. Current snapshot is None and we're moving FROM archive mode to non-archive mode *)
       let old_is_archive =
         String.(lowercase_ascii (trim m.node.history_mode)) = "archive"
       in
-      let new_is_archive =
-        String.(lowercase_ascii (trim node.history_mode)) = "archive"
-      in
       let new_snapshot =
-        if
+        if new_is_archive then `None
+        else if
           (is_auto_snapshot m.snapshot
           || (m.snapshot = `None && old_is_archive && not new_is_archive))
           && ((not (String.equal m.node.network node.network))
@@ -728,6 +733,7 @@ let set_node_with_autoname node m =
         core = {m.core with instance_name = new_name};
         snapshot = new_snapshot;
       }
+    else if new_is_archive then {m with node; snapshot = `None}
     else {m with node}
 
 let spec =
@@ -1169,6 +1175,9 @@ module For_tests = struct
   let fresh_model = base_initial_model
 
   let with_snapshot snapshot m = {m with snapshot}
+
+  let with_instance_name instance_name m =
+    {m with core = {m.core with instance_name}}
 
   let node_of m = m.node
 

--- a/src/ui/pages/install_node_form_v3.mli
+++ b/src/ui/pages/install_node_form_v3.mli
@@ -72,6 +72,10 @@ module For_tests : sig
       bypassing any field on-change logic. *)
   val with_snapshot : snapshot_selection -> model -> model
 
+  (** Test-only setter overriding the instance name, to simulate a user
+      who renamed the instance away from the auto-generated name. *)
+  val with_instance_name : string -> model -> model
+
   (** Read back the model's node configuration. *)
   val node_of : model -> Form_builder_common.node_config
 

--- a/test/test_install_node_form_pure.ml
+++ b/test/test_install_node_form_pure.ml
@@ -68,6 +68,46 @@ let test_archive_clears_manual_snapshot_issue_1000 () =
     "`None"
     (describe (Install_node_form.For_tests.snapshot_of after))
 
+(** Same invariant through the other branch of [set_node_with_autoname]:
+    when the user has renamed the instance away from the auto-generated
+    name, the autoname branch is skipped, but switching to archive must
+    still clear a manually-selected snapshot. *)
+let test_archive_clears_manual_snapshot_renamed_instance () =
+  let manual_snapshot =
+    `Tzinit
+      Install_node_form.
+        {
+          network_slug = "shadownet";
+          kind_slug = "rolling";
+          label = "Tzinit \xc2\xb7 2026-07-20";
+        }
+  in
+  let before =
+    Install_node_form.For_tests.(
+      fresh_model ()
+      |> with_snapshot manual_snapshot
+      |> with_instance_name "my-custom-name")
+  in
+  let archive_node =
+    {
+      (Install_node_form.For_tests.node_of before) with
+      Octez_manager_ui.Form_builder_common.history_mode = "archive";
+    }
+  in
+  let after =
+    Install_node_form.For_tests.set_node_with_autoname archive_node before
+  in
+  let is_none =
+    match Install_node_form.For_tests.snapshot_of after with
+    | `None -> true
+    | `Url _ | `Tzinit _ -> false
+  in
+  check
+    bool
+    "archive must clear manual snapshot even for renamed instances"
+    true
+    is_none
+
 let () =
   Alcotest.run
     "Install Node Form (pure)"
@@ -78,5 +118,9 @@ let () =
             "archive clears manual snapshot (#1000)"
             `Quick
             test_archive_clears_manual_snapshot_issue_1000;
+          Alcotest.test_case
+            "archive clears manual snapshot on renamed instance (#1000)"
+            `Quick
+            test_archive_clears_manual_snapshot_renamed_instance;
         ] );
     ]


### PR DESCRIPTION
Fixes #1000. Stacked on #1021 — that PR is the intentionally-red regression test; this one contains only the fix and turns it green. (If #1021 merges first, GitHub retargets this PR to `main`; alternatively the two can be reviewed together here and #1021 closed.)

## Fix

`set_node_with_autoname` — the callback the History Mode field invokes — now forces the snapshot selection to `` `None `` on **any** switch to archive, instead of only resetting auto-selected snapshots. Both branches are covered: the autoname path and the renamed-instance path (which previously kept the model's snapshot untouched entirely).

Archive nodes never bootstrap from a snapshot; since the Snapshot field is hidden in archive mode, a surviving manual selection bypassed its `history_snapshot_conflict` validation and was silently submitted as an archive install's bootstrap.

## Tests

- `archive clears manual snapshot (#1000)` — the regression test from #1021, now green.
- `archive clears manual snapshot on renamed instance (#1000)` — new in this PR, covers the renamed-instance branch through one extra behavior-neutral `For_tests` setter (`with_instance_name`).

## Checklist
- [x] CHANGELOG entry under [Unreleased] → Fixed (fixes #1000)
- [x] `dune build`, `dune runtest` (all suites green), `dune fmt`, `./scripts/check-copyright.sh` pass
- [x] No form fields added/removed — no golden-path field-count impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)