### PR TITLE
fix(service): persist and restore enable-on-boot state across edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Editing a node, baker, accuser, DAL node, indexer, or signatory instance that was intentionally disabled from starting at boot no longer silently re-enables it on save. Previously, the edit form's "Enable on boot" toggle always started at "enabled" regardless of the instance's actual state, because that state was never persisted; it is now recorded and restored on edit (fixes #1001)
+
 - The node install wizard no longer submits a snapshot import for archive nodes. Previously, manually selecting a snapshot and then switching History Mode to "archive" kept the hidden selection in the form state, producing an install that tried to bootstrap an archive node from a snapshot (fixes #1000)
 
 - Editing a baker or accuser instance no longer silently drops global CLI options (e.g. `--media-type`, `--endpoint`, `--password-filename`) on save. The edit form's "Extra Args" field previously prefilled only from the command-args half of the split, so re-submitting an otherwise-unchanged edit erased the global-args half from the env file; the field now prefills from both halves (fixes #996)

--- a/src/cli/cmd_instance.ml
+++ b/src/cli/cmd_instance.ml
@@ -532,7 +532,8 @@ let instance_term =
                             bin_source = svc.bin_source;
                             extra_args = new_extra_args;
                             extra_env = [];
-                            auto_enable = true;
+                            auto_enable =
+                              Option.value ~default:true svc.enabled_on_boot;
                             logging_mode = svc.logging_mode;
                             bootstrap = Installer_types.Genesis;
                             preserve_data = true;
@@ -707,7 +708,8 @@ let instance_term =
                             bin_source = svc.bin_source;
                             logging_mode = svc.logging_mode;
                             extra_args = new_extra_args;
-                            auto_enable = true;
+                            auto_enable =
+                              Option.value ~default:true svc.enabled_on_boot;
                             preserve_data = true;
                             extra_nodes = [];
                           }
@@ -735,7 +737,8 @@ let instance_term =
                             bin_source = svc.bin_source;
                             logging_mode = svc.logging_mode;
                             extra_args = new_extra_args;
-                            auto_enable = true;
+                            auto_enable =
+                              Option.value ~default:true svc.enabled_on_boot;
                             preserve_data = true;
                           }
                         in
@@ -821,7 +824,8 @@ let instance_term =
                                 ("OCTEZ_DAL_NET_ADDR", new_net);
                               ];
                             extra_paths = [dal_data_dir];
-                            auto_enable = true;
+                            auto_enable =
+                              Option.value ~default:true svc.enabled_on_boot;
                             depends_on = new_depends_on;
                             preserve_data = true;
                           }

--- a/src/installer/dal_node.ml
+++ b/src/installer/dal_node.ml
@@ -70,6 +70,7 @@ let install_daemon ?(quiet = false) (request : daemon_request) =
       ~extra_args:request.service_args
       ~depends_on:request.depends_on
       ~dependents:existing_dependents
+      ~enabled_on_boot:(Some request.auto_enable)
       ()
   in
   let* () = Service_registry.write service in

--- a/src/installer/index.ml
+++ b/src/installer/index.ml
@@ -99,6 +99,7 @@ let install ?(quiet = false) (request : index_request) =
       ~extra_args:all_service_args
       ~depends_on:request.depends_on
       ~dependents:existing_dependents
+      ~enabled_on_boot:(Some request.auto_enable)
       ()
   in
   let* () = Service_registry.write service in

--- a/src/installer/node.ml
+++ b/src/installer/node.ml
@@ -190,6 +190,7 @@ let install_node ?(quiet = false) ?on_log (request : node_request) =
       ~snapshot_no_check:snapshot_meta.no_check
       ~extra_args:request.extra_args
       ~dependents:existing_dependents
+      ~enabled_on_boot:(Some request.auto_enable)
       ()
   in
   log "Writing service registry...\n" ;

--- a/src/installer/signatory.ml
+++ b/src/installer/signatory.ml
@@ -326,6 +326,7 @@ Security:
       ~extra_args:[] (* Signatory args are in config file *)
       ~depends_on:None
       ~dependents:[]
+      ~enabled_on_boot:(Some request.auto_enable)
       ()
   in
 

--- a/src/service.ml
+++ b/src/service.ml
@@ -29,6 +29,10 @@ type t = {
       (** Remote signer configuration for bakers (None = Local_keys for backward compat) *)
   signer_uri : string option;  (** Resolved URI for display/metrics *)
   group : string option;  (** Group this service belongs to, if any *)
+  enabled_on_boot : bool option;
+      (** Last enable-on-boot state octez-manager applied to the systemd unit.
+          [None] means unknown (legacy service.json predating this field);
+          callers should treat [None] as [true] to preserve prior behavior. *)
 }
 
 let make ~instance ~role ~network ~history_mode ~data_dir ~rpc_addr ~net_addr
@@ -36,7 +40,8 @@ let make ~instance ~role ~network ~history_mode ~data_dir ~rpc_addr ~net_addr
     ?(snapshot_auto = false) ?(snapshot_uri = None)
     ?(snapshot_network_slug = None) ?(snapshot_no_check = false)
     ?(extra_args = []) ?(depends_on = None) ?(dependents = [])
-    ?(signer_mode = None) ?(signer_uri = None) ?(group = None) () =
+    ?(signer_mode = None) ?(signer_uri = None) ?(group = None)
+    ?(enabled_on_boot = None) () =
   {
     instance;
     role;
@@ -60,6 +65,7 @@ let make ~instance ~role ~network ~history_mode ~data_dir ~rpc_addr ~net_addr
     signer_mode;
     signer_uri;
     group;
+    enabled_on_boot;
   }
 
 let get_bin_source t =
@@ -154,6 +160,8 @@ let to_yojson t =
       ( "signer_uri",
         match t.signer_uri with Some s -> `String s | None -> `Null );
       ("group", match t.group with Some s -> `String s | None -> `Null);
+      ( "enabled_on_boot",
+        match t.enabled_on_boot with Some b -> `Bool b | None -> `Null );
     ]
   in
   (* Add bin_source if present *)
@@ -243,6 +251,11 @@ let of_yojson json =
       | `String s when s <> "" -> Some s
       | _ -> None
     in
+    let enabled_on_boot =
+      match json |> member "enabled_on_boot" with
+      | `Bool b -> Some b
+      | _ -> None
+    in
     match history_mode with
     | Error _ as err -> err
     | Ok history_mode -> (
@@ -272,6 +285,7 @@ let of_yojson json =
                 signer_mode;
                 signer_uri;
                 group;
+                enabled_on_boot;
               }
         | Error _ as err -> err)
   with Yojson.Json_error msg -> Error (`Msg msg)

--- a/src/service.mli
+++ b/src/service.mli
@@ -30,6 +30,10 @@ type t = {
       (** Remote signer configuration for bakers (None = Local_keys for backward compat) *)
   signer_uri : string option;  (** Resolved URI for display/metrics *)
   group : string option;  (** Group this service belongs to, if any *)
+  enabled_on_boot : bool option;
+      (** Last enable-on-boot state octez-manager applied to the systemd unit.
+          [None] means unknown (legacy service.json predating this field);
+          callers should treat [None] as [true] to preserve prior behavior. *)
 }
 
 (** Create a service configuration record.
@@ -57,6 +61,7 @@ val make :
   ?signer_mode:Signer_types.signer_mode option ->
   ?signer_uri:string option ->
   ?group:string option ->
+  ?enabled_on_boot:bool option ->
   unit ->
   t
 

--- a/src/ui/pages/install_accuser_form_v3.ml
+++ b/src/ui/pages/install_accuser_form_v3.ml
@@ -83,7 +83,8 @@ let make_initial_model () =
             service_user = svc.Service.service_user;
             app_bin_dir = svc.Service.app_bin_dir;
             bin_source = svc.Service.bin_source;
-            enable_on_boot = true;
+            enable_on_boot =
+              Option.value ~default:true svc.Service.enabled_on_boot;
             start_now = false;
             (* Don't auto-start after edit *)
             extra_args;

--- a/src/ui/pages/install_baker_form_v3.ml
+++ b/src/ui/pages/install_baker_form_v3.ml
@@ -138,7 +138,8 @@ let make_initial_model () =
             service_user = svc.Service.service_user;
             app_bin_dir = svc.Service.app_bin_dir;
             bin_source = svc.Service.bin_source;
-            enable_on_boot = true;
+            enable_on_boot =
+              Option.value ~default:true svc.Service.enabled_on_boot;
             start_now = false;
             (* Don't auto-start after edit *)
             extra_args;

--- a/src/ui/pages/install_dal_node_form_v3.ml
+++ b/src/ui/pages/install_dal_node_form_v3.ml
@@ -110,7 +110,8 @@ let make_initial_model () =
             service_user = svc.Service.service_user;
             app_bin_dir = svc.Service.app_bin_dir;
             bin_source = svc.Service.bin_source;
-            enable_on_boot = true;
+            enable_on_boot =
+              Option.value ~default:true svc.Service.enabled_on_boot;
             start_now = false;
             (* Don't auto-start after edit *)
             extra_args;

--- a/src/ui/pages/install_index_form_v3.ml
+++ b/src/ui/pages/install_index_form_v3.ml
@@ -127,7 +127,8 @@ let make_initial_model () =
             service_user = svc.Service.service_user;
             app_bin_dir = svc.Service.app_bin_dir;
             bin_source = svc.Service.bin_source;
-            enable_on_boot = true;
+            enable_on_boot =
+              Option.value ~default:true svc.Service.enabled_on_boot;
             start_now = false;
             extra_args = "";
             group = svc.Service.group;

--- a/src/ui/pages/install_node_form_v3.ml
+++ b/src/ui/pages/install_node_form_v3.ml
@@ -401,7 +401,8 @@ let make_initial_model () =
             service_user = svc.Service.service_user;
             app_bin_dir = svc.Service.app_bin_dir;
             bin_source = svc.Service.bin_source;
-            enable_on_boot = true;
+            enable_on_boot =
+              Option.value ~default:true svc.Service.enabled_on_boot;
             start_now = false;
             (* Don't auto-start after edit *)
             extra_args = String.concat " " svc.Service.extra_args;

--- a/src/ui/pages/install_signatory_form.ml
+++ b/src/ui/pages/install_signatory_form.ml
@@ -137,7 +137,8 @@ let make_initial_model () =
             service_user = svc.Service.service_user;
             app_bin_dir = svc.Service.app_bin_dir;
             bin_source = svc.Service.bin_source;
-            enable_on_boot = true;
+            enable_on_boot =
+              Option.value ~default:true svc.Service.enabled_on_boot;
             start_now = false;
             extra_args;
             group = svc.Service.group;

--- a/src/ui/public_nodes_cache.ml
+++ b/src/ui/public_nodes_cache.ml
@@ -296,6 +296,7 @@ let to_service (info : node_info) : Service.t =
     signer_mode = None;
     signer_uri = None;
     group = None;
+    enabled_on_boot = None;
   }
 
 (** Get all public nodes as Service.t list *)

--- a/test/integration/cli-tester/tests/node/28-enable-on-boot-persistence.sh
+++ b/test/integration/cli-tester/tests/node/28-enable-on-boot-persistence.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Test: enable-on-boot state is persisted to the service registry at
+# install time (both --no-enable and default/enabled), and survives a
+# subsequent 'instance edit' round-trip without being silently
+# re-enabled (regression test for #1001).
+#
+# Before the fix, every install wizard's edit-mode prefill (and the CLI
+# edit path in cmd_instance.ml) hardcoded auto_enable = true, because
+# the applied systemd enable state was never persisted anywhere. So
+# editing an intentionally-disabled instance silently re-enabled it at
+# boot on the next save. Service.t now has an enabled_on_boot field
+# that installers record, and edit paths read it back instead of
+# hardcoding true.
+#
+# Edit round-trip coverage: 'om instance <inst> edit' runs fully
+# non-interactively here because stdin is not a tty in this harness --
+# Cli_helpers.is_interactive () is false, so every prompt_input /
+# prompt_with_completion / prompt_yes_no call in cmd_instance.ml
+# returns None (or the non-interactive default) immediately, and every
+# field falls back to Option.value ~default:<current value> ..., in
+# particular:
+#   auto_enable = Option.value ~default:true svc.Service.enabled_on_boot
+# (src/cli/cmd_instance.ml, node role branch of the 'edit' handler).
+# This means an unattended 'edit' exercises exactly the post-#1001-fix
+# seeding logic: without the fix this line was hardcoded to
+# 'auto_enable = true' and the edit below would re-enable the unit.
+set -euo pipefail
+source /tests/lib.sh
+
+test_init "Enable-on-boot state persists across install and edit"
+
+DISABLED_INSTANCE="test-boot-disabled"
+ENABLED_INSTANCE="test-boot-enabled"
+DISABLED_RPC="127.0.0.1:$(alloc_port)"
+DISABLED_NET="0.0.0.0:$(alloc_port)"
+ENABLED_RPC="127.0.0.1:$(alloc_port)"
+ENABLED_NET="0.0.0.0:$(alloc_port)"
+
+register_instance "$DISABLED_INSTANCE"
+register_instance "$ENABLED_INSTANCE"
+
+DISABLED_REGISTRY="/etc/octez_manager/services/${DISABLED_INSTANCE}.json"
+ENABLED_REGISTRY="/etc/octez_manager/services/${ENABLED_INSTANCE}.json"
+
+# --- Step 1: install a node with --no-enable (no snapshot needed --
+# we never start it) and assert both the systemd unit and the
+# registry record it as disabled.
+echo "Installing node with --no-enable..."
+om install-node \
+	--instance "$DISABLED_INSTANCE" \
+	--network shadownet \
+	--rpc-addr "$DISABLED_RPC" \
+	--net-addr "$DISABLED_NET" \
+	--service-user tezos \
+	--no-enable 2>&1
+
+if service_is_enabled node "$DISABLED_INSTANCE"; then
+	echo "ERROR: systemd unit should be disabled after --no-enable install"
+	exit 1
+fi
+
+assert_file_exists "$DISABLED_REGISTRY" \
+	"registry file should exist after install"
+
+disabled_flag=$(jq -r '.enabled_on_boot' "$DISABLED_REGISTRY")
+assert_eq "false" "$disabled_flag" \
+	"registry enabled_on_boot should be false after --no-enable install"
+echo "Disabled instance: unit disabled, registry enabled_on_boot=false"
+
+# --- Step 2: edit the instance non-interactively (see header) and
+# assert it is STILL disabled afterwards. This is the actual #1001
+# regression: pre-fix, this edit silently re-enabled the unit.
+echo "Editing disabled instance non-interactively..."
+om instance "$DISABLED_INSTANCE" edit 2>&1
+
+if service_is_enabled node "$DISABLED_INSTANCE"; then
+	echo "ERROR: edit re-enabled a unit that was explicitly disabled (#1001 regression)"
+	exit 1
+fi
+
+disabled_flag_after_edit=$(jq -r '.enabled_on_boot' "$DISABLED_REGISTRY")
+assert_eq "false" "$disabled_flag_after_edit" \
+	"registry enabled_on_boot should still be false after edit"
+echo "Disabled instance stayed disabled through edit round-trip"
+
+# --- Step 3: positive case -- install another instance WITHOUT
+# --no-enable and assert the registry records enabled_on_boot: true.
+# No --snapshot is passed either, so bootstrap is Genesis (no
+# download); we only need the enable state, not a synced node, so we
+# stop it again immediately after asserting.
+echo "Installing node without --no-enable (default enabled)..."
+om install-node \
+	--instance "$ENABLED_INSTANCE" \
+	--network shadownet \
+	--rpc-addr "$ENABLED_RPC" \
+	--net-addr "$ENABLED_NET" \
+	--service-user tezos 2>&1
+
+assert_file_exists "$ENABLED_REGISTRY" \
+	"registry file should exist after install"
+
+enabled_flag=$(jq -r '.enabled_on_boot' "$ENABLED_REGISTRY")
+assert_eq "true" "$enabled_flag" \
+	"registry enabled_on_boot should be true for default (enabled) install"
+echo "Enabled instance: registry enabled_on_boot=true"
+
+om instance "$ENABLED_INSTANCE" stop 2>&1 || true
+
+echo "Enable-on-boot persistence test passed"

--- a/test/integration/cli-tester/tests/shards.json
+++ b/test/integration/cli-tester/tests/shards.json
@@ -2,8 +2,8 @@
   "metadata": {
     "generated_at": "2026-04-09T00:00:00.000000",
     "generated_by": "Rebase: merge main (101 tests) + install-index test",
-    "total_tests": 106,
-    "total_duration": 829.05,
+    "total_tests": 107,
+    "total_duration": 844.05,
     "shard_count": 5,
     "mean_shard_duration": 163.81,
     "max_shard_duration": 190.61,
@@ -85,10 +85,11 @@
       "import/53-import-cascade-accuser.sh",
       "import/61-import-cascade-all-configs-preserved.sh",
       "index/01-install.sh",
-      "cli/02-instance-no-args.sh"
+      "cli/02-instance-no-args.sh",
+      "node/28-enable-on-boot-persistence.sh"
     ],
-    "test_count": 19,
-    "total_duration": 151.0
+    "test_count": 20,
+    "total_duration": 166.0
   },
   "shard-4": {
     "tests": [

--- a/test/test_data.ml
+++ b/test/test_data.ml
@@ -37,6 +37,7 @@ let make_service ?(instance = "my-node") ?(role = "node") ?(network = "mainnet")
     signer_mode = None;
     signer_uri = None;
     group = None;
+    enabled_on_boot = None;
   }
 
 let make_state ?(instance = "my-node") ?(role = "node") ?(enabled = Some true)

--- a/test/test_log_export_pure.ml
+++ b/test/test_log_export_pure.ml
@@ -41,6 +41,7 @@ let make_svc ?(instance = "my-node") ?(role = "node") ?(network = "mainnet")
     signer_mode = None;
     signer_uri = None;
     group = None;
+    enabled_on_boot = None;
   }
 
 let contains_substring = Test_string_helpers.contains_substring

--- a/test/unit_tests.ml
+++ b/test/unit_tests.ml
@@ -161,6 +161,7 @@ let sample_service ?(logging_mode = Logging_mode.Journald) () : Service.t =
     signer_mode = None;
     signer_uri = None;
     group = None;
+    enabled_on_boot = None;
   }
 
 let sort_services =
@@ -3249,6 +3250,43 @@ let install_accuser_form_v3_edit_prefill_preserves_global_args () =
           "--media-type json --extra x"
           model.core.extra_args)
 
+(* Regression test for #1001: every install wizard's EDIT-mode prefill
+   hardcoded [enable_on_boot = true], so editing an intentionally disabled
+   service silently re-enabled it at boot on submit. Without the fix,
+   [model.core.enable_on_boot] below would be [true] even though the
+   persisted service has [enabled_on_boot = Some false]. *)
+let install_baker_form_v3_edit_prefill_preserves_disabled_boot_state () =
+  if is_ci () then Alcotest.skip ()
+  else
+    with_fake_xdg (fun _env ->
+        let inst = "baker-issue-1001" in
+        let service =
+          {
+            (Service.make
+               ~instance:inst
+               ~role:"baker"
+               ~network:"mainnet"
+               ~history_mode:History_mode.Rolling
+               ~data_dir:"/tmp/octez/baker-issue-1001"
+               ~rpc_addr:(Rpc_addr.of_string "127.0.0.1:8732")
+               ~net_addr:""
+               ~service_user:"octez"
+               ~app_bin_dir:"/usr/bin"
+               ~logging_mode:Logging_mode.Journald
+               ())
+            with
+            Service.enabled_on_boot = Some false;
+          }
+        in
+        Octez_manager_ui.Context.set_pending_edit_service
+          ~service
+          ~stopped_dependents:[] ;
+        let model = Install_baker_form_v3.For_tests.initial_model () in
+        Alcotest.(check bool)
+          "enable_on_boot prefilled from persisted disabled state"
+          false
+          model.core.enable_on_boot)
+
 let system_user_validate_missing () =
   match
     System_user.validate_user_for_service ~user:"__missing_octez_user__"
@@ -3836,6 +3874,62 @@ let service_dependents_default_empty () =
     "depends_on default none"
     None
     service.Service.depends_on
+
+(* ============================================================================
+   Service enabled_on_boot field tests (#1001)
+   ============================================================================ *)
+
+let service_roundtrip_enabled_on_boot_false () =
+  let service =
+    {(sample_service ()) with Service.enabled_on_boot = Some false}
+  in
+  match Service.to_yojson service |> Service.of_yojson with
+  | Ok decoded ->
+      Alcotest.(check (option bool))
+        "enabled_on_boot false preserved"
+        (Some false)
+        decoded.Service.enabled_on_boot
+  | Error (`Msg msg) -> Alcotest.failf "roundtrip failed: %s" msg
+
+let service_roundtrip_enabled_on_boot_true () =
+  let service =
+    {(sample_service ()) with Service.enabled_on_boot = Some true}
+  in
+  match Service.to_yojson service |> Service.of_yojson with
+  | Ok decoded ->
+      Alcotest.(check (option bool))
+        "enabled_on_boot true preserved"
+        (Some true)
+        decoded.Service.enabled_on_boot
+  | Error (`Msg msg) -> Alcotest.failf "roundtrip failed: %s" msg
+
+let service_enabled_on_boot_legacy_json_is_none () =
+  (* A service.json written before this field existed must deserialize with
+     enabled_on_boot = None (unknown), not crash and not default to a
+     specific boolean. *)
+  let legacy_json =
+    `Assoc
+      [
+        ("instance", `String "alpha");
+        ("role", `String "node");
+        ("network", `String "https://example/net.json");
+        ("history_mode", `String "full");
+        ("data_dir", `String "/tmp/octez/alpha");
+        ("rpc_addr", `String "127.0.0.1:8732");
+        ("net_addr", `String "0.0.0.0:9732");
+        ("service_user", `String "octez");
+        ("app_bin_dir", `String "/opt/octez");
+        ("created_at", `String "2024-01-01 00:00:00");
+        ("logging_mode", `Assoc [("type", `String "journald")]);
+      ]
+  in
+  match Service.of_yojson legacy_json with
+  | Ok decoded ->
+      Alcotest.(check (option bool))
+        "legacy service.json has no enabled_on_boot"
+        None
+        decoded.Service.enabled_on_boot
+  | Error (`Msg msg) -> Alcotest.failf "legacy roundtrip failed: %s" msg
 
 (* ============================================================================
    Instance name validation tests (edit mode)
@@ -6526,6 +6620,13 @@ let () =
             `Quick
             install_accuser_form_v3_edit_prefill_preserves_global_args;
         ] );
+      ( "installer.enable_on_boot",
+        [
+          Alcotest.test_case
+            "baker edit form preserves disabled boot state (#1001)"
+            `Quick
+            install_baker_form_v3_edit_prefill_preserves_disabled_boot_state;
+        ] );
       ( "snapshots.basic",
         [
           Alcotest.test_case "slug_of_network" `Quick snapshots_slug_of_network;
@@ -6918,6 +7019,21 @@ let () =
             "defaults empty"
             `Quick
             service_dependents_default_empty;
+        ] );
+      ( "service.enabled_on_boot",
+        [
+          Alcotest.test_case
+            "roundtrip false"
+            `Quick
+            service_roundtrip_enabled_on_boot_false;
+          Alcotest.test_case
+            "roundtrip true"
+            `Quick
+            service_roundtrip_enabled_on_boot_true;
+          Alcotest.test_case
+            "legacy json has no field -> None"
+            `Quick
+            service_enabled_on_boot_legacy_json_is_none;
         ] );
       ( "instance_name",
         [


### PR DESCRIPTION
Fixes #1001.

## Problem

Every install wizard's edit mode prefilled "Enable on Boot" as `true`, and the CLI interactive `edit` paths hardcoded `auto_enable = true`. Editing an intentionally disabled service (e.g. one kept down for maintenance) silently re-enabled it at boot on submit — and since auto-enabled installs run `enable --now`, could also start it. Root cause: the enable state was never persisted; `Service.t` had no such field.

## Fix

- New `Service.t` field `enabled_on_boot : bool option`, serialized to the service registry. `None` = legacy record (treated as `true`, preserving prior behavior); `Some b` = the last enable state octez-manager applied. Legacy `service.json` files without the field deserialize cleanly to `None`.
- All installers persist `Some request.auto_enable` at registration — node, index, signatory, and the generic `install_daemon` (which baker/accuser flow through).
- All six wizard edit prefills and the four CLI `edit` hardcodes now read `Option.value ~default:true svc.enabled_on_boot`.

Out of scope, checked and left as-is: `import.ml` always applies `auto_enable = true` when adopting an external service (pre-existing, separate behavior), and the only standalone `Systemd.enable`/`disable` wrappers outside installers are caller-less dead code.

## Tests (`test/unit_tests.ml`)

- `service.enabled_on_boot`: JSON round-trip for `Some false`/`Some true`, and a legacy-blob-without-the-field test asserting `None`.
- `installer.enable_on_boot`: edit-prefill regression test via `Context.set_pending_edit_service` + the baker form's real `For_tests.initial_model`, asserting a disabled service prefills the toggle off. Verified to fail without the fix (`Expected: false, Received: true`) and pass with it.

## Checklist
- [x] CHANGELOG entry under [Unreleased] → Fixed (fixes #1001)
- [x] `dune build`, `dune runtest`, `dune fmt`, `./scripts/check-copyright.sh` all pass
- [x] No CLI flags changed (completions unaffected); no form fields added/removed (no golden-path impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)