### PR TITLE
fix(net): accept bracketed IPv6 in host:port addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Host:port fields (RPC address, P2P address, Signatory address) no longer reject bracketed IPv6 literals such as `[::1]:8732`, which previously failed validation with "Must be host:port" even though octez accepts them. A bare (unbracketed) IPv6 address combined with a port, e.g. `fe80::1:9732`, is inherently ambiguous and is now rejected with an actionable message asking to bracket the address instead of a generic format error (fixes #1006)
+
 - Editing a node, baker, accuser, DAL node, indexer, or signatory instance that was intentionally disabled from starting at boot no longer silently re-enables it on save. Previously, the edit form's "Enable on boot" toggle always started at "enabled" regardless of the instance's actual state, because that state was never persisted; it is now recorded and restored on edit (fixes #1001)
 
 - The node install wizard no longer submits a snapshot import for archive nodes. Previously, manually selecting a snapshot and then switching History Mode to "archive" kept the hidden selection in the form state, producing an install that tried to bootstrap an archive node from a snapshot (fixes #1000)

--- a/src/dune
+++ b/src/dune
@@ -57,6 +57,7 @@
   signer_validation
   manager_interfaces
   capabilities
+  host_port
   rpc_addr
   port_validation
   external_service

--- a/src/external_service.ml
+++ b/src/external_service.ml
@@ -255,24 +255,37 @@ let parse_endpoint url =
     | _ -> None
   with _ -> None
 
+(** Strip the surrounding square brackets from a bracketed IPv6 literal
+    (turning [\[::1\]] into [::1]), so it can be compared against a host
+    parsed from a URI (which never carries brackets). Non-bracketed
+    hosts are returned unchanged. *)
+let strip_brackets h =
+  let len = String.length h in
+  if len >= 2 && h.[0] = '[' && h.[len - 1] = ']' then String.sub h 1 (len - 2)
+  else h
+
 (** Check if an endpoint matches a service's RPC address. *)
 let endpoint_matches_rpc ~endpoint ~rpc_addr =
-  match (parse_endpoint endpoint, rpc_addr) with
-  | Some (ep_host, ep_port), addr -> (
-      match String.split_on_char ':' addr with
-      | [host; port] | [""; host; port] -> (
+  match parse_endpoint endpoint with
+  | None -> false
+  | Some (ep_host, ep_port) -> (
+      match Host_port.split rpc_addr with
+      | Error _ -> false
+      | Ok (host, port) -> (
           try
             let rpc_port = int_of_string port in
-            let rpc_host = if host = "" then "0.0.0.0" else host in
+            let host = strip_brackets host in
+            let rpc_host = if String.equal host "" then "0.0.0.0" else host in
             let normalize h =
-              if h = "localhost" || h = "127.0.0.1" || h = "0.0.0.0" then
-                "localhost"
+              if
+                String.equal h "localhost" || String.equal h "127.0.0.1"
+                || String.equal h "0.0.0.0"
+              then "localhost"
               else h
             in
-            ep_port = rpc_port && normalize ep_host = normalize rpc_host
-          with _ -> false)
-      | _ -> false)
-  | _ -> false
+            Int.equal ep_port rpc_port
+            && String.equal (normalize ep_host) (normalize rpc_host)
+          with _ -> false))
 
 (** Get services this one depends on via endpoint matching. *)
 let get_dependencies external_svc all_services =

--- a/src/host_port.ml
+++ b/src/host_port.ml
@@ -1,0 +1,31 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+type error = Invalid_format | Bare_ipv6
+
+let bare_ipv6_message = "IPv6 addresses must be bracketed: [::1]:8732"
+
+let split_bracketed (s : string) : (string * string, error) result =
+  let len = String.length s in
+  match String.index_opt s ']' with
+  | None -> Error Invalid_format
+  | Some close_idx -> (
+      let host = String.sub s 0 (close_idx + 1) in
+      let rest_start = close_idx + 1 in
+      match rest_start < len && s.[rest_start] = ':' with
+      | false -> Error Invalid_format
+      | true ->
+          let port = String.sub s (rest_start + 1) (len - rest_start - 1) in
+          Ok (host, port))
+
+let split (s : string) : (string * string, error) result =
+  if String.length s > 0 && s.[0] = '[' then split_bracketed s
+  else
+    match String.split_on_char ':' s with
+    | [host; port] -> Ok (host, port)
+    | [] | [_] -> Error Invalid_format
+    | _ :: _ :: _ :: _ -> Error Bare_ipv6

--- a/src/host_port.mli
+++ b/src/host_port.mli
@@ -1,0 +1,48 @@
+(******************************************************************************)
+(*                                                                            *)
+(* SPDX-License-Identifier: MIT                                               *)
+(* Copyright (c) 2026 Nomadic Labs <contact@nomadic-labs.com>                 *)
+(*                                                                            *)
+(******************************************************************************)
+
+(** Bracket-aware [host:port] address splitting.
+
+    Every place in the codebase that parses a [host:port] address (RPC
+    addresses, P2P addresses, Signatory HTTP addresses, ...) used to split
+    naively on [':'], which rejects IPv6 literals such as [::1] because
+    they contain colons themselves. This module centralizes the splitting
+    logic so all call sites agree on the same policy:
+
+    - A single-colon [host:port] is split as before (IPv4, hostnames, and
+      the empty/wildcard host used for "bind all interfaces", e.g. the
+      port-only form with an empty host part before the colon).
+    - A bracketed IPv6 literal followed by a port (optionally with a zone
+      id, e.g. bracketed [fe80::1%eth0] followed by [:9732]) is accepted.
+      The returned host string includes its brackets, since that is
+      exactly the form octez accepts back on the command line — callers
+      must not strip them when round-tripping the value.
+    - A bare IPv6 literal combined with a port (e.g. [fe80::1:9732], with
+      no brackets) is ambiguous: there is no way to tell where the
+      address ends and the port begins. Such inputs are rejected with
+      {!Bare_ipv6} rather than silently mis-parsed; callers must bracket
+      the address instead. *)
+
+(** Reasons {!split} can fail to recognize a [host:port] string. *)
+type error =
+  | Invalid_format
+      (** Does not look like [host:port] (no colon, or malformed
+          brackets). *)
+  | Bare_ipv6
+      (** Multiple colons outside of brackets — most likely an
+          unbracketed IPv6 literal combined with a port. *)
+
+(** Actionable message recommended for {!Bare_ipv6}, shared so every
+    caller reports the same text: IPv6 addresses must be bracketed, e.g.
+    bracketed [::1] followed by [:8732]. *)
+val bare_ipv6_message : string
+
+(** Split a [host:port] string into its raw host and port substrings.
+    The host substring includes brackets for a bracketed IPv6 literal.
+    The port substring is returned verbatim (not parsed as an int) so
+    callers can apply their own numeric range validation. *)
+val split : string -> (string * string, error) result

--- a/src/installer/import.ml
+++ b/src/installer/import.ml
@@ -522,13 +522,13 @@ let create_dal_from_external ~instance ~external_svc ~network ~data_dir
       let increment_port addr =
         if addr = "" then ""
         else
-          match String.split_on_char ':' addr with
-          | [host; port] -> (
+          match Host_port.split addr with
+          | Ok (host, port) -> (
               try
                 let port_num = int_of_string port in
                 Printf.sprintf "%s:%d" host (port_num + 1)
               with _ -> addr)
-          | _ -> addr
+          | Error _ -> addr
       in
       (increment_port effective_rpc_addr, increment_port effective_net_addr)
     else (effective_rpc_addr, effective_net_addr)

--- a/src/installer/signatory.ml
+++ b/src/installer/signatory.ml
@@ -17,15 +17,17 @@ let validate_address address =
   let trimmed = String.trim address in
   if trimmed = "" then R.error_msg "Address cannot be empty"
   else
-    match String.split_on_char ':' trimmed with
-    | [_host; port_str] -> (
+    match Host_port.split trimmed with
+    | Ok (_host, port_str) -> (
         match int_of_string_opt port_str with
         | Some port when port > 0 && port <= 65535 -> Ok trimmed
         | _ ->
             R.error_msgf
               "Invalid port in address '%s'. Port must be 1-65535."
               trimmed)
-    | _ ->
+    | Error Host_port.Bare_ipv6 ->
+        R.error_msgf "%s Got '%s'." Host_port.bare_ipv6_message trimmed
+    | Error Host_port.Invalid_format ->
         R.error_msgf
           "Invalid address format '%s'. Expected 'host:port' (e.g., \
            '127.0.0.1:6732')."

--- a/src/port_validation.ml
+++ b/src/port_validation.ml
@@ -8,20 +8,20 @@
 (** Port validation utilities shared between CLI and UI. *)
 
 let parse_host_port (s : string) : (string * int) option =
-  match String.split_on_char ':' s with
-  | [host; port] -> (
+  match Host_port.split s with
+  | Error _ -> None
+  | Ok (host, port) -> (
       try
         let p = int_of_string (String.trim port) in
         let h = String.trim host in
         if p > 0 && p < 65536 && h <> "" then Some (h, p) else None
       with _ -> None)
-  | _ -> None
 
 let parse_port addr =
-  match String.split_on_char ':' addr with
-  | [_; port_str] -> (
+  match Host_port.split addr with
+  | Error _ -> None
+  | Ok (_, port_str) -> (
       try Some (int_of_string (String.trim port_str)) with _ -> None)
-  | _ -> None
 
 (** Cache for service ports to avoid repeated I/O during form validation.
     Short TTL since services can be added/removed. *)
@@ -185,6 +185,7 @@ let next_free_port ~start ~avoid =
 
 type validation_error =
   | Invalid_format of string
+  | Bare_ipv6
   | Port_out_of_range
   | Used_by_other_instance of int * string
   | Port_in_use of int * string option
@@ -192,6 +193,7 @@ type validation_error =
 let pp_error = function
   | Invalid_format example ->
       Printf.sprintf "Must be host:port (e.g., %s)" example
+  | Bare_ipv6 -> Host_port.bare_ipv6_message
   | Port_out_of_range -> "Port must be between 1024 and 65535"
   | Used_by_other_instance (port, instance) ->
       Printf.sprintf "Port %d is used by instance '%s'" port instance
@@ -205,37 +207,44 @@ let pp_error = function
     @param example Example format to show in error messages
     @return Ok () if valid, Error with reason if not *)
 let validate_addr ~addr ?exclude_instance ~example () =
-  match parse_host_port addr with
-  | None -> Error (Invalid_format example)
-  | Some (_host, port) -> (
-      if port < 1024 || port > 65535 then Error Port_out_of_range
-      else
-        let rpc_ports, p2p_ports = ports_from_services ?exclude_instance () in
-        let all_ports = rpc_ports @ p2p_ports in
-        let find_instance p =
-          List.find_opt (fun (pt, _) -> pt = p) all_ports |> Option.map snd
-        in
-        match find_instance port with
-        | Some instance -> Error (Used_by_other_instance (port, instance))
-        | None ->
-            let owned_by_self =
-              match exclude_instance with
-              | Some inst -> port_owned_by_instance ~instance:inst port
-              | None -> false
+  match Host_port.split addr with
+  | Error Host_port.Bare_ipv6 -> Error Bare_ipv6
+  | Error Host_port.Invalid_format -> Error (Invalid_format example)
+  | Ok _ -> (
+      match parse_host_port addr with
+      | None -> Error (Invalid_format example)
+      | Some (_host, port) -> (
+          if port < 1024 || port > 65535 then Error Port_out_of_range
+          else
+            let rpc_ports, p2p_ports =
+              ports_from_services ?exclude_instance ()
             in
-            if owned_by_self then Ok ()
-            else if is_port_in_use port then
-              (* Use get_port_process for the error detail when no override *)
-              let proc_opt =
-                match !port_in_use_override with
-                | Some _ -> None
-                | None -> (
-                    match get_port_process port with
-                    | Some p -> p
-                    | None -> None)
-              in
-              Error (Port_in_use (port, proc_opt))
-            else Ok ())
+            let all_ports = rpc_ports @ p2p_ports in
+            let find_instance p =
+              List.find_opt (fun (pt, _) -> pt = p) all_ports |> Option.map snd
+            in
+            match find_instance port with
+            | Some instance -> Error (Used_by_other_instance (port, instance))
+            | None ->
+                let owned_by_self =
+                  match exclude_instance with
+                  | Some inst -> port_owned_by_instance ~instance:inst port
+                  | None -> false
+                in
+                if owned_by_self then Ok ()
+                else if is_port_in_use port then
+                  (* Use get_port_process for the error detail when no
+                     override *)
+                  let proc_opt =
+                    match !port_in_use_override with
+                    | Some _ -> None
+                    | None -> (
+                        match get_port_process port with
+                        | Some p -> p
+                        | None -> None)
+                  in
+                  Error (Port_in_use (port, proc_opt))
+                else Ok ()))
 
 (** Validate an RPC address. *)
 let validate_rpc_addr ?exclude_instance addr =

--- a/src/port_validation.mli
+++ b/src/port_validation.mli
@@ -39,6 +39,9 @@ val clear_port_in_use_override : unit -> unit
 (** Validation error types. *)
 type validation_error =
   | Invalid_format of string  (** Invalid host:port format *)
+  | Bare_ipv6
+      (** Multiple colons outside of brackets — an unbracketed IPv6
+          address combined with a port is ambiguous. *)
   | Port_out_of_range  (** Port not in 1024-65535 range *)
   | Used_by_other_instance of int * string  (** Port and instance name *)
   | Port_in_use of int * string option  (** Port and optional process name *)

--- a/src/rpc_addr.ml
+++ b/src/rpc_addr.ml
@@ -16,20 +16,20 @@ let of_string s = s
 let to_string t = t
 
 let host t =
-  match String.split_on_char ':' t with
-  | [h; _] ->
+  match Host_port.split t with
+  | Error _ -> None
+  | Ok (h, _) ->
       let h = String.trim h in
       if h <> "" then Some h else None
-  | _ -> None
 
 let port t =
-  match String.split_on_char ':' t with
-  | [_; p] -> (
+  match Host_port.split t with
+  | Error _ -> None
+  | Ok (_, p) -> (
       try
         let p = int_of_string (String.trim p) in
         if p > 0 && p < 65536 then Some p else None
       with _ -> None)
-  | _ -> None
 
 let to_endpoint t =
   let trimmed = String.trim t in

--- a/src/signatory_validation.ml
+++ b/src/signatory_validation.ml
@@ -60,8 +60,17 @@ let validate_authorized_keys keys =
     @param name Field name for error messages
     @return Ok () if valid, Error with message otherwise *)
 let validate_http_address ~addr ~name =
-  match String.split_on_char ':' addr with
-  | [host; port_str] -> (
+  match Host_port.split addr with
+  | Error Host_port.Bare_ipv6 ->
+      Error (`Msg (Printf.sprintf "%s: %s" name Host_port.bare_ipv6_message))
+  | Error Host_port.Invalid_format ->
+      Error
+        (`Msg
+           (Printf.sprintf
+              "%s: must be in format 'host:port', got '%s'"
+              name
+              addr))
+  | Ok (host, port_str) -> (
       if host = "" then
         Error (`Msg (Printf.sprintf "%s: host cannot be empty" name))
       else
@@ -75,13 +84,6 @@ let validate_http_address ~addr ~name =
           Error
             (`Msg (Printf.sprintf "%s: invalid port number '%s'" name port_str))
       )
-  | _ ->
-      Error
-        (`Msg
-           (Printf.sprintf
-              "%s: must be in format 'host:port', got '%s'"
-              name
-              addr))
 
 (** Validate Signatory backend configuration.
     

--- a/test/test_port_validation.ml
+++ b/test/test_port_validation.ml
@@ -44,8 +44,22 @@ let test_parse_host_port_wildcard () =
 
 let test_parse_host_port_ipv6 () =
   let result = Port_validation.parse_host_port "[::1]:8732" in
-  (* IPv6 addresses with brackets not supported - contains multiple colons *)
-  check_some_pair "IPv6 not supported" None result
+  (* Bracketed IPv6 literals are accepted; the host keeps its brackets so
+     it round-trips into a valid octez CLI argument (see #1006). *)
+  check_some_pair "bracketed IPv6 accepted" (Some ("[::1]", 8732)) result
+
+let test_parse_host_port_ipv6_zone_id () =
+  let result = Port_validation.parse_host_port "[fe80::1%eth0]:9732" in
+  (* Zone ids are part of the bracketed literal and accepted verbatim. *)
+  check_some_pair
+    "bracketed IPv6 with zone id accepted"
+    (Some ("[fe80::1%eth0]", 9732))
+    result
+
+let test_parse_host_port_bare_ipv6_rejected () =
+  let result = Port_validation.parse_host_port "fe80::1:9732" in
+  (* Bare (unbracketed) IPv6 combined with a port is ambiguous — rejected. *)
+  check_some_pair "bare IPv6 rejected" None result
 
 let test_parse_host_port_no_port () =
   let result = Port_validation.parse_host_port "127.0.0.1" in
@@ -330,6 +344,47 @@ let test_validate_addr_wildcard () =
       check bool "port in use is valid" true true
   | Error _ -> fail "unexpected error for wildcard"
 
+let test_validate_addr_bracketed_ipv6 () =
+  let result =
+    Port_validation.validate_addr
+      ~addr:"[::1]:54325"
+      ~example:"127.0.0.1:54325"
+      ()
+  in
+  match result with
+  | Ok () -> check bool "bracketed IPv6 accepted" true true
+  | Error (Port_validation.Port_in_use _) ->
+      check bool "port in use is valid" true true
+  | Error _ -> fail "unexpected error for bracketed IPv6"
+
+(* Naive substring search, to avoid pulling in a regex library just for
+   an assertion. *)
+let contains_substring ~needle haystack =
+  let hlen = String.length haystack and nlen = String.length needle in
+  let rec loop i =
+    if i + nlen > hlen then false
+    else if String.equal (String.sub haystack i nlen) needle then true
+    else loop (i + 1)
+  in
+  loop 0
+
+let test_validate_addr_bare_ipv6_rejected () =
+  let result =
+    Port_validation.validate_addr
+      ~addr:"fe80::1:9732"
+      ~example:"127.0.0.1:8732"
+      ()
+  in
+  match result with
+  | Error Port_validation.Bare_ipv6 ->
+      let msg = Port_validation.pp_error Port_validation.Bare_ipv6 in
+      check
+        bool
+        "actionable bracket message"
+        true
+        (contains_substring ~needle:"bracketed" msg)
+  | _ -> fail "bare IPv6 with port should be rejected as Bare_ipv6"
+
 (* ============================================================ *)
 (* Test Suite *)
 (* ============================================================ *)
@@ -340,6 +395,10 @@ let parse_host_port_tests =
     ("parse hostname:port", `Quick, test_parse_host_port_hostname);
     ("parse wildcard:port", `Quick, test_parse_host_port_wildcard);
     ("parse IPv6:port", `Quick, test_parse_host_port_ipv6);
+    ("parse IPv6:port with zone id", `Quick, test_parse_host_port_ipv6_zone_id);
+    ( "parse bare IPv6:port rejected",
+      `Quick,
+      test_parse_host_port_bare_ipv6_rejected );
     ("parse no port", `Quick, test_parse_host_port_no_port);
     ("parse invalid format", `Quick, test_parse_host_port_invalid);
     ("parse empty string", `Quick, test_parse_host_port_empty);
@@ -367,6 +426,10 @@ let validate_addr_tests =
     ("validate port too high", `Quick, test_validate_addr_port_too_high);
     ("validate boundary 1024", `Quick, test_validate_addr_boundary_1024);
     ("validate boundary 65535", `Quick, test_validate_addr_boundary_65535);
+    ("validate bracketed IPv6", `Quick, test_validate_addr_bracketed_ipv6);
+    ( "validate bare IPv6 rejected",
+      `Quick,
+      test_validate_addr_bare_ipv6_rejected );
   ]
 
 let validate_specific_tests =

--- a/test/test_rpc_addr.ml
+++ b/test/test_rpc_addr.ml
@@ -73,6 +73,46 @@ let test_to_endpoint_with_path () =
     "http://127.0.0.1:8732/some/path"
     endpoint
 
+(* ============================================================ *)
+(* IPv6 host/port tests (see #1006) *)
+(* ============================================================ *)
+
+let test_host_bracketed_ipv6 () =
+  let addr = Rpc_addr.of_string "[::1]:8732" in
+  Alcotest.(check (option string))
+    "host keeps its brackets"
+    (Some "[::1]")
+    (Rpc_addr.host addr)
+
+let test_port_bracketed_ipv6 () =
+  let addr = Rpc_addr.of_string "[::1]:8732" in
+  Alcotest.(check (option int))
+    "port extracted"
+    (Some 8732)
+    (Rpc_addr.port addr)
+
+let test_host_bare_ipv6_rejected () =
+  let addr = Rpc_addr.of_string "fe80::1:9732" in
+  Alcotest.(check (option string))
+    "bare IPv6 host rejected (ambiguous)"
+    None
+    (Rpc_addr.host addr)
+
+let test_port_bare_ipv6_rejected () =
+  let addr = Rpc_addr.of_string "fe80::1:9732" in
+  Alcotest.(check (option int))
+    "bare IPv6 port rejected (ambiguous)"
+    None
+    (Rpc_addr.port addr)
+
+let test_round_trip_preserves_bracketed_ipv6 () =
+  let raw = "[::1]:8732" in
+  let addr = Rpc_addr.of_string raw in
+  Alcotest.(check string)
+    "of_string / to_string round-trip preserves brackets"
+    raw
+    (Rpc_addr.to_string addr)
+
 let () =
   let open Alcotest in
   run
@@ -100,5 +140,16 @@ let () =
           test_case "empty string" `Quick test_to_endpoint_empty_string;
           test_case "whitespace only" `Quick test_to_endpoint_whitespace_only;
           test_case "with path" `Quick test_to_endpoint_with_path;
+        ] );
+      ( "ipv6",
+        [
+          test_case "host keeps brackets" `Quick test_host_bracketed_ipv6;
+          test_case "port extracted" `Quick test_port_bracketed_ipv6;
+          test_case "bare host rejected" `Quick test_host_bare_ipv6_rejected;
+          test_case "bare port rejected" `Quick test_port_bare_ipv6_rejected;
+          test_case
+            "round-trip preserves brackets"
+            `Quick
+            test_round_trip_preserves_bracketed_ipv6;
         ] );
     ]

--- a/test/test_signatory_validation.ml
+++ b/test/test_signatory_validation.ml
@@ -89,6 +89,8 @@ let test_valid_http_addresses () =
       ("0.0.0.0:8080", "Any address");
       ("192.168.1.100:9000", "Private network");
       ("signatory.example.com:6732", "Domain name");
+      ("[::1]:6732", "Bracketed IPv6 loopback");
+      ("[fe80::1%eth0]:6732", "Bracketed IPv6 with zone id");
     ]
   in
   List.iter
@@ -114,6 +116,7 @@ let test_invalid_http_addresses () =
       ("127.0.0.1:65536", "Port too high");
       ("127.0.0.1:abc", "Invalid port");
       ("127.0.0.1:6732:extra", "Too many colons");
+      ("fe80::1:9732", "Bare IPv6 with port (ambiguous, must be bracketed)");
     ]
   in
   List.iter
@@ -124,6 +127,28 @@ let test_invalid_http_addresses () =
       | Ok () -> Alcotest.failf "%s: Expected %s to be invalid" description addr
       | Error (`Msg _) -> ())
     addresses
+
+let test_bare_ipv6_error_message_is_actionable () =
+  match
+    Signatory_validation.validate_http_address
+      ~addr:"fe80::1:9732"
+      ~name:"address"
+  with
+  | Ok () -> Alcotest.fail "Expected bare IPv6 address to be rejected"
+  | Error (`Msg msg) ->
+      let contains_substring ~needle haystack =
+        let hlen = String.length haystack and nlen = String.length needle in
+        let rec loop i =
+          if i + nlen > hlen then false
+          else if String.equal (String.sub haystack i nlen) needle then true
+          else loop (i + 1)
+        in
+        loop 0
+      in
+      Alcotest.(check bool)
+        "error message mentions bracketing"
+        true
+        (contains_substring ~needle:"bracketed" msg)
 
 let test_valid_backends () =
   let backends =
@@ -303,6 +328,10 @@ let () =
         [
           test_case "valid HTTP addresses" `Quick test_valid_http_addresses;
           test_case "invalid HTTP addresses" `Quick test_invalid_http_addresses;
+          test_case
+            "bare IPv6 error message is actionable"
+            `Quick
+            test_bare_ipv6_error_message_is_actionable;
         ] );
       ( "Backends",
         [


### PR DESCRIPTION
Fixes #1006.

## Problem

Every host:port parser split on `:` and required exactly two segments, so IPv6 literals were rejected everywhere with "Must be host:port (e.g., 127.0.0.1:8732)" — even though octez itself accepts them. IPv6-only hosts could not enter a valid RPC/P2P/signatory address at all.

## Fix

New shared `Host_port` module (`src/host_port.ml{,i}`) doing bracket-aware splitting, used by every address parser:

- `host:port` (IPv4, hostnames): unchanged.
- `[::1]:8732`, `[fe80::1%eth0]:9732`: accepted; the bracketed form is preserved in the host string so values round-trip into valid octez CLI args.
- Bare IPv6 with a port (`fe80::1:9732`) is inherently ambiguous and stays rejected — but now with an actionable error: *"IPv6 addresses must be bracketed: [::1]:8732"* instead of the generic format message.

Converted call sites: `port_validation` (parse/validate + new error variant), `rpc_addr` (host/port), `signatory_validation`, `external_service` (endpoint comparison now strips brackets when matching against parsed URLs; fixed polymorphic equality on the touched lines), `installer/signatory`, `installer/import` (clone-strategy port increment). Deliberately not converted (different contracts, documented in the code): `ui/metrics.ml`'s bind-address parser (bare port = localhost semantics) and `cmd_install_signatory`'s `pkh[:perms]` spec parser.

## Tests

New matrices in `test/test_port_validation.ml`, `test/test_rpc_addr.ml`, `test/test_signatory_validation.ml`: IPv4, hostname, bracketed IPv6, zone id, bare-IPv6 rejection + message, empty host, wildcard, port range, `Rpc_addr` round-trip. Verified pre-fix failure: with the old `port_validation.ml`, 3 tests fail with `Expected: Some ("[::1]", 8732) / Received: None`.

## Checklist
- [x] CHANGELOG entry under [Unreleased] → Fixed (fixes #1006)
- [x] `dune build`, `dune runtest`, `dune fmt`, `./scripts/check-copyright.sh` all pass; each commit compiles independently
- [x] No CLI flags/form fields changed (no completions/golden-path impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)